### PR TITLE
Fixed an issue with OB loading, and also removed the reuse pixel id text

### DIFF
--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -130,7 +130,7 @@ class FacebookWordpressPixelInjection {
         $capi_integration_status =
         FacebookWordpressOptions::get_capi_integration_status();
         if ( '1' === $capi_integration_status ) {
-            FacebookPixel::get_open_bridge_config_code();
+            echo FacebookPixel::get_open_bridge_config_code();
         }
         echo FacebookPixel::get_pixel_init_code( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
             FacebookWordpressOptions::get_agent_string(),

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -130,7 +130,7 @@ class FacebookWordpressPixelInjection {
         $capi_integration_status =
         FacebookWordpressOptions::get_capi_integration_status();
         if ( '1' === $capi_integration_status ) {
-            echo FacebookPixel::get_open_bridge_config_code();
+            echo FacebookPixel::get_open_bridge_config_code(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         }
         echo FacebookPixel::get_pixel_init_code( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
             FacebookWordpressOptions::get_agent_string(),

--- a/core/class-facebookwordpresssettingspage.php
+++ b/core/class-facebookwordpresssettingspage.php
@@ -153,40 +153,8 @@ class FacebookWordpressSettingsPage {
                 )
             );
         }
-        $pixel_id_message = $this->get_previous_pixel_id_message();
-        if ( $pixel_id_message ) {
-            echo $pixel_id_message; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-        }
         echo $this->get_fbe_browser_settings(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         wp_enqueue_script( 'fbe_allinone_script' );
-    }
-
-    /**
-     * Retrieves a message regarding the previous pixel ID setup.
-     *
-     * If the Facebook Business Extension is installed, it returns null.
-     * Otherwise, it checks for the existence of a pixel ID and returns
-     * a formatted message indicating the reuse of the pixel ID from a
-     * previous setup. If no pixel ID is found, it returns null.
-     *
-     * @return string|null The message with the previous pixel ID or null if
-     *                     the pixel ID is not found or FBE is installed.
-     */
-    private function get_previous_pixel_id_message() {
-        if ( FacebookWordpressOptions::get_is_fbe_installed() ) {
-            return null;
-        }
-        $pixel_id = FacebookWordpressOptions::get_pixel_id();
-        if ( empty( $pixel_id ) ) {
-            return null;
-        }
-        $message =
-        sprintf(
-            '<p>Reuse the pixel id from your previous setup: ' .
-            '<strong>%s</strong></p>',
-            $pixel_id
-        );
-        return $message;
     }
 
     /**


### PR DESCRIPTION
The echo command was missing from the code that loads OpenBridge, making the plugin unable to send CAPI events.

Also the text that said reuse pixel id ... was removed from the top of the window, which was confusing and irrelevant in case MBE was not connected