### PR TITLE
Move noscript tag to body element

### DIFF
--- a/__tests__/core/FacebookWordpressPixelInjectionTest.php
+++ b/__tests__/core/FacebookWordpressPixelInjectionTest.php
@@ -79,7 +79,7 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
       array( $injection_obj, 'inject_pixel_code' )
     );
     \WP_Mock::expectActionAdded(
-      'wp_head',
+      'wp_body_open',
       array( $injection_obj, 'inject_pixel_noscript_code' )
     );
 

--- a/core/class-aamfieldsextractor.php
+++ b/core/class-aamfieldsextractor.php
@@ -66,8 +66,14 @@ final class AAMFieldsExtractor {
     if (
         isset( $user_data_array[ AAMSettingsFields::DATE_OF_BIRTH ] )
         ) {
-        $unix_timestamp =
-        strtotime( $user_data_array[ AAMSettingsFields::DATE_OF_BIRTH ] );
+
+        $date_time      = \DateTime::createFromFormat(
+            'Y-m-d',
+            $user_data_array[ AAMSettingsFields::DATE_OF_BIRTH ],
+            new \DateTimeZone( 'GMT' )
+        );
+        $unix_timestamp = $date_time ? $date_time->getTimestamp() : false;
+
         if ( ! $unix_timestamp ) {
             unset( $user_data_array[ AAMSettingsFields::DATE_OF_BIRTH ] );
         } else {

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -64,7 +64,7 @@ class FacebookWordpressPixelInjection {
                 array( $this, 'inject_pixel_code' )
             );
             add_action(
-                'wp_head',
+                'wp_body_open',
                 array( $this, 'inject_pixel_noscript_code' )
             );
             foreach (


### PR DESCRIPTION
This changeset updates the placement of the `noscript` pixel tag so that it is added within the `body` tag to keep the code valid HTML.

Originally started in this PR: https://github.com/facebookincubator/Facebook-Pixel-for-Wordpress/pull/35