### PR TITLE
Update WP.org plugin directory tags

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Meta pixel for WordPress ===
 Contributors: facebook
-Tags: Facebook, Facebook Conversion Pixel, Facebook Pixel, Facebook Pixel Events, Conversions API, facebook retargeting, facebook standard events, Meta, Meta Pixel, Meta Conversion API, CAPI,
+Tags: Facebook, Meta, Conversions API, Pixel, Catalog
 Requires at least: 5.7
 Tested up to: 6.7
 Requires PHP: 8.1

--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === Meta pixel for WordPress ===
 Contributors: facebook
-Tags: Facebook, Meta, Conversions API, Pixel, Catalog
+Tags: Facebook, Meta, Conversions API, Pixel, Meta Ads
 Requires at least: 5.7
 Tested up to: 6.7
 Requires PHP: 8.1


### PR DESCRIPTION
This changeset updates the tags shown in the [WP.org plugin directory](https://wordpress.org/plugins/official-facebook-pixel/). As we are limited to five tags, we had to change the tags listed.