### PR TITLE
Fix issue with uncategorized products

### DIFF
--- a/integration/class-facebookwordpresswoocommerce.php
+++ b/integration/class-facebookwordpresswoocommerce.php
@@ -228,7 +228,7 @@ class FacebookWordpressWooCommerce extends FacebookWordpressIntegrationBase {
             $product_id,
             'product_cat'
         );
-        return count( $categories ) > 0 ? $categories[0]->name : null;
+        return ! empty( $categories ) && count( $categories ) > 0 ? $categories[0]->name : null;
     }
 
     /**


### PR DESCRIPTION
## Description

Certain plugin users have had issues with products which do not have a category assigned to it. (This happens when a product does have even the "Uncategorized" category assigned.)

This changeset updates the check for product categories so that the plugin can function in this edge case.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/b2b0midg)).
- [n/a] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [n/a] I have updated or requested update to plugin documentations (if necessary).


## Changelog entry

Fix issue with uncategorized products
