### PR TITLE
Remove plugin settings matching old DB key on uninstall

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -29,4 +29,6 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 }
 
 delete_option( FacebookPluginConfig::SETTINGS_KEY );
+delete_option( FacebookPluginConfig::OLD_SETTINGS_KEY );
+
 delete_user_meta( get_current_user_id(), FacebookPluginConfig::ADMIN_IGNORE_PIXEL_ID_NOTICE );


### PR DESCRIPTION
This changeset makes sure that both database entries containing the plugin settings are removed when uninstalling the plugin. Previously, only the current setting DB entry was being removed when uninstalling the plugin.

Because the plugin copies values from the old DB entry (`facebook_config`) to the new one (`facebook_business_extension_config`) when being run, the plugin never returns to an "empty" state when reinstalled on a machine that had an older version of the plugin which used the `facebook_config` options DB key.