### PR TITLE
Checking if wp.com can be detected

### DIFF
--- a/core/class-facebookwordpressoptions.php
+++ b/core/class-facebookwordpressoptions.php
@@ -508,12 +508,16 @@ class FacebookWordpressOptions {
      * @return string The constructed agent string.
      */
     public static function get_agent_string() {
-    return sprintf(
-        '%s-%s-%s',
-        self::$version_info['source'],
-        self::$version_info['version'],
-        self::$version_info['pluginVersion']
-    );
+        $source = self::$version_info['source'];
+        if (defined('IS_WPCOM') && IS_WPCOM) {
+            $source .= '_com';
+        }
+        return sprintf(
+            '%s-%s-%s',
+            $source,
+            self::$version_info['version'],
+            self::$version_info['pluginVersion']
+        );
     }
 
     /**


### PR DESCRIPTION
## Description

Added a check to see if IS_WPCOM works for detecting whether the website is running on wp.org or .com

### Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/b2b0midg)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary).


## Changelog entry

Tweak - Updated agent string to factor in wp.org
