### PR TITLE
Read fbc & fbp from databag instead of relying on cookies

### DIFF
--- a/class-facebookforwordpress.php
+++ b/class-facebookforwordpress.php
@@ -124,29 +124,6 @@ class FacebookForWordpress {
                 $data
             );
         }
-        if ( isset( $_SERVER['HTTP_ORIGIN'] ) ) {
-            $origin = wp_kses( wp_unslash( $_SERVER['HTTP_ORIGIN'] ), array() );
-            header( "Access-Control-Allow-Origin: $origin" );
-            header( 'Access-Control-Allow-Credentials: true' );
-            header( 'Access-Control-Max-Age: 86400' );
-
-            $fbc = isset(
-                $_COOKIE['_fbc']
-            )
-              ? $_COOKIE['_fbc'] : // phpcs:ignore
-              ( isset( $data['_fbc'] ) ? $data['_fbc'] : null );
-            $fbp = isset( $_COOKIE['_fbp'] )
-              ? $_COOKIE['_fbp'] : // phpcs:ignore
-            ( isset( $data['_fbp'] ) ? $data['_fbp'] : null );
-
-            if ( $fbc ) {
-                setcookie( '_fbc', $fbc, time() + ( 86400 * 30 ), '/' );
-            }
-
-            if ( $fbp ) {
-                setcookie( '_fbp', $fbp, time() + ( 86400 * 30 ), '/' );
-            }
-        }
         exit();
         }
     }

--- a/core/class-facebookwordpressopenbridge.php
+++ b/core/class-facebookwordpressopenbridge.php
@@ -200,10 +200,10 @@ class FacebookWordpressOpenBridge {
             'content_category' =>
             self::get_custom_data( 'content_category', $databag ),
         );
-        if (isset($databag['fb.fbp'])) {
+        if ( isset( $databag['fb.fbp'] ) ) {
             $event_data['fbp'] = $databag['fb.fbp'];
         }
-        if (isset($databag['fb.clickID'])) {
+        if ( isset( $databag['fb.clickID'] ) ) {
             $event_data['fbc'] = $databag['fb.clickID'];
         }
         return $event_data;

--- a/core/class-facebookwordpressopenbridge.php
+++ b/core/class-facebookwordpressopenbridge.php
@@ -200,6 +200,12 @@ class FacebookWordpressOpenBridge {
             'content_category' =>
             self::get_custom_data( 'content_category', $databag ),
         );
+        if (isset($databag['fb.fbp'])) {
+            $event_data['fbp'] = $databag['fb.fbp'];
+        }
+        if (isset($databag['fb.clickID'])) {
+            $event_data['fbc'] = $databag['fb.clickID'];
+        }
         return $event_data;
     }
 

--- a/core/class-servereventfactory.php
+++ b/core/class-servereventfactory.php
@@ -313,11 +313,11 @@ class ServerEventFactory {
             );
 
             $user_data = $event->getUserData();
-            if ( isset ($data[ 'fbp' ])) {
-                $user_data->setFbp( $data[ 'fbp' ] );
+            if ( isset( $data['fbp'] ) ) {
+                $user_data->setFbp( $data['fbp'] );
             }
-            if ( isset ($data[ 'fbc' ])) {
-                $user_data->setFbc( $data[ 'fbc' ] );
+            if ( isset( $data['fbc'] ) ) {
+                $user_data->setFbc( $data['fbc'] );
             }
             if (
             isset( $user_data_array[ AAMSettingsFields::EMAIL ] )

--- a/core/class-servereventfactory.php
+++ b/core/class-servereventfactory.php
@@ -313,6 +313,12 @@ class ServerEventFactory {
             );
 
             $user_data = $event->getUserData();
+            if ( isset ($data[ 'fbp' ])) {
+                $user_data->setFbp( $data[ 'fbp' ] );
+            }
+            if ( isset ($data[ 'fbc' ])) {
+                $user_data->setFbc( $data[ 'fbc' ] );
+            }
             if (
             isset( $user_data_array[ AAMSettingsFields::EMAIL ] )
             ) {


### PR DESCRIPTION
When a cookie is set on the client side, the backend does not see that cookie on the first load. Therefore, fbc & fbp are always missed on the first load. 

In this PR, we are reading those values from the payload that's sent to the backend by OpenBridge. This does not need to be done through setting cookies and instead we can rely on the payload itself.

This can be tested by:
- Putting debug logs in either class-servereventfactory.php to see if fbp & fbc values exist in the user_data
- Checking the match keys that are sent to EventsManager on the first call ( must make sure not to send an event twice, or load the page more than once )

