### PR TITLE
Don't include conf files and hook dirs in build

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -10,6 +10,10 @@
     <fileset dir="${basedir}" id="sourcedir">
         <exclude name=".editorconfig" />
         <exclude name=".gitignore" />
+        <exclude name=".prettierrc" />
+        <exclude name="package.json" />
+        <exclude name="package-lock.json" />
+        <exclude name="phpcs.xml" />
         <exclude name="build.properties" />
         <exclude name="build.xml" />
         <exclude name="README.md" />
@@ -17,6 +21,8 @@
         <exclude name="task/**" />
         <exclude name="__tests__/**" />
         <exclude name="js/**" />
+        <exclude name=".githooks/**" />
+        <exclude name=".github/**" />
     </fileset>
 
     <!-- Fileset for all built JS files -->


### PR DESCRIPTION
This changeseet updates the build definition to exclude configuration files, hooks and GH actions directories from the build process as they are not needed in the published version of the plugin.