### PR TITLE
Improve EMQ cookie saving

### DIFF
--- a/__tests__/core/ServerEventFactoryTest.php
+++ b/__tests__/core/ServerEventFactoryTest.php
@@ -573,6 +573,16 @@ final class ServerEventFactoryTest extends FacebookWordpressTestBase {
     $_COOKIE['_fbp'] = '_fbp_value';
 
     \WP_Mock::userFunction(
+      'wp_unslash',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+
+    \WP_Mock::userFunction(
       'sanitize_text_field',
       array(
         'args'   => array( \Mockery::any() ),

--- a/__tests__/integration/FacebookWordpressEasyDigitalDownloadsTest.php
+++ b/__tests__/integration/FacebookWordpressEasyDigitalDownloadsTest.php
@@ -397,7 +397,7 @@ final class FacebookWordpressEasyDigitalDownloadsTest extends FacebookWordpressT
     $tracked_events =
     FacebookServerSideEvent::get_instance()->get_tracked_events();
 
-    $this->assertCount( 1, $tracked_events );
+    $this->assertCount( 2, $tracked_events );
 
     $event       = $tracked_events[0];
     $custom_data = $event->getCustomData();

--- a/class-facebookforwordpress.php
+++ b/class-facebookforwordpress.php
@@ -129,6 +129,23 @@ class FacebookForWordpress {
             header( "Access-Control-Allow-Origin: $origin" );
             header( 'Access-Control-Allow-Credentials: true' );
             header( 'Access-Control-Max-Age: 86400' );
+
+            $fbc = isset(
+                $_COOKIE['_fbc']
+            )
+              ? $_COOKIE['_fbc'] : // phpcs:ignore
+              ( isset( $data['_fbc'] ) ? $data['_fbc'] : null );
+            $fbp = isset( $_COOKIE['_fbp'] )
+              ? $_COOKIE['_fbp'] : // phpcs:ignore
+            ( isset( $data['_fbp'] ) ? $data['_fbp'] : null );
+
+            if ( $fbc ) {
+                setcookie( '_fbc', $fbc, time() + ( 86400 * 30 ), '/' );
+            }
+
+            if ( $fbp ) {
+                setcookie( '_fbp', $fbp, time() + ( 86400 * 30 ), '/' );
+            }
         }
         exit();
         }

--- a/core/class-servereventfactory.php
+++ b/core/class-servereventfactory.php
@@ -164,14 +164,14 @@ class ServerEventFactory {
      * null if the cookie is not present.
      */
     private static function get_fbp() {
-        $fbp = null;
+      $fbp = null;
 
-        if ( ! empty( $_COOKIE['_fbp'] ) ) {
-            $fbp = sanitize_text_field( $_COOKIE['_fbp'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-        }
+      if ( ! empty( $_COOKIE['_fbp'] ) ) {
+          $fbp = sanitize_text_field( wp_unslash( $_COOKIE['_fbp'] ) );
+      }
 
-        return $fbp;
-    }
+      return $fbp;
+  }
 
     /**
      * Retrieves the Facebook Click ID (FBC) cookie or session variable.

--- a/integration/class-facebookwordpresseasydigitaldownloads.php
+++ b/integration/class-facebookwordpresseasydigitaldownloads.php
@@ -158,6 +158,18 @@ class FacebookWordpressEasyDigitalDownloads extends FacebookWordpressIntegration
                 FacebookServerSideEvent::get_instance()->track( $server_event );
             }
         }
+        parse_str( $_POST['post_data'], $post_data ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+        if ( isset( $post_data['facebook_event_id'] ) ) {
+            $event_id     = $post_data['facebook_event_id'];
+            $server_event = ServerEventFactory::safe_create_event(
+                'AddToCart',
+                array( __CLASS__, 'createAddToCartEvent' ),
+                array( $download_id ),
+                self::TRACKING_NAME
+            );
+            $server_event->setEventId( $event_id );
+            FacebookServerSideEvent::get_instance()->track( $server_event );
+        }
     }
 
     /**


### PR DESCRIPTION
This changeset aims to improve cookie availability for the backend on first pixel load. We attempt to load the cookie from the OpenBridge data.