### PR TITLE
Throttle API call using transient to avoid recursive calls to wpcom

### DIFF
--- a/facebook-for-wordpress.php
+++ b/facebook-for-wordpress.php
@@ -68,10 +68,11 @@ class FacebookForWordpress {
 
     if ( false === get_option( 'is_wordpress_com_hosted' ) ) {
         if ( false === get_transient( 'facebook_wpcom_check' ) ) {
+            set_transient( 'facebook_wpcom_check', 1, HOUR_IN_SECONDS );
+            
             $is_wp_com_hosted = FacebookWordpressOptions::is_wordpress_com_hosted();
 
             update_option( 'is_wordpress_com_hosted', $is_wp_com_hosted );
-            set_transient( 'facebook_wpcom_check', 1, HOUR_IN_SECONDS );
         }
     }
 

--- a/facebook-for-wordpress.php
+++ b/facebook-for-wordpress.php
@@ -72,7 +72,7 @@ class FacebookForWordpress {
     }
 
     private static function update_db_for_wpcom() {
-        if ( false !== get_option( 'is_wordpress_com_hosted' ) ) { 
+        if ( false !== get_option( 'is_wordpress_com_hosted' ) ) {
             return;
         }
 

--- a/facebook-for-wordpress.php
+++ b/facebook-for-wordpress.php
@@ -67,7 +67,12 @@ class FacebookForWordpress {
     $this->register_settings_page();
 
     if ( false === get_option( 'is_wordpress_com_hosted' ) ) {
-        update_option( 'is_wordpress_com_hosted', FacebookWordpressOptions::is_wordpress_com_hosted() );
+        if ( false === get_transient( 'facebook_wpcom_check' ) ) {
+            $is_wp_com_hosted = FacebookWordpressOptions::is_wordpress_com_hosted();
+
+            update_option( 'is_wordpress_com_hosted', $is_wp_com_hosted );
+            set_transient( 'facebook_wpcom_check', 1, HOUR_IN_SECONDS );
+        }
     }
 
     new ServerEventAsyncTask();

--- a/facebook-for-wordpress.php
+++ b/facebook-for-wordpress.php
@@ -66,19 +66,26 @@ class FacebookForWordpress {
 
     $this->register_settings_page();
 
-    if ( false === get_option( 'is_wordpress_com_hosted' ) ) {
-        if ( false === get_transient( 'facebook_wpcom_check' ) ) {
-            set_transient( 'facebook_wpcom_check', 1, HOUR_IN_SECONDS );
-            
-            $is_wp_com_hosted = FacebookWordpressOptions::is_wordpress_com_hosted();
-
-            update_option( 'is_wordpress_com_hosted', $is_wp_com_hosted );
-        }
-    }
-
     new ServerEventAsyncTask();
+
+    self::update_db_for_wpcom();
     }
 
+    private static function update_db_for_wpcom() {
+        if ( false !== get_option( 'is_wordpress_com_hosted' ) ) { 
+            return;
+        }
+
+        if ( false !== get_transient( 'facebook_wpcom_check' ) ) {
+            return;
+        }
+
+        set_transient( 'facebook_wpcom_check', 1, HOUR_IN_SECONDS );
+
+        $is_wp_com_hosted = FacebookWordpressOptions::is_wordpress_com_hosted();
+
+        update_option( 'is_wordpress_com_hosted', $is_wp_com_hosted );
+    }
 
     /**
      * Registers the pixel injection. This method instantiates the


### PR DESCRIPTION
Throttle API call using transient to avoid recursive calls to wpcom

## Description

Please include a summary of the changes and the related issue. 
Please also include relevant motivation and context. 
List any dependencies that are required for this change.

### Type of change

Please delete options that are not relevant.

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/b2b0midg)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary).


## Changelog entry

Fix: Throttle API call using transient to avoid recursive calls to wpcom

## Test Plan

This should be tested manually. 
