### PR TITLE
Detect hosting type

### DIFF
--- a/core/class-facebookwordpressoptions.php
+++ b/core/class-facebookwordpressoptions.php
@@ -511,7 +511,7 @@ class FacebookWordpressOptions {
         $source = self::$version_info['source'];
 
         if ( 1 === get_option( 'is_wordpress_com_hosted' ) ) {
-            $source .= '_com';
+            $source .= '_1';
         }
 
         return sprintf(

--- a/core/class-facebookwordpressoptions.php
+++ b/core/class-facebookwordpressoptions.php
@@ -510,7 +510,7 @@ class FacebookWordpressOptions {
      public static function get_agent_string() {
         $source = self::$version_info['source'];
 
-        if ( 1 === get_option( 'is_wordpress_com_hosted' ) ) {
+        if ( function_exists( 'get_option' ) && 1 === get_option( 'is_wordpress_com_hosted' ) ) {
             $source .= '_1';
         }
 

--- a/core/class-facebookwordpressoptions.php
+++ b/core/class-facebookwordpressoptions.php
@@ -510,7 +510,7 @@ class FacebookWordpressOptions {
      public static function get_agent_string() {
         $source = self::$version_info['source'];
 
-        if ( self::is_wordpress_com_hosted() ) {
+        if ( 1 === get_option( 'is_wordpress_com_hosted' ) ) {
             $source .= '_com';
         }
 
@@ -536,9 +536,9 @@ class FacebookWordpressOptions {
         $response_body = json_decode( wp_remote_retrieve_body( $response ), true );
 
         if ( ! is_wp_error( $response ) && isset( $response_body['ID'] ) ) {
-            return true;
+            return 1;
         }
-        return false;
+        return 0;
     }
 
     /**

--- a/core/class-facebookwordpressoptions.php
+++ b/core/class-facebookwordpressoptions.php
@@ -507,13 +507,38 @@ class FacebookWordpressOptions {
      *
      * @return string The constructed agent string.
      */
-    public static function get_agent_string() {
-    return sprintf(
-        '%s-%s-%s',
-        self::$version_info['source'],
-        self::$version_info['version'],
-        self::$version_info['pluginVersion']
-    );
+     public static function get_agent_string() {
+        $source = self::$version_info['source'];
+
+        if ( self::is_wordpress_com_hosted() ) {
+            $source .= '_com';
+        }
+
+        return sprintf(
+            '%s-%s-%s',
+            $source,
+            self::$version_info['version'],
+            self::$version_info['pluginVersion']
+        );
+    }
+
+    /**
+     * Determines whether the current site is hosted on WordPress.com.
+     *
+     * This method makes a request to the WordPress.com REST API to check if the
+     * current site is hosted on WordPress.com.
+     *
+     * @return bool Whether the current site is hosted on WordPress.com.
+     */
+    public static function is_wordpress_com_hosted() {
+        $api_url       = 'https://public-api.wordpress.com/rest/v1.1/sites/' . wp_parse_url( get_site_url() )['host'];
+        $response      = wp_remote_get( $api_url );
+        $response_body = json_decode( wp_remote_retrieve_body( $response ), true );
+
+        if ( ! is_wp_error( $response ) && isset( $response_body['ID'] ) ) {
+            return true;
+        }
+        return false;
     }
 
     /**

--- a/facebook-for-wordpress.php
+++ b/facebook-for-wordpress.php
@@ -66,6 +66,10 @@ class FacebookForWordpress {
 
     $this->register_settings_page();
 
+    if ( false === get_option( 'is_wordpress_com_hosted' ) ) {
+        update_option( 'is_wordpress_com_hosted', FacebookWordpressOptions::is_wordpress_com_hosted() );
+    }
+
     new ServerEventAsyncTask();
     }
 


### PR DESCRIPTION
## Description

This changeset attempts to detect the hosting type for the WordPress site where the plugin is installed and updates the agent string based on that.

### Type of change

Please delete options that are not relevant.

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/b2b0midg)).
- [n/a] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [n/a] I have updated or requested update to plugin documentations (if necessary).


## Changelog entry

Add hosting type detection
