### PR TITLE
Bug fix: admin email on Pixel init

### DIFF
--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -129,9 +129,12 @@ class FacebookWordpressPixelInjection {
         echo FacebookPixel::get_pixel_base_code(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         $capi_integration_status =
         FacebookWordpressOptions::get_capi_integration_status();
+        // Only include user info for frontend users, not internal/admin users
+        $user_info = FacebookPluginUtils::is_internal_user() ?
+            array() : FacebookWordpressOptions::get_user_info();
         echo FacebookPixel::get_pixel_init_code( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
             FacebookWordpressOptions::get_agent_string(),
-            FacebookWordpressOptions::get_user_info(), // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+            $user_info, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
             '1' === $capi_integration_status // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         );
         echo FacebookPixel::get_pixel_page_view_code(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped


### PR DESCRIPTION
## Description

The Problem: 
The $param field in the Facebook Pixel initialization code was being populated with admin user data (email, first name, last name)
This occurred because the plugin was calling FacebookWordpressOptions::get_user_info() for any logged-in user, including admins
While all individual event tracking functions properly filter out admin users using FacebookPluginUtils::is_internal_user(), the main pixel initialization code did not apply this filter

This problem was also reported by the open source community: https://wordpress.org/support/topic/exposes-your-admin-email-address/

The Fix
I modified [**class-facebookwordpresspixelinjection.php**] to:
- Check if the current user is an internal/admin user using FacebookPluginUtils::is_internal_user()
- Only include user info for non-admin users by passing an empty array for admin users

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/b2b0midg)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary).


## Changelog entry

Bug fix / vulnerability: fix admin email on Pixel init


## Test Plan

Test by viewing source on my demo website. This fix ensures that admin user data is never included in the pixel tracking parameters, while maintaining full functionality for legitimate frontend users. The solution is consistent with how the plugin already protects admin data in all other tracking functions.
(Previous state: my wp-admin email/detail are included. New state: whether logged in or not (as admin), admin detail not included).

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before

### After
