### PR TITLE
Set up CAPI in the same script block as init

### DIFF
--- a/__tests__/core/FacebookPixelTest.php
+++ b/__tests__/core/FacebookPixelTest.php
@@ -161,14 +161,16 @@ final class FacebookPixelTest extends FacebookWordpressTestBase {
     FacebookPixel::set_pixel_id( '' );
     $code = FacebookPixel::get_pixel_init_code(
       'mockAgent',
-      array( 'key' => 'value' )
+      array( 'key' => 'value' ),
+      false
     );
     $this->assertEmpty( $code );
 
     FacebookPixel::set_pixel_id( '123' );
     $code = FacebookPixel::get_pixel_init_code(
       'mockAgent',
-      array( 'key' => 'value' )
+      array( 'key' => 'value' ),
+      false
     );
     $this->assertCodeStartAndEndWithScript( $code );
 
@@ -180,12 +182,33 @@ final class FacebookPixelTest extends FacebookWordpressTestBase {
     $code = FacebookPixel::get_pixel_init_code(
       'mockAgent',
       '{"key": "value"}',
+      false,
       false
     );
 
     $this->assertCodeStartAndEndWithNoScript( $code );
     $this->assertStringContainsString(
       "fbq('init', '123', {\"key\": \"value\"}, {\"agent\":\"mockAgent\"})",
+      $code
+    );
+
+    $code = FacebookPixel::get_pixel_init_code(
+      'mockAgent',
+      array( 'key' => 'value' ),
+      true
+    );
+
+    $this->assertCodeStartAndEndWithScript( $code );
+    $this->assertStringContainsString(
+      "var url = window.location.origin + '?ob=open-bridge';",
+      $code
+    );
+    $this->assertStringContainsString(
+      "fbq('set', 'openbridge', '123', url);",
+      $code
+    );
+    $this->assertStringContainsString(
+      "fbq('init', '123', {\"key\":\"value\"}, {\"agent\":\"mockAgent\"})",
       $code
     );
   }

--- a/core/class-facebookpixel.php
+++ b/core/class-facebookpixel.php
@@ -144,12 +144,8 @@ src="https://www.facebook.com/tr?id=%s&ev=%s%s&noscript=1" />
           return;
       }
 
-        $code = "
-          <script type='text/javascript'>
-            var url = window.location.origin + '?ob=open-bridge';
-            fbq('set', 'openbridge', '%s', url);
-          </script>
-        ";
+        $code = "var url = window.location.origin + '?ob=open-bridge';
+            fbq('set', 'openbridge', '%s', url);";
         return sprintf( $code, self::$pixel_id );
     }
 
@@ -161,19 +157,25 @@ src="https://www.facebook.com/tr?id=%s&ev=%s%s&noscript=1" />
      * in the pixel init code.
      * @param array  $param        The parameters for the pixel event.
      * Defaults to an empty array.
+     * @param bool   $include_capi        Whether CAPI injection is
+     * enabled or not.
      * @param bool   $with_script_tag Whether to include the script tag in
      * the pixel init code. Defaults to true.
      */
     public static function get_pixel_init_code(
         $agent_string,
         $param = array(),
+        $include_capi,
         $with_script_tag = true
     ) {
         if ( empty( self::$pixel_id ) ) {
             return;
         }
 
-        $pixel_fbq_code_without_script = "fbq('%s', '%s'%s%s)";
+        $capi_integration_injection    = $include_capi ?
+            ( self::get_open_bridge_config_code() . PHP_EOL ) : '';
+        $pixel_fbq_code_without_script = $capi_integration_injection .
+            "fbq('%s', '%s'%s%s)";
 
         $code      = $with_script_tag ? "<script type='text/javascript'>" .
         $pixel_fbq_code_without_script .

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -129,12 +129,10 @@ class FacebookWordpressPixelInjection {
         echo FacebookPixel::get_pixel_base_code(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         $capi_integration_status =
         FacebookWordpressOptions::get_capi_integration_status();
-        if ( '1' === $capi_integration_status ) {
-            echo FacebookPixel::get_open_bridge_config_code(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-        }
         echo FacebookPixel::get_pixel_init_code( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
             FacebookWordpressOptions::get_agent_string(),
-            FacebookWordpressOptions::get_user_info() // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+            FacebookWordpressOptions::get_user_info(), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+            '1' === $capi_integration_status // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         );
         echo FacebookPixel::get_pixel_page_view_code(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
     }


### PR DESCRIPTION
The Meta Pixel fires CAPI events using an openbridge connection. This connection is set up with a call to configure it directly. If this call happens after to the pixel being initialized, then the pixel will not re-configure itself to set up the openbridge plugin properly.

This diff updates the config to be set in the same script block as the init, eliminating the race condition that allows this case to happen.