### PR TITLE
Fixes warning message when no categories provided

### DIFF
--- a/integration/FacebookWordpressWooCommerce.php
+++ b/integration/FacebookWordpressWooCommerce.php
@@ -123,6 +123,8 @@ class FacebookWordpressWooCommerce extends FacebookWordpressIntegrationBase {
         $product_id,
         'product_cat'
       );
+    // get_the_terms() can return false or a WP_Error object
+    $categories = is_array($categories) ? $categories : [];
     return count($categories) > 0 ? $categories[0]->name : null;
   }
 


### PR DESCRIPTION
This fixes a warning message on [PHP 7.2+](https://www.php.net/manual/en/function.count.php#refsect1-function.count-changelog) when get_the_terms() does not return an array.

<img width="1177" alt="Screen Shot 2021-04-12 at 3 58 22 PM" src="https://user-images.githubusercontent.com/7253840/114468716-2952c280-9ba9-11eb-892c-d5ac2a00bc12.png">