### PR TITLE
Enhance test event code usage into frontend CAPI events

### DIFF
--- a/core/class-facebookcapievent.php
+++ b/core/class-facebookcapievent.php
@@ -185,14 +185,14 @@ class FacebookCapiEvent {
                 session_start();
                 $test_event_code = null;
                 if ( isset( $_POST['test_event_code'] ) ) {
-                    $test_event_code = sanitize_text_field( wp_unslash( $_POST['test_event_code'] ));
-                    $_SESSION[ FacebookPixelConstants::TEST_EVENT_SESSION ] 
-                        = $test_event_code;
+                    $test_event_code                                        =
+                        sanitize_text_field( wp_unslash( $_POST['test_event_code'] ) );
+                    $_SESSION[ FacebookPixelConstants::TEST_EVENT_SESSION ] = $test_event_code;
                 }
 
                 $event_request = ( new EventRequest( $pixel_id ) )
                     ->setEvents( $events )
-                    ->setTestEventCode($test_event_code);
+                    ->setTestEventCode( $test_event_code );
 
                 $normalized_event = $event_request->normalize();
 

--- a/core/class-facebookcapievent.php
+++ b/core/class-facebookcapievent.php
@@ -122,16 +122,16 @@ class FacebookCapiEvent {
         sanitize_text_field( wp_unslash( $_POST['nonce'] ) ) : null;
         if ( ! isset( $nonce ) ||
         ! wp_verify_nonce( $nonce, 'send_capi_event_nonce' ) ) {
-        wp_send_json_error(
-            wp_json_encode(
-                array(
-                    'error' => array(
-                        'message'        => 'Invalid nonce',
-                        'error_user_msg' => 'Invalid nonce',
-                    ),
+            wp_send_json_error(
+                wp_json_encode(
+                    array(
+                        'error' => array(
+                            'message'        => 'Invalid nonce',
+                            'error_user_msg' => 'Invalid nonce',
+                        ),
+                    )
                 )
-            )
-        );
+            );
             wp_die();
         }
 
@@ -151,88 +151,86 @@ class FacebookCapiEvent {
             $_POST['custom_data'] : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
             $invalid_custom_data =
             self::get_invalid_event_custom_data( $custom_data );
-        if ( ! empty( $invalid_custom_data ) ) {
-            $invalid_custom_data_msg = implode( ',', $invalid_custom_data );
-            wp_send_json_error(
-                wp_json_encode(
-                    array(
-                        'error' => array(
-                            'message'        => 'Invalid custom_data attribute',
-                            'error_user_msg' =>
-                            'Invalid custom_data attributes: '
-                            . $invalid_custom_data_msg,
+            if ( ! empty( $invalid_custom_data ) ) {
+                $invalid_custom_data_msg = implode( ',', $invalid_custom_data );
+                wp_send_json_error(
+                    wp_json_encode(
+                        array(
+                            'error' => array(
+                                'message'        => 'Invalid custom_data attribute',
+                                'error_user_msg' =>
+                                'Invalid custom_data attributes: '
+                                . $invalid_custom_data_msg,
 
-                        ),
+                            ),
+                        )
                     )
-                )
-            );
-            wp_die();
-        } else {
-            $event = ServerEventFactory::safe_create_event(
-                $event_name,
-                array( $this, 'get_event_custom_data' ),
-                array( $custom_data ),
-                'fb-capi-event',
-                true
-            );
-
-            $events = array();
-            array_push( $events, $event );
-
-            // A test event code could be posted from admin settings. 
-            // If so, store a session so that front end events can be
-            // viewed as Events Manager test events too.
-            session_start();
-            $test_event_code = null;
-            if (isset( $_POST[ 'test_event_code' ] )) {
-                $test_event_code = sanitize_text_field(
-                    wp_unslash( $_POST[ 'test_event_code' ] )
                 );
-                $_SESSION[ FacebookPixelConstants::TEST_EVENT_SESSION ] 
-                    = $test_event_code;
-            }
+                wp_die();
+            } else {
+                $event = ServerEventFactory::safe_create_event(
+                    $event_name,
+                    array( $this, 'get_event_custom_data' ),
+                    array( $custom_data ),
+                    'fb-capi-event',
+                    true
+                );
 
-            $event_request = ( new EventRequest( $pixel_id ) )
-                ->setEvents( $events )
-                ->setTestEventCode($test_event_code);
+                $events = array();
+                array_push( $events, $event );
 
-            $normalized_event = $event_request->normalize();
-
-            if ( ! empty( $_POST['user_data'] ) ) {
-                foreach ( $normalized_event['data'] as $key => $value ) {
-                    $normalized_event['data'][ $key ]['user_data'] +=
-                    isset( $_POST['user_data'] ) ?
-                    $_POST['user_data'] : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+                // A test event code could be posted from admin settings.
+                // If so, store a session so that front end events can be
+                // viewed as Events Manager test events too.
+                session_start();
+                $test_event_code = null;
+                if ( isset( $_POST['test_event_code'] ) ) {
+                    $test_event_code = sanitize_text_field( wp_unslash( $_POST['test_event_code'] ));
+                    $_SESSION[ FacebookPixelConstants::TEST_EVENT_SESSION ] 
+                        = $test_event_code;
                 }
-            }
 
-            $payload = wp_json_encode( $normalized_event );
-        }
+                $event_request = ( new EventRequest( $pixel_id ) )
+                    ->setEvents( $events )
+                    ->setTestEventCode($test_event_code);
+
+                $normalized_event = $event_request->normalize();
+
+                if ( ! empty( $_POST['user_data'] ) ) {
+                    foreach ( $normalized_event['data'] as $key => $value ) {
+                        $normalized_event['data'][ $key ]['user_data'] +=
+                        isset( $_POST['user_data'] ) ?
+                        $_POST['user_data'] : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+                    }
+                }
+
+                $payload = wp_json_encode( $normalized_event );
+            }
         } else {
             $validated_payload =
             self::validate_payload(
                 isset( $_POST['payload'] ) ?
                 $_POST['payload'] : null // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
             );
-        if ( ! $validated_payload['valid'] ) {
-            wp_send_json_error(
-                wp_json_encode(
-                    array(
-                        'error' => array(
-                            'message'        => $validated_payload['message'],
-                            'error_user_msg' =>
-                            $validated_payload['error_user_msg'],
-                        ),
+            if ( ! $validated_payload['valid'] ) {
+                wp_send_json_error(
+                    wp_json_encode(
+                        array(
+                            'error' => array(
+                                'message'        => $validated_payload['message'],
+                                'error_user_msg' =>
+                                $validated_payload['error_user_msg'],
+                            ),
+                        )
                     )
-                )
-            );
-            wp_die();
-        } else {
-            $payload = wp_json_encode(
-                isset( $_POST['payload'] )
-                ? $_POST['payload'] : null // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-            );
-        }
+                );
+                wp_die();
+            } else {
+                $payload = wp_json_encode(
+                    isset( $_POST['payload'] )
+                    ? $_POST['payload'] : null // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+                );
+            }
         }
 
         $args = array(

--- a/core/class-facebookcapievent.php
+++ b/core/class-facebookcapievent.php
@@ -157,7 +157,8 @@ class FacebookCapiEvent {
                     wp_json_encode(
                         array(
                             'error' => array(
-                                'message'        => 'Invalid custom_data attribute',
+                                'message'
+                                    => 'Invalid custom_data attribute',
                                 'error_user_msg' =>
                                 'Invalid custom_data attributes: '
                                 . $invalid_custom_data_msg,
@@ -186,8 +187,11 @@ class FacebookCapiEvent {
                 $test_event_code = null;
                 if ( isset( $_POST['test_event_code'] ) ) {
                     $test_event_code                                        =
-                        sanitize_text_field( wp_unslash( $_POST['test_event_code'] ) );
-                    $_SESSION[ FacebookPixelConstants::TEST_EVENT_SESSION ] = $test_event_code;
+                        sanitize_text_field(
+                            wp_unslash( $_POST['test_event_code'] )
+                        );
+                    $_SESSION[ FacebookPixelConstants::TEST_EVENT_SESSION ] =
+                        $test_event_code;
                 }
 
                 $event_request = ( new EventRequest( $pixel_id ) )
@@ -217,7 +221,8 @@ class FacebookCapiEvent {
                     wp_json_encode(
                         array(
                             'error' => array(
-                                'message'        => $validated_payload['message'],
+                                'message'
+                                    => $validated_payload['message'],
                                 'error_user_msg' =>
                                 $validated_payload['error_user_msg'],
                             ),

--- a/core/class-facebookcapievent.php
+++ b/core/class-facebookcapievent.php
@@ -179,24 +179,31 @@ class FacebookCapiEvent {
             $events = array();
             array_push( $events, $event );
 
+            // A test event code could be posted from admin settings. 
+            // If so, store a session so that front end events can be
+            // viewed as Events Manager test events too.
+            session_start();
+            $test_event_code = null;
+            if (isset( $_POST[ 'test_event_code' ] )) {
+                $test_event_code = sanitize_text_field(
+                    wp_unslash( $_POST[ 'test_event_code' ] )
+                );
+                $_SESSION[ FacebookPixelConstants::TEST_EVENT_SESSION ] 
+                    = $test_event_code;
+            }
+
             $event_request = ( new EventRequest( $pixel_id ) )
                 ->setEvents( $events )
-                ->setTestEventCode(
-                    isset( $_POST['test_event_code'] ) ?
-                    sanitize_text_field(
-                        wp_unslash( $_POST['test_event_code'] )
-                    ) :
-                    null
-                );
+                ->setTestEventCode($test_event_code);
 
             $normalized_event = $event_request->normalize();
 
             if ( ! empty( $_POST['user_data'] ) ) {
-            foreach ( $normalized_event['data'] as $key => $value ) {
-                $normalized_event['data'][ $key ]['user_data'] +=
-                isset( $_POST['user_data'] ) ?
-                $_POST['user_data'] : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-            }
+                foreach ( $normalized_event['data'] as $key => $value ) {
+                    $normalized_event['data'][ $key ]['user_data'] +=
+                    isset( $_POST['user_data'] ) ?
+                    $_POST['user_data'] : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+                }
             }
 
             $payload = wp_json_encode( $normalized_event );

--- a/core/class-facebookpixelconstants.php
+++ b/core/class-facebookpixelconstants.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * Facebook Pixel Plugin FacebookPixelConstants class.
+ *
+ * This file contains shared constants used across the plugin.
+ *
+ * @package FacebookPixelPlugin
+ */
+
+/**
+ * Define FacebookPixelConstants class.
+ *
+ * @return void
+ */
+
+/*
+* Copyright (C) 2017-present, Meta, Inc.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; version 2 of the License.
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*/
+
+namespace FacebookPixelPlugin\Core;
+
+defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
+
+/**
+ * Class FacebookPixelConstants
+ *
+ * Contains shared constants used by FacebookCapiEvent,
+ * FacebookServerSideEvent, and other plugin classes.
+ */
+class FacebookPixelConstants {
+    const TEST_EVENT_SESSION = 'test_event_code';
+}

--- a/core/class-facebookserversideevent.php
+++ b/core/class-facebookserversideevent.php
@@ -191,9 +191,13 @@ class FacebookServerSideEvent {
                     ->setEvents( $events )
                     ->setPartnerAgent( $agent )
                     ->setTestEventCode(
-                        isset( $_SESSION[ FacebookPixelConstants::TEST_EVENT_SESSION ] ) ?
+                        isset(
+                            $_SESSION[ FacebookPixelConstants::TEST_EVENT_SESSION ]
+                        ) ?
                         sanitize_text_field(
-                            wp_unslash( $_SESSION[ FacebookPixelConstants::TEST_EVENT_SESSION ] )
+                            wp_unslash(
+                                $_SESSION[ FacebookPixelConstants::TEST_EVENT_SESSION ]
+                            )
                         ) :
                         null
                     );

--- a/core/class-facebookserversideevent.php
+++ b/core/class-facebookserversideevent.php
@@ -189,7 +189,14 @@ class FacebookServerSideEvent {
 
             $request = ( new EventRequest( $pixel_id ) )
                     ->setEvents( $events )
-                    ->setPartnerAgent( $agent );
+                    ->setPartnerAgent( $agent )
+                    ->setTestEventCode(
+                        isset( $_SESSION[ FacebookPixelConstants::TEST_EVENT_SESSION ] ) ?
+                        sanitize_text_field(
+                            wp_unslash( $_SESSION[ FacebookPixelConstants::TEST_EVENT_SESSION ] )
+                        ) :
+                        null
+                    );
 
             $response = $request->execute();
         } catch ( \Exception $e ) {

--- a/core/class-facebookwordpresssettingspage.php
+++ b/core/class-facebookwordpresssettingspage.php
@@ -307,10 +307,10 @@ class FacebookWordpressSettingsPage {
                                 ?>
                                 /test_events">
                                 <b>Events Manager</b></a>.
-                                For developers: this will be applied 
-                                to your current browser session, 
-                                applicable to your website events 
-                                too. 
+                                For developers: this will be applied
+                                to your current browser session,
+                                applicable to your website events
+                                too.
                             </p>
                         </div>
                     </div>

--- a/core/class-facebookwordpresssettingspage.php
+++ b/core/class-facebookwordpresssettingspage.php
@@ -307,6 +307,10 @@ class FacebookWordpressSettingsPage {
                                 ?>
                                 /test_events">
                                 <b>Events Manager</b></a>.
+                                For developers: this will be applied 
+                                to your current browser session, 
+                                applicable to your website events 
+                                too. 
                             </p>
                         </div>
                     </div>


### PR DESCRIPTION
## Description

**Problem**: Test event code in wp-admin settings was only being used to fire a sample test event from the admin settings. It was a problem for developers to check if CAPI events are firing from their frontend websites, because there is no test event code applied to the frontend events. It is also difficult to ascertain if CAPI events are being fired for a given third party plugin, since Meta only shows real time events when it has a test event code.
**Solution**: leverage the same test code into the front end CAPI events, for that browser session.
**Purpose**: developer productivity, both the website developer to test, and open source community/Meta engineers to test bug fixes and new features. Leverage the test code for that session alone. Noting, this therefore does not apply to incognito mode.
**Additionally**: introduced a constants setting for sharing within the plugin front and backend. For this diff it is used for the new session variable name for test_event_code.

### Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/b2b0midg)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary).


## Changelog entry

Enhance test event code usage into frontend CAPI events

## Test Plan

Before: Pageview events fired only for browser, but not for CAPI. Impossible to see CAPI test events unless you hack the code yourself.
After: once the test code was set for my session in wp-admin, I could see supplementary CAPI test events being fired and dedupled correctly (on Events Manager).

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before
<img width="2070" height="382" alt="image" src="https://github.com/user-attachments/assets/243fe6c5-a6c9-4c2f-bddc-caa351a51d18" />
(browser event only, not server, therefore no dedupe evident in test events)

### After
<img width="1748" height="796" alt="image" src="https://github.com/user-attachments/assets/c5ebee16-7472-46c6-b741-4180d8dcc797" />
<img width="2104" height="562" alt="image" src="https://github.com/user-attachments/assets/41f921cd-c720-44ea-a53c-844c5ae756a8" />
