### PR TITLE
Fix PHP 8.4 deprecation warnings causing test failures

### DIFF
--- a/__tests__/FacebookWordpressTestBase.php
+++ b/__tests__/FacebookWordpressTestBase.php
@@ -36,6 +36,9 @@ use FacebookPixelPlugin\FacebookAds\Object\ServerSide\AdsPixelSettings;
  */
 abstract class FacebookWordpressTestBase extends TestCase {
 
+    protected $mocked_fbpixel;
+    protected $mocked_options;
+
     /**
      * Sets up the environment for each test.
      *

--- a/__tests__/FacebookWordpressTestBase.php
+++ b/__tests__/FacebookWordpressTestBase.php
@@ -27,7 +27,8 @@
 
 namespace FacebookPixelPlugin\Tests;
 
-use WP_Mock\Tools\TestCase;
+use PHPUnit\Framework\TestCase;
+use WP_Mock\Tools\Constraints\ExpectationsMet;
 use FacebookPixelPlugin\Core\AAMSettingsFields;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\AdsPixelSettings;
 
@@ -173,5 +174,20 @@ abstract class FacebookWordpressTestBase extends TestCase {
         $aam_settings->setEnableAutomaticMatching( true );
         $aam_settings->setEnabledAutomaticMatchingFields( AAMSettingsFields::get_all_fields() );
         return $aam_settings;
+    }
+
+    public function assertConditionsMet( $message = '' ) {
+        $this->assertThat( null, new ExpectationsMet(), $message );
+    }
+
+    public function assertHooksAdded() {
+        $hooks_not_added = $expected_hooks = 0;
+        try {
+            \WP_Mock::assertHooksAdded();
+        } catch ( \Exception $e ) {
+            $hooks_not_added = 1;
+            $expected_hooks  = $e->getMessage();
+        }
+        $this->assertEmpty( $hooks_not_added, (string) $expected_hooks );
     }
 }

--- a/build.xml
+++ b/build.xml
@@ -34,6 +34,9 @@
         <echo msg="Cleaning build folder..." />
         <delete dir="${builddir}" />
         <echo msg="Build folder deleted" />
+        <echo msg="Regenerating autoloader..." />
+        <composer command="dump-autoload" />
+        <echo msg="Autoloader regenerated" />
         <echo msg="Prepare complete" />
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -46,9 +46,32 @@
     <target name="Build" description="rebuilds this package" depends="Clean">
         <echo msg="Running Build..." />
         <echo msg="Copy files into build folder..." />
-        <copy todir="${buildsourcedir}">
-            <fileset refid="sourcedir" />
-        </copy>
+        <mkdir dir="${buildsourcedir}" />
+        <exec executable="rsync" passthru="true" checkreturn="true">
+            <arg value="-a" />
+            <arg value="--exclude=.editorconfig" />
+            <arg value="--exclude=.gitignore" />
+            <arg value="--exclude=.prettierrc" />
+            <arg value="--exclude=package.json" />
+            <arg value="--exclude=package-lock.json" />
+            <arg value="--exclude=phpcs.xml" />
+            <arg value="--exclude=build.properties" />
+            <arg value="--exclude=build.xml" />
+            <arg value="--exclude=README.md" />
+            <arg value="--exclude=vendor" />
+            <arg value="--exclude=task" />
+            <arg value="--exclude=__tests__" />
+            <arg value="--exclude=__tests_sdk__" />
+            <arg value="--exclude=js/lib" />
+            <arg value="--exclude=.githooks" />
+            <arg value="--exclude=.github" />
+            <arg value="--exclude=build" />
+            <arg value="--exclude=.git" />
+            <arg value="--exclude=composer.lock" />
+            <arg value="--exclude=FacebookAds/Object/Fields" />
+            <arg value="--exclude=FacebookAds/Object/Values" />
+            <arg line="./ ${buildsourcedir}/" />
+        </exec>
         <echo msg="Copy complete" />
         <echo msg="Run compose install..." />
         <composer command="install">
@@ -99,12 +122,11 @@
         <echo msg="Running Package..." />
             <taskdef name="versionnumbertask" classname="FacebookWordpressGetVersionNumberTask" classpath="${taskdir}" />
             <versionnumbertask versionprop="version.number" />
-            <zip destfile="${builddir}/${packagebasename}-${version.number}.zip">
-                <fileset dir="${builddir}/" defaultexcludes="true">
-                    <include name="**" />
-                    <exclude name="./test" />
-                </fileset>
-            </zip>
+            <exec executable="zip" dir="${builddir}" passthru="true">
+                <arg value="-r" />
+                <arg value="${packagebasename}-${version.number}.zip" />
+                <arg value="official-facebook-pixel" />
+            </exec>
         <echo msg="Package complete" />
     </target>
 

--- a/build.xml
+++ b/build.xml
@@ -6,26 +6,6 @@
 <project name="pixel-plugins" basedir="." default="main">
     <property file="./build.properties" />
 
-    <!-- Fileset for all files -->
-    <fileset dir="${basedir}" id="sourcedir">
-        <exclude name=".editorconfig" />
-        <exclude name=".gitignore" />
-        <exclude name=".prettierrc" />
-        <exclude name="package.json" />
-        <exclude name="package-lock.json" />
-        <exclude name="phpcs.xml" />
-        <exclude name="build.properties" />
-        <exclude name="build.xml" />
-        <exclude name="README.md" />
-        <exclude name="vendor/**" />
-        <exclude name="task/**" />
-        <exclude name="__tests__/**" />
-		<exclude name="__tests_sdk__/**" />
-        <exclude name="js/lib/**" />
-        <exclude name=".githooks/**" />
-        <exclude name=".github/**" />
-    </fileset>
-
     <!-- ============================================  -->
     <!-- Target: Clean                                 -->
     <!-- ============================================  -->

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "type": "project",
   "require-dev": {
     "phing/phing": "^3.0.0-RC3",
-    "10up/wp_mock": "1.0.1",
+    "10up/wp_mock": "^1.1",
     "squizlabs/php_codesniffer": "^3.10",
     "wp-coding-standards/wpcs": "^3.1",
     "symfony/finder": "~2.6",

--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
     },
     "classmap": [
       "./"
+    ],
+    "exclude-from-classmap": [
+      "FacebookAds/"
     ]
   },
   "autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3bd3e2af4a274ae9c74b2ab67c80b0a6",
+    "content-hash": "9c9c271a73f23193a72ec7371aa98a30",
     "packages": [
         {
             "name": "techcrunch/wp-async-task",
@@ -66,16 +66,16 @@
     "packages-dev": [
         {
             "name": "10up/wp_mock",
-            "version": "1.0.1",
+            "version": "1.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/10up/wp_mock.git",
-                "reference": "48b7f22934a4351e45e336f09263ee27fc9ddcbe"
+                "reference": "f25b5895ed31bf5e7036fe0c666664364ae011c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/10up/wp_mock/zipball/48b7f22934a4351e45e336f09263ee27fc9ddcbe",
-                "reference": "48b7f22934a4351e45e336f09263ee27fc9ddcbe",
+                "url": "https://api.github.com/repos/10up/wp_mock/zipball/f25b5895ed31bf5e7036fe0c666664364ae011c2",
+                "reference": "f25b5895ed31bf5e7036fe0c666664364ae011c2",
                 "shasum": ""
             },
             "require": {
@@ -114,9 +114,9 @@
             "description": "A mocking library to take the pain out of unit testing for WordPress",
             "support": {
                 "issues": "https://github.com/10up/wp_mock/issues",
-                "source": "https://github.com/10up/wp_mock/tree/1.0.1"
+                "source": "https://github.com/10up/wp_mock/tree/1.1.0"
             },
-            "time": "2024-01-22T02:22:57+00:00"
+            "time": "2025-03-12T00:36:13+00:00"
         },
         {
             "name": "antecedent/patchwork",

--- a/core/class-facebookpluginutils.php
+++ b/core/class-facebookpluginutils.php
@@ -42,7 +42,7 @@ class FacebookPluginUtils {
      */
     public static function is_positive_integer( $pixel_id ) {
         return isset( $pixel_id )
-        && ctype_digit( $pixel_id ) && '0' !== $pixel_id;
+        && ctype_digit( (string) $pixel_id ) && '0' !== (string) $pixel_id;
     }
 
     /**

--- a/core/class-pixelrenderer.php
+++ b/core/class-pixelrenderer.php
@@ -111,7 +111,7 @@ class PixelRenderer {
         );
         return sprintf(
             self::FBQ_EVENT_CODE,
-            $class->getConstant( strtoupper( $event->getEventName() ) ) !== false ?
+            $class->getConstant( strtoupper( (string) $event->getEventName() ) ) !== false ?
             self::TRACK : self::TRACK_CUSTOM,
             $event->getEventName(),
             wp_json_encode( $normalized_custom_data, JSON_PRETTY_PRINT ),


### PR DESCRIPTION
## Description

- Fixed PHP 8.4 deprecation warnings that caused 123 out of 124 tests are failing with errors (not assertion failures). The root cause is PHP 8.4 deprecation notices being treated as errors by PHPUnit. 
- Replaced WP_Mock\Tools\TestCase with PHPUnit\Framework\TestCase in test base class (WP_Mock's TestCase::run() uses an implicit nullable parameter deprecated in PHP 8.4)
- Added (string) casts for ctype_digit() and strtoupper() calls that now require string arguments in PHP 8.4                                                              
- Updated wp_mock from 1.0.1 to ^1.1 and added platform.php: 7.4 config to composer.json                                                                                  
- Fixed phing build failures caused by macOS endpoint security blocking PHP file operations on FacebookAds SDK files                                                        
- Added exclude-from-classmap for FacebookAds/ in composer.json to fix composer install                                                                                   
- Replaced phing's PHP-based <copy> task with rsync in build.xml                                                                                                          
- Replaced phing's PHP-based <zip> task with shell zip in build.xml                                                                                                       
- Excluded unused FacebookAds/Object/Fields and FacebookAds/Object/Values directories (~900 files) from the build — these are not used by the plugin or its ServerSide SDK (to be cleaned up, but zip filesize now reduced from 2.8Mb to 1.6Mb.
- Added composer dump-autoload to phing Clean target to regenerate autoloader before tests                                                                                  
       
### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/b2b0midg)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary).


## Changelog entry

Addressing 123 out of 124 tests are failing with errors, with root cause PHP 8.4 deprecation notices being treated as errors by PHPUnit.


## Test Plan

  - composer install completes successfully: 123 out of 124 tests to fail pre-fix, and post fix we have 0 errors. MacOS phing errors also resolved.                                                                                                                           
  - vendor/bin/phing runs tests (105 passed, 284 assertions) and produces zip
  - Install generated zip on WordPress site and verify plugin functions correctly 
  - Running `phing` caused s. Finally, the Biz SDK cleanup (2025 December) had some unused tests - we can clean these up as a followup, but for now I have EXCLUDED them in the zip created, **bringing zip file size from 2.8Mb to 1.6Mb**

## Screenshots
Please provide screenshots or snapshots of the system/state both before and after implementing the changes, if appropriate
### Before

### After
