### PR TITLE
Fix pixel not appending properly with Gravity Forms redirect confirmations

### DIFF
--- a/integration/FacebookWordpressGravityForms.php
+++ b/integration/FacebookWordpressGravityForms.php
@@ -27,7 +27,7 @@ class FacebookWordpressGravityForms extends FacebookWordpressIntegrationBase {
   const TRACKING_NAME = 'gravity-forms';
 
   public static function injectPixelCode() {
-    add_action(
+    add_filter(
       'gform_confirmation',
       array(__CLASS__, 'injectLeadEvent'),
       99, 4);

--- a/integration/FacebookWordpressGravityForms.php
+++ b/integration/FacebookWordpressGravityForms.php
@@ -48,16 +48,15 @@ class FacebookWordpressGravityForms extends FacebookWordpressIntegrationBase {
     ", $pixel_code);
 
     if (is_string($confirmation)) {
-      $confirmation .= $code;
+        $confirmation .= $code;
     } elseif ( is_array($confirmation) && isset($confirmation['redirect'])) {
-      $redirect_code = sprintf("
-    <!-- Facebook Pixel Gravity Forms Redirect Code -->
-    <script>
-    document.location.href=%s
-    </script>
-    <!-- End Facebook Pixel Gravity Forms Redirect Code -->
-    ", json_encode($confirmation['redirect']));
-      $confirmation = $code . $redirect_code;
+        $redirect_code = sprintf("
+            <!-- Facebook Pixel Gravity Forms Redirect Code -->
+            <script>%sdocument.location.href=%s;%s</script>
+            <!-- End Facebook Pixel Gravity Forms Redirect Code -->
+            ", apply_filters('gform_cdata_open', ''), defined('JSON_HEX_TAG') ? json_encode($confirmation['redirect'], JSON_HEX_TAG) : json_encode($confirmation['redirect']), apply_filters('gform_cdata_close', '')
+		);
+        $confirmation = $code . $redirect_code;
     }
 
     return $confirmation;

--- a/integration/FacebookWordpressGravityForms.php
+++ b/integration/FacebookWordpressGravityForms.php
@@ -30,12 +30,12 @@ class FacebookWordpressGravityForms extends FacebookWordpressIntegrationBase {
     add_action(
       'gform_confirmation',
       array(__CLASS__, 'injectLeadEvent'),
-      10, 4);
+      99, 4);
   }
 
-  public static function injectLeadEvent($confimation, $form, $entry, $ajax) {
+  public static function injectLeadEvent($confirmation, $form, $entry, $ajax) {
     if (FacebookPluginUtils::isAdmin()) {
-      return $confimation;
+      return $confirmation;
     }
 
     $pixel_code = FacebookPixel::getPixelLeadCode(array(), self::TRACKING_NAME, false);
@@ -47,7 +47,19 @@ class FacebookWordpressGravityForms extends FacebookWordpressIntegrationBase {
     <!-- End Facebook Pixel Event Code -->
     ", $pixel_code);
 
-    $confimation .= $code;
-    return $confimation;
+    if (is_string($confirmation)) {
+      $confirmation .= $code;
+    } elseif ( is_array($confirmation) && isset($confirmation['redirect'])) {
+      $redirect_code = sprintf("
+    <!-- Facebook Pixel Gravity Forms Redirect Code -->
+    <script>
+    document.location.href=%s
+    </script>
+    <!-- End Facebook Pixel Gravity Forms Redirect Code -->
+    ", json_encode($confirmation['redirect']));
+      $confirmation = $code . $redirect_code;
+    }
+
+    return $confirmation;
   }
 }


### PR DESCRIPTION
### Description
This PR fixes an issue where Gravity Forms confirmations do not process properly when the Facebook Pixel is added to a redirect type confirmation.

When a redirect type confirmation is used, the confirmation is updated to return the Facebook Pixel along with a Javascript based redirect rather than using Gravity Forms' header based redirect.

(Related Issue: #2)

### Testing Instructions
1. Create a Gravity Forms form.
1. Set the default confirmation to the Text type.
1. Submit the form.
1. Confirm the Facebook Pixel is properly included and event was registered.
1. Change the default confirmation to the Page type.
1. Submit the form.
1. Confirm the Facebook Pixel is properly included, the event was registered and user was redirected to selected page.
1. Change the default confirmation to the Redirect type.
1. Submit the form.
1. Confirm the Facebook Pixel is properly included, the event was registered and user was redirected to the defined redirect URL.