### PR TITLE
Add CAPI ParamBuilder to improve fbc/fbp coverage

### DIFF
--- a/__tests__/FacebookWordpressTestBase.php
+++ b/__tests__/FacebookWordpressTestBase.php
@@ -78,6 +78,19 @@ abstract class FacebookWordpressTestBase extends TestCase {
         $_POST                  = array();
         $_SESSION               = array();
         FacebookSignalState::release();
+
+        \WP_Mock::userFunction(
+            'get_site_url',
+            array( 'return' => 'https://www.pikachu.com' )
+        );
+        \WP_Mock::userFunction(
+            'wp_unslash',
+            array(
+                'return' => function ( $input ) {
+                    return $input;
+                },
+            )
+        );
     }
 
     /**

--- a/__tests__/FacebookWordpressTestBase.php
+++ b/__tests__/FacebookWordpressTestBase.php
@@ -91,6 +91,10 @@ abstract class FacebookWordpressTestBase extends TestCase {
                 },
             )
         );
+        \WP_Mock::userFunction(
+            'is_ssl',
+            array( 'return' => true )
+        );
     }
 
     /**

--- a/__tests__/bootstrap.php
+++ b/__tests__/bootstrap.php
@@ -24,6 +24,15 @@ require_once __DIR__ . '/../vendor/autoload.php';
 if ( ! defined( 'ABSPATH' ) ) {
     define( 'ABSPATH', dirname( __DIR__ ) . '/' );
 }
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+    define( 'MINUTE_IN_SECONDS', 60 );
+}
+if ( ! defined( 'DAY_IN_SECONDS' ) ) {
+    define( 'DAY_IN_SECONDS', 24 * 60 * 60 );
+}
+if ( ! defined( 'WEEK_IN_SECONDS' ) ) {
+    define( 'WEEK_IN_SECONDS', 7 * 24 * 60 * 60 );
+}
 if ( ! defined( 'YEAR_IN_SECONDS' ) ) {
     define( 'YEAR_IN_SECONDS', 365 * 24 * 60 * 60 );
 }

--- a/__tests__/core/FacebookParamBuilderTest.php
+++ b/__tests__/core/FacebookParamBuilderTest.php
@@ -57,6 +57,15 @@ final class FacebookParamBuilderTest extends FacebookWordpressTestBase {
 			}
 			$prop->setValue( null, false );
 		}
+
+		\WP_Mock::userFunction(
+			'get_transient',
+			array( 'return' => false )
+		);
+		\WP_Mock::userFunction(
+			'set_transient',
+			array( 'return' => true )
+		);
 	}
 
 	/**

--- a/__tests__/core/FacebookParamBuilderTest.php
+++ b/__tests__/core/FacebookParamBuilderTest.php
@@ -1,0 +1,317 @@
+<?php
+/**
+ * Facebook Pixel Plugin FacebookParamBuilderTest class.
+ *
+ * @package FacebookPixelPlugin
+ */
+
+/**
+ * Copyright (C) 2017-present, Meta, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+namespace FacebookPixelPlugin\Tests\Core;
+
+use FacebookPixelPlugin\Core\FacebookParamBuilder;
+use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
+
+/**
+ * FacebookParamBuilderTest class.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class FacebookParamBuilderTest extends FacebookWordpressTestBase {
+
+	/**
+	 * Reset ParamBuilder static state before each test.
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		// Reset the static singleton via reflection.
+		$reflection = new \ReflectionClass( FacebookParamBuilder::class );
+		$instance   = $reflection->getProperty( 'instance' );
+		$instance->setAccessible( true );
+		$instance->setValue( null, null );
+
+		$setup_done = $reflection->getProperty( 'server_setup_done' );
+		$setup_done->setAccessible( true );
+		$setup_done->setValue( null, false );
+	}
+
+	/**
+	 * Tests that get_instance returns a ParamBuilder or null.
+	 */
+	public function testGetInstanceReturnsValueOrNull() {
+		\WP_Mock::userFunction(
+			'get_site_url',
+			array( 'return' => 'https://www.example.com' )
+		);
+		\WP_Mock::userFunction(
+			'sanitize_text_field',
+			array(
+				'args'   => array( \Mockery::any() ),
+				'return' => function ( $input ) {
+					return $input;
+				},
+			)
+		);
+		\WP_Mock::userFunction(
+			'wp_unslash',
+			array(
+				'args'   => array( \Mockery::any() ),
+				'return' => function ( $input ) {
+					return $input;
+				},
+			)
+		);
+
+		$instance = FacebookParamBuilder::get_instance();
+		// Should return an instance or null (if the class is not available).
+		$this->assertTrue(
+			null === $instance || $instance instanceof \FacebookAds\ParamBuilder
+		);
+	}
+
+	/**
+	 * Tests that get_fbc returns null when no data is available.
+	 */
+	public function testGetFbcReturnsNullWhenNoData() {
+		\WP_Mock::userFunction(
+			'get_site_url',
+			array( 'return' => 'https://www.example.com' )
+		);
+		\WP_Mock::userFunction(
+			'sanitize_text_field',
+			array(
+				'args'   => array( \Mockery::any() ),
+				'return' => function ( $input ) {
+					return $input;
+				},
+			)
+		);
+		\WP_Mock::userFunction(
+			'wp_unslash',
+			array(
+				'args'   => array( \Mockery::any() ),
+				'return' => function ( $input ) {
+					return $input;
+				},
+			)
+		);
+
+		// With no cookies or query params, fbc should be null.
+		$fbc = FacebookParamBuilder::get_fbc();
+		$this->assertNull( $fbc );
+	}
+
+	/**
+	 * Tests that get_fbp returns a string or null.
+	 *
+	 * ParamBuilder may generate an FBP value even without cookies,
+	 * so we just verify the type is correct.
+	 */
+	public function testGetFbpReturnsStringOrNull() {
+		\WP_Mock::userFunction(
+			'get_site_url',
+			array( 'return' => 'https://www.example.com' )
+		);
+		\WP_Mock::userFunction(
+			'sanitize_text_field',
+			array(
+				'args'   => array( \Mockery::any() ),
+				'return' => function ( $input ) {
+					return $input;
+				},
+			)
+		);
+		\WP_Mock::userFunction(
+			'wp_unslash',
+			array(
+				'args'   => array( \Mockery::any() ),
+				'return' => function ( $input ) {
+					return $input;
+				},
+			)
+		);
+
+		$fbp = FacebookParamBuilder::get_fbp();
+		$this->assertTrue( null === $fbp || is_string( $fbp ) );
+	}
+
+	/**
+	 * Tests that server_setup does not error when called.
+	 */
+	public function testServerSetupDoesNotError() {
+		\WP_Mock::userFunction(
+			'get_site_url',
+			array( 'return' => 'https://www.example.com' )
+		);
+		\WP_Mock::userFunction(
+			'sanitize_text_field',
+			array(
+				'args'   => array( \Mockery::any() ),
+				'return' => function ( $input ) {
+					return $input;
+				},
+			)
+		);
+		\WP_Mock::userFunction(
+			'wp_unslash',
+			array(
+				'args'   => array( \Mockery::any() ),
+				'return' => function ( $input ) {
+					return $input;
+				},
+			)
+		);
+
+		// Should not throw any exception.
+		FacebookParamBuilder::server_setup();
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Tests that server_setup is idempotent.
+	 */
+	public function testServerSetupIsIdempotent() {
+		\WP_Mock::userFunction(
+			'get_site_url',
+			array( 'return' => 'https://www.example.com' )
+		);
+		\WP_Mock::userFunction(
+			'sanitize_text_field',
+			array(
+				'args'   => array( \Mockery::any() ),
+				'return' => function ( $input ) {
+					return $input;
+				},
+			)
+		);
+		\WP_Mock::userFunction(
+			'wp_unslash',
+			array(
+				'args'   => array( \Mockery::any() ),
+				'return' => function ( $input ) {
+					return $input;
+				},
+			)
+		);
+
+		// Calling twice should not error.
+		FacebookParamBuilder::server_setup();
+		FacebookParamBuilder::server_setup();
+		$this->assertTrue( true );
+	}
+
+	/**
+	 * Tests that client_setup does nothing when pixel ID is not set.
+	 */
+	public function testClientSetupDoesNothingWithoutPixelId() {
+		$mocked_options = \Mockery::mock(
+			'alias:FacebookPixelPlugin\Core\FacebookWordpressOptions'
+		);
+		$mocked_options->shouldReceive( 'get_pixel_id' )
+			->andReturn( '' );
+
+		$mocked_utils = \Mockery::mock(
+			'alias:FacebookPixelPlugin\Core\FacebookPluginUtils'
+		);
+		$mocked_utils->shouldReceive( 'is_positive_integer' )
+			->with( '' )
+			->andReturn( false );
+
+		// wp_enqueue_script should NOT be called.
+		\WP_Mock::userFunction(
+			'wp_enqueue_script',
+			array( 'times' => 0 )
+		);
+
+		FacebookParamBuilder::client_setup();
+	}
+
+	/**
+	 * Tests that client_setup enqueues the script when pixel ID is set.
+	 */
+	public function testClientSetupEnqueuesScriptWithPixelId() {
+		$mocked_options = \Mockery::mock(
+			'alias:FacebookPixelPlugin\Core\FacebookWordpressOptions'
+		);
+		$mocked_options->shouldReceive( 'get_pixel_id' )
+			->andReturn( '1234' );
+
+		$mocked_utils = \Mockery::mock(
+			'alias:FacebookPixelPlugin\Core\FacebookPluginUtils'
+		);
+		$mocked_utils->shouldReceive( 'is_positive_integer' )
+			->with( '1234' )
+			->andReturn( true );
+
+		\WP_Mock::userFunction(
+			'wp_enqueue_script',
+			array(
+				'times' => 1,
+				'args'  => array(
+					FacebookParamBuilder::CLIENT_JS_HANDLE,
+					FacebookParamBuilder::CLIENT_JS_URL,
+					array(),
+					null,
+					true,
+				),
+			)
+		);
+
+		\WP_Mock::userFunction(
+			'wp_add_inline_script',
+			array(
+				'times' => 1,
+				'args'  => array(
+					FacebookParamBuilder::CLIENT_JS_HANDLE,
+					\Mockery::type( 'string' ),
+				),
+			)
+		);
+
+		FacebookParamBuilder::client_setup();
+	}
+
+	/**
+	 * Tests that get_instance returns the same singleton instance.
+	 */
+	public function testGetInstanceReturnsSingleton() {
+		\WP_Mock::userFunction(
+			'get_site_url',
+			array( 'return' => 'https://www.example.com' )
+		);
+		\WP_Mock::userFunction(
+			'sanitize_text_field',
+			array(
+				'args'   => array( \Mockery::any() ),
+				'return' => function ( $input ) {
+					return $input;
+				},
+			)
+		);
+		\WP_Mock::userFunction(
+			'wp_unslash',
+			array(
+				'args'   => array( \Mockery::any() ),
+				'return' => function ( $input ) {
+					return $input;
+				},
+			)
+		);
+
+		$instance1 = FacebookParamBuilder::get_instance();
+		$instance2 = FacebookParamBuilder::get_instance();
+
+		$this->assertSame( $instance1, $instance2 );
+	}
+}

--- a/__tests__/core/FacebookParamBuilderTest.php
+++ b/__tests__/core/FacebookParamBuilderTest.php
@@ -225,60 +225,6 @@ final class FacebookParamBuilderTest extends FacebookWordpressTestBase {
 	}
 
 	/**
-	 * Tests that get_client_script_tag returns empty when pixel ID is not set.
-	 */
-	public function testClientScriptTagEmptyWithoutPixelId() {
-		$mocked_options = \Mockery::mock(
-			'alias:FacebookPixelPlugin\Core\FacebookWordpressOptions'
-		);
-		$mocked_options->shouldReceive( 'get_pixel_id' )
-			->andReturn( '' );
-
-		$mocked_utils = \Mockery::mock(
-			'alias:FacebookPixelPlugin\Core\FacebookPluginUtils'
-		);
-		$mocked_utils->shouldReceive( 'is_positive_integer' )
-			->with( '' )
-			->andReturn( false );
-
-		$tag = FacebookParamBuilder::get_client_script_tag();
-		$this->assertEmpty( $tag );
-	}
-
-	/**
-	 * Tests that get_client_script_tag returns script HTML when pixel ID is set.
-	 */
-	public function testClientScriptTagContainsScriptWhenPixelIdSet() {
-		$mocked_options = \Mockery::mock(
-			'alias:FacebookPixelPlugin\Core\FacebookWordpressOptions'
-		);
-		$mocked_options->shouldReceive( 'get_pixel_id' )
-			->andReturn( '1234' );
-
-		$mocked_utils = \Mockery::mock(
-			'alias:FacebookPixelPlugin\Core\FacebookPluginUtils'
-		);
-		$mocked_utils->shouldReceive( 'is_positive_integer' )
-			->with( '1234' )
-			->andReturn( true );
-
-		\WP_Mock::userFunction(
-			'esc_url',
-			array(
-				'args'   => array( \Mockery::any() ),
-				'return' => function ( $input ) {
-					return $input;
-				},
-			)
-		);
-
-		$tag = FacebookParamBuilder::get_client_script_tag();
-		$this->assertStringContainsString( 'meta-capi-param-builder-clientjs', $tag );
-		$this->assertStringContainsString( 'processAndCollectAllParams', $tag );
-		$this->assertStringContainsString( '<script', $tag );
-	}
-
-	/**
 	 * Tests that server_setup skips cookie-setting when tracking is paused.
 	 */
 	public function testServerSetupSkipsWhenPaused() {

--- a/__tests__/core/FacebookParamBuilderTest.php
+++ b/__tests__/core/FacebookParamBuilderTest.php
@@ -31,339 +31,339 @@ use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
  */
 final class FacebookParamBuilderTest extends FacebookWordpressTestBase {
 
-	/**
-	 * Reset ParamBuilder static state before each test.
-	 */
-	public function setUp(): void {
-		parent::setUp();
-		// Reset the static singleton via reflection.
-		$reflection = new \ReflectionClass( FacebookParamBuilder::class );
-		$instance   = $reflection->getProperty( 'instance' );
-		if ( PHP_VERSION_ID < 80100 ) {
-			$instance->setAccessible( true );
-		}
-		$instance->setValue( null, null );
+    /**
+     * Reset ParamBuilder static state before each test.
+     */
+    public function setUp(): void {
+        parent::setUp();
+        // Reset the static singleton via reflection.
+        $reflection = new \ReflectionClass( FacebookParamBuilder::class );
+        $instance   = $reflection->getProperty( 'instance' );
+        if ( PHP_VERSION_ID < 80100 ) {
+            $instance->setAccessible( true );
+        }
+        $instance->setValue( null, null );
 
-		$setup_done = $reflection->getProperty( 'server_setup_done' );
-		if ( PHP_VERSION_ID < 80100 ) {
-			$setup_done->setAccessible( true );
-		}
-		$setup_done->setValue( null, false );
+        $setup_done = $reflection->getProperty( 'server_setup_done' );
+        if ( PHP_VERSION_ID < 80100 ) {
+            $setup_done->setAccessible( true );
+        }
+        $setup_done->setValue( null, false );
 
-		foreach ( array( 'resolved_fbc', 'resolved_fbp' ) as $cache_prop ) {
-			$prop = $reflection->getProperty( $cache_prop );
-			if ( PHP_VERSION_ID < 80100 ) {
-				$prop->setAccessible( true );
-			}
-			$prop->setValue( null, false );
-		}
+        foreach ( array( 'resolved_fbc', 'resolved_fbp' ) as $cache_prop ) {
+            $prop = $reflection->getProperty( $cache_prop );
+            if ( PHP_VERSION_ID < 80100 ) {
+                $prop->setAccessible( true );
+            }
+            $prop->setValue( null, false );
+        }
 
-		\WP_Mock::userFunction(
-			'get_transient',
-			array( 'return' => false )
-		);
-		\WP_Mock::userFunction(
-			'set_transient',
-			array( 'return' => true )
-		);
-	}
+        \WP_Mock::userFunction(
+            'get_transient',
+            array( 'return' => false )
+        );
+        \WP_Mock::userFunction(
+            'set_transient',
+            array( 'return' => true )
+        );
+    }
 
-	/**
-	 * Tests that get_instance returns a ParamBuilder or null.
-	 */
-	public function testGetInstanceReturnsValueOrNull() {
-		\WP_Mock::userFunction(
-			'get_site_url',
-			array( 'return' => 'https://www.example.com' )
-		);
-		\WP_Mock::userFunction(
-			'sanitize_text_field',
-			array(
-				'args'   => array( \Mockery::any() ),
-				'return' => function ( $input ) {
-					return $input;
-				},
-			)
-		);
-		\WP_Mock::userFunction(
-			'wp_unslash',
-			array(
-				'args'   => array( \Mockery::any() ),
-				'return' => function ( $input ) {
-					return $input;
-				},
-			)
-		);
+    /**
+     * Tests that get_instance returns a ParamBuilder or null.
+     */
+    public function testGetInstanceReturnsValueOrNull() {
+        \WP_Mock::userFunction(
+            'get_site_url',
+            array( 'return' => 'https://www.example.com' )
+        );
+        \WP_Mock::userFunction(
+            'sanitize_text_field',
+            array(
+                'args'   => array( \Mockery::any() ),
+                'return' => function ( $input ) {
+                    return $input;
+                },
+            )
+        );
+        \WP_Mock::userFunction(
+            'wp_unslash',
+            array(
+                'args'   => array( \Mockery::any() ),
+                'return' => function ( $input ) {
+                    return $input;
+                },
+            )
+        );
 
-		$instance = FacebookParamBuilder::get_instance();
-		// Should return an instance or null (if the class is not available).
-		$this->assertTrue(
-			null === $instance || $instance instanceof \FacebookAds\ParamBuilder
-		);
-	}
+        $instance = FacebookParamBuilder::get_instance();
+        // Should return an instance or null (if the class is not available).
+        $this->assertTrue(
+            null === $instance || $instance instanceof \FacebookAds\ParamBuilder
+        );
+    }
 
-	/**
-	 * Tests that get_fbc returns null when no data is available.
-	 */
-	public function testGetFbcReturnsNullWhenNoData() {
-		\WP_Mock::userFunction(
-			'get_site_url',
-			array( 'return' => 'https://www.example.com' )
-		);
-		\WP_Mock::userFunction(
-			'sanitize_text_field',
-			array(
-				'args'   => array( \Mockery::any() ),
-				'return' => function ( $input ) {
-					return $input;
-				},
-			)
-		);
-		\WP_Mock::userFunction(
-			'wp_unslash',
-			array(
-				'args'   => array( \Mockery::any() ),
-				'return' => function ( $input ) {
-					return $input;
-				},
-			)
-		);
+    /**
+     * Tests that get_fbc returns null when no data is available.
+     */
+    public function testGetFbcReturnsNullWhenNoData() {
+        \WP_Mock::userFunction(
+            'get_site_url',
+            array( 'return' => 'https://www.example.com' )
+        );
+        \WP_Mock::userFunction(
+            'sanitize_text_field',
+            array(
+                'args'   => array( \Mockery::any() ),
+                'return' => function ( $input ) {
+                    return $input;
+                },
+            )
+        );
+        \WP_Mock::userFunction(
+            'wp_unslash',
+            array(
+                'args'   => array( \Mockery::any() ),
+                'return' => function ( $input ) {
+                    return $input;
+                },
+            )
+        );
 
-		// With no cookies or query params, fbc should be null.
-		$fbc = FacebookParamBuilder::get_fbc();
-		$this->assertNull( $fbc );
-	}
+        // With no cookies or query params, fbc should be null.
+        $fbc = FacebookParamBuilder::get_fbc();
+        $this->assertNull( $fbc );
+    }
 
-	/**
-	 * Tests that get_fbp returns a string or null.
-	 *
-	 * ParamBuilder may generate an FBP value even without cookies,
-	 * so we just verify the type is correct.
-	 */
-	public function testGetFbpReturnsStringOrNull() {
-		\WP_Mock::userFunction(
-			'get_site_url',
-			array( 'return' => 'https://www.example.com' )
-		);
-		\WP_Mock::userFunction(
-			'sanitize_text_field',
-			array(
-				'args'   => array( \Mockery::any() ),
-				'return' => function ( $input ) {
-					return $input;
-				},
-			)
-		);
-		\WP_Mock::userFunction(
-			'wp_unslash',
-			array(
-				'args'   => array( \Mockery::any() ),
-				'return' => function ( $input ) {
-					return $input;
-				},
-			)
-		);
+    /**
+     * Tests that get_fbp returns a string or null.
+     *
+     * ParamBuilder may generate an FBP value even without cookies,
+     * so we just verify the type is correct.
+     */
+    public function testGetFbpReturnsStringOrNull() {
+        \WP_Mock::userFunction(
+            'get_site_url',
+            array( 'return' => 'https://www.example.com' )
+        );
+        \WP_Mock::userFunction(
+            'sanitize_text_field',
+            array(
+                'args'   => array( \Mockery::any() ),
+                'return' => function ( $input ) {
+                    return $input;
+                },
+            )
+        );
+        \WP_Mock::userFunction(
+            'wp_unslash',
+            array(
+                'args'   => array( \Mockery::any() ),
+                'return' => function ( $input ) {
+                    return $input;
+                },
+            )
+        );
 
-		$fbp = FacebookParamBuilder::get_fbp();
-		$this->assertTrue( null === $fbp || is_string( $fbp ) );
-	}
+        $fbp = FacebookParamBuilder::get_fbp();
+        $this->assertTrue( null === $fbp || is_string( $fbp ) );
+    }
 
-	/**
-	 * Tests that server_setup does not error when called.
-	 */
-	public function testServerSetupDoesNotError() {
-		\WP_Mock::userFunction(
-			'get_site_url',
-			array( 'return' => 'https://www.example.com' )
-		);
-		\WP_Mock::userFunction(
-			'sanitize_text_field',
-			array(
-				'args'   => array( \Mockery::any() ),
-				'return' => function ( $input ) {
-					return $input;
-				},
-			)
-		);
-		\WP_Mock::userFunction(
-			'wp_unslash',
-			array(
-				'args'   => array( \Mockery::any() ),
-				'return' => function ( $input ) {
-					return $input;
-				},
-			)
-		);
+    /**
+     * Tests that server_setup does not error when called.
+     */
+    public function testServerSetupDoesNotError() {
+        \WP_Mock::userFunction(
+            'get_site_url',
+            array( 'return' => 'https://www.example.com' )
+        );
+        \WP_Mock::userFunction(
+            'sanitize_text_field',
+            array(
+                'args'   => array( \Mockery::any() ),
+                'return' => function ( $input ) {
+                    return $input;
+                },
+            )
+        );
+        \WP_Mock::userFunction(
+            'wp_unslash',
+            array(
+                'args'   => array( \Mockery::any() ),
+                'return' => function ( $input ) {
+                    return $input;
+                },
+            )
+        );
 
-		// Should not throw any exception.
-		FacebookParamBuilder::server_setup();
-		$this->assertTrue( true );
-	}
+        // Should not throw any exception.
+        FacebookParamBuilder::server_setup();
+        $this->assertTrue( true );
+    }
 
-	/**
-	 * Tests that server_setup is idempotent.
-	 */
-	public function testServerSetupIsIdempotent() {
-		\WP_Mock::userFunction(
-			'get_site_url',
-			array( 'return' => 'https://www.example.com' )
-		);
-		\WP_Mock::userFunction(
-			'sanitize_text_field',
-			array(
-				'args'   => array( \Mockery::any() ),
-				'return' => function ( $input ) {
-					return $input;
-				},
-			)
-		);
-		\WP_Mock::userFunction(
-			'wp_unslash',
-			array(
-				'args'   => array( \Mockery::any() ),
-				'return' => function ( $input ) {
-					return $input;
-				},
-			)
-		);
+    /**
+     * Tests that server_setup is idempotent.
+     */
+    public function testServerSetupIsIdempotent() {
+        \WP_Mock::userFunction(
+            'get_site_url',
+            array( 'return' => 'https://www.example.com' )
+        );
+        \WP_Mock::userFunction(
+            'sanitize_text_field',
+            array(
+                'args'   => array( \Mockery::any() ),
+                'return' => function ( $input ) {
+                    return $input;
+                },
+            )
+        );
+        \WP_Mock::userFunction(
+            'wp_unslash',
+            array(
+                'args'   => array( \Mockery::any() ),
+                'return' => function ( $input ) {
+                    return $input;
+                },
+            )
+        );
 
-		// Calling twice should not error.
-		FacebookParamBuilder::server_setup();
-		FacebookParamBuilder::server_setup();
-		$this->assertTrue( true );
-	}
+        // Calling twice should not error.
+        FacebookParamBuilder::server_setup();
+        FacebookParamBuilder::server_setup();
+        $this->assertTrue( true );
+    }
 
-	/**
-	 * Tests that server_setup stores attribution data but skips
-	 * cookie-setting when tracking is paused.
-	 */
-	public function testServerSetupStoresAttributionWhenPaused() {
-		FacebookSignalState::hold();
+    /**
+     * Tests that server_setup stores attribution data but skips
+     * cookie-setting when tracking is paused.
+     */
+    public function testServerSetupStoresAttributionWhenPaused() {
+        FacebookSignalState::hold();
 
-		FacebookParamBuilder::server_setup();
+        FacebookParamBuilder::server_setup();
 
-		$fbp = FacebookSignalState::get_attribution_data( 'fbp' );
-		$this->assertTrue(
-			null === $fbp || is_string( $fbp ),
-			'Attribution fbp should be null or string when paused'
-		);
-	}
+        $fbp = FacebookSignalState::get_attribution_data( 'fbp' );
+        $this->assertTrue(
+            null === $fbp || is_string( $fbp ),
+            'Attribution fbp should be null or string when paused'
+        );
+    }
 
-	/**
-	 * Tests that server_setup stores cookie domains in attribution when paused.
-	 */
-	public function testServerSetupStoresDomainsWhenPaused() {
-		FacebookSignalState::hold();
+    /**
+     * Tests that server_setup stores cookie domains in attribution when paused.
+     */
+    public function testServerSetupStoresDomainsWhenPaused() {
+        FacebookSignalState::hold();
 
-		FacebookParamBuilder::server_setup();
+        FacebookParamBuilder::server_setup();
 
-		$fbp_domain = FacebookSignalState::get_attribution_data( 'fbp_domain' );
-		$this->assertTrue(
-			null === $fbp_domain || is_string( $fbp_domain ),
-			'Attribution fbp_domain should be null or string when paused'
-		);
-	}
+        $fbp_domain = FacebookSignalState::get_attribution_data( 'fbp_domain' );
+        $this->assertTrue(
+            null === $fbp_domain || is_string( $fbp_domain ),
+            'Attribution fbp_domain should be null or string when paused'
+        );
+    }
 
-	/**
-	 * Tests that server_setup does not store attribution when not paused.
-	 */
-	public function testServerSetupDoesNotStoreAttributionWhenNotPaused() {
-		\WP_Mock::userFunction(
-			'sanitize_text_field',
-			array(
-				'args'   => array( \Mockery::any() ),
-				'return' => function ( $input ) {
-					return $input;
-				},
-			)
-		);
+    /**
+     * Tests that server_setup does not store attribution when not paused.
+     */
+    public function testServerSetupDoesNotStoreAttributionWhenNotPaused() {
+        \WP_Mock::userFunction(
+            'sanitize_text_field',
+            array(
+                'args'   => array( \Mockery::any() ),
+                'return' => function ( $input ) {
+                    return $input;
+                },
+            )
+        );
 
-		FacebookParamBuilder::server_setup();
+        FacebookParamBuilder::server_setup();
 
-		$this->assertNull(
-			FacebookSignalState::get_attribution_data( 'fbp_domain' ),
-			'Attribution should not be stored when not paused'
-		);
-	}
+        $this->assertNull(
+            FacebookSignalState::get_attribution_data( 'fbp_domain' ),
+            'Attribution should not be stored when not paused'
+        );
+    }
 
-	/**
-	 * Tests that get_fbp returns the same value on repeated calls.
-	 */
-	public function testGetFbpReturnsSameValueOnRepeatedCalls() {
-		\WP_Mock::userFunction(
-			'get_site_url',
-			array( 'return' => 'https://www.example.com' )
-		);
-		\WP_Mock::userFunction(
-			'sanitize_text_field',
-			array(
-				'args'   => array( \Mockery::any() ),
-				'return' => function ( $input ) {
-					return $input;
-				},
-			)
-		);
+    /**
+     * Tests that get_fbp returns the same value on repeated calls.
+     */
+    public function testGetFbpReturnsSameValueOnRepeatedCalls() {
+        \WP_Mock::userFunction(
+            'get_site_url',
+            array( 'return' => 'https://www.example.com' )
+        );
+        \WP_Mock::userFunction(
+            'sanitize_text_field',
+            array(
+                'args'   => array( \Mockery::any() ),
+                'return' => function ( $input ) {
+                    return $input;
+                },
+            )
+        );
 
-		$first  = FacebookParamBuilder::get_fbp();
-		$second = FacebookParamBuilder::get_fbp();
+        $first  = FacebookParamBuilder::get_fbp();
+        $second = FacebookParamBuilder::get_fbp();
 
-		$this->assertSame( $first, $second );
-	}
+        $this->assertSame( $first, $second );
+    }
 
-	/**
-	 * Tests that get_fbc returns the same value on repeated calls.
-	 */
-	public function testGetFbcReturnsSameValueOnRepeatedCalls() {
-		\WP_Mock::userFunction(
-			'get_site_url',
-			array( 'return' => 'https://www.example.com' )
-		);
-		\WP_Mock::userFunction(
-			'sanitize_text_field',
-			array(
-				'args'   => array( \Mockery::any() ),
-				'return' => function ( $input ) {
-					return $input;
-				},
-			)
-		);
+    /**
+     * Tests that get_fbc returns the same value on repeated calls.
+     */
+    public function testGetFbcReturnsSameValueOnRepeatedCalls() {
+        \WP_Mock::userFunction(
+            'get_site_url',
+            array( 'return' => 'https://www.example.com' )
+        );
+        \WP_Mock::userFunction(
+            'sanitize_text_field',
+            array(
+                'args'   => array( \Mockery::any() ),
+                'return' => function ( $input ) {
+                    return $input;
+                },
+            )
+        );
 
-		$first  = FacebookParamBuilder::get_fbc();
-		$second = FacebookParamBuilder::get_fbc();
+        $first  = FacebookParamBuilder::get_fbc();
+        $second = FacebookParamBuilder::get_fbc();
 
-		$this->assertSame( $first, $second );
-	}
+        $this->assertSame( $first, $second );
+    }
 
-	/**
-	 * Tests that get_instance returns the same singleton instance.
-	 */
-	public function testGetInstanceReturnsSingleton() {
-		\WP_Mock::userFunction(
-			'get_site_url',
-			array( 'return' => 'https://www.example.com' )
-		);
-		\WP_Mock::userFunction(
-			'sanitize_text_field',
-			array(
-				'args'   => array( \Mockery::any() ),
-				'return' => function ( $input ) {
-					return $input;
-				},
-			)
-		);
-		\WP_Mock::userFunction(
-			'wp_unslash',
-			array(
-				'args'   => array( \Mockery::any() ),
-				'return' => function ( $input ) {
-					return $input;
-				},
-			)
-		);
+    /**
+     * Tests that get_instance returns the same singleton instance.
+     */
+    public function testGetInstanceReturnsSingleton() {
+        \WP_Mock::userFunction(
+            'get_site_url',
+            array( 'return' => 'https://www.example.com' )
+        );
+        \WP_Mock::userFunction(
+            'sanitize_text_field',
+            array(
+                'args'   => array( \Mockery::any() ),
+                'return' => function ( $input ) {
+                    return $input;
+                },
+            )
+        );
+        \WP_Mock::userFunction(
+            'wp_unslash',
+            array(
+                'args'   => array( \Mockery::any() ),
+                'return' => function ( $input ) {
+                    return $input;
+                },
+            )
+        );
 
-		$instance1 = FacebookParamBuilder::get_instance();
-		$instance2 = FacebookParamBuilder::get_instance();
+        $instance1 = FacebookParamBuilder::get_instance();
+        $instance2 = FacebookParamBuilder::get_instance();
 
-		$this->assertSame( $instance1, $instance2 );
-	}
+        $this->assertSame( $instance1, $instance2 );
+    }
 }

--- a/__tests__/core/FacebookParamBuilderTest.php
+++ b/__tests__/core/FacebookParamBuilderTest.php
@@ -238,7 +238,7 @@ final class FacebookParamBuilderTest extends FacebookWordpressTestBase {
 	 * cookie-setting when tracking is paused.
 	 */
 	public function testServerSetupStoresAttributionWhenPaused() {
-		FacebookSignalState::pause();
+		FacebookSignalState::hold();
 
 		FacebookParamBuilder::server_setup();
 
@@ -253,7 +253,7 @@ final class FacebookParamBuilderTest extends FacebookWordpressTestBase {
 	 * Tests that server_setup stores cookie domains in attribution when paused.
 	 */
 	public function testServerSetupStoresDomainsWhenPaused() {
-		FacebookSignalState::pause();
+		FacebookSignalState::hold();
 
 		FacebookParamBuilder::server_setup();
 

--- a/__tests__/core/FacebookParamBuilderTest.php
+++ b/__tests__/core/FacebookParamBuilderTest.php
@@ -225,21 +225,18 @@ final class FacebookParamBuilderTest extends FacebookWordpressTestBase {
 	}
 
 	/**
-	 * Tests that server_setup skips cookie-setting when tracking is paused.
+	 * Tests that server_setup stores attribution data but skips
+	 * cookie-setting when tracking is paused.
 	 */
-	public function testServerSetupSkipsWhenPaused() {
+	public function testServerSetupStoresAttributionWhenPaused() {
 		FacebookSignalState::pause();
 
 		FacebookParamBuilder::server_setup();
 
-		$reflection = new \ReflectionClass( FacebookParamBuilder::class );
-		$instance   = $reflection->getProperty( 'instance' );
-		if ( PHP_VERSION_ID < 80100 ) {
-			$instance->setAccessible( true );
-		}
-		$this->assertNull(
-			$instance->getValue(),
-			'ParamBuilder instance should not be created when tracking is paused'
+		$fbp = FacebookSignalState::get_attribution_data( 'fbp' );
+		$this->assertTrue(
+			null === $fbp || is_string( $fbp ),
+			'Attribution fbp should be null or string when paused'
 		);
 	}
 

--- a/__tests__/core/FacebookParamBuilderTest.php
+++ b/__tests__/core/FacebookParamBuilderTest.php
@@ -212,9 +212,9 @@ final class FacebookParamBuilderTest extends FacebookWordpressTestBase {
 	}
 
 	/**
-	 * Tests that client_setup does nothing when pixel ID is not set.
+	 * Tests that get_client_script_tag returns empty when pixel ID is not set.
 	 */
-	public function testClientSetupDoesNothingWithoutPixelId() {
+	public function testClientScriptTagEmptyWithoutPixelId() {
 		$mocked_options = \Mockery::mock(
 			'alias:FacebookPixelPlugin\Core\FacebookWordpressOptions'
 		);
@@ -228,19 +228,14 @@ final class FacebookParamBuilderTest extends FacebookWordpressTestBase {
 			->with( '' )
 			->andReturn( false );
 
-		// wp_enqueue_script should NOT be called.
-		\WP_Mock::userFunction(
-			'wp_enqueue_script',
-			array( 'times' => 0 )
-		);
-
-		FacebookParamBuilder::client_setup();
+		$tag = FacebookParamBuilder::get_client_script_tag();
+		$this->assertEmpty( $tag );
 	}
 
 	/**
-	 * Tests that client_setup enqueues the script when pixel ID is set.
+	 * Tests that get_client_script_tag returns script HTML when pixel ID is set.
 	 */
-	public function testClientSetupEnqueuesScriptWithPixelId() {
+	public function testClientScriptTagContainsScriptWhenPixelIdSet() {
 		$mocked_options = \Mockery::mock(
 			'alias:FacebookPixelPlugin\Core\FacebookWordpressOptions'
 		);
@@ -255,31 +250,19 @@ final class FacebookParamBuilderTest extends FacebookWordpressTestBase {
 			->andReturn( true );
 
 		\WP_Mock::userFunction(
-			'wp_enqueue_script',
+			'esc_url',
 			array(
-				'times' => 1,
-				'args'  => array(
-					FacebookParamBuilder::CLIENT_JS_HANDLE,
-					FacebookParamBuilder::CLIENT_JS_URL,
-					array(),
-					null,
-					true,
-				),
+				'args'   => array( \Mockery::any() ),
+				'return' => function ( $input ) {
+					return $input;
+				},
 			)
 		);
 
-		\WP_Mock::userFunction(
-			'wp_add_inline_script',
-			array(
-				'times' => 1,
-				'args'  => array(
-					FacebookParamBuilder::CLIENT_JS_HANDLE,
-					\Mockery::type( 'string' ),
-				),
-			)
-		);
-
-		FacebookParamBuilder::client_setup();
+		$tag = FacebookParamBuilder::get_client_script_tag();
+		$this->assertStringContainsString( 'meta-capi-param-builder-clientjs', $tag );
+		$this->assertStringContainsString( 'processAndCollectAllParams', $tag );
+		$this->assertStringContainsString( '<script', $tag );
 	}
 
 	/**

--- a/__tests__/core/FacebookParamBuilderTest.php
+++ b/__tests__/core/FacebookParamBuilderTest.php
@@ -241,6 +241,91 @@ final class FacebookParamBuilderTest extends FacebookWordpressTestBase {
 	}
 
 	/**
+	 * Tests that server_setup stores cookie domains in attribution when paused.
+	 */
+	public function testServerSetupStoresDomainsWhenPaused() {
+		FacebookSignalState::pause();
+
+		FacebookParamBuilder::server_setup();
+
+		$fbp_domain = FacebookSignalState::get_attribution_data( 'fbp_domain' );
+		$this->assertTrue(
+			null === $fbp_domain || is_string( $fbp_domain ),
+			'Attribution fbp_domain should be null or string when paused'
+		);
+	}
+
+	/**
+	 * Tests that server_setup does not store attribution when not paused.
+	 */
+	public function testServerSetupDoesNotStoreAttributionWhenNotPaused() {
+		\WP_Mock::userFunction(
+			'sanitize_text_field',
+			array(
+				'args'   => array( \Mockery::any() ),
+				'return' => function ( $input ) {
+					return $input;
+				},
+			)
+		);
+
+		FacebookParamBuilder::server_setup();
+
+		$this->assertNull(
+			FacebookSignalState::get_attribution_data( 'fbp_domain' ),
+			'Attribution should not be stored when not paused'
+		);
+	}
+
+	/**
+	 * Tests that get_fbp returns the same value on repeated calls.
+	 */
+	public function testGetFbpReturnsSameValueOnRepeatedCalls() {
+		\WP_Mock::userFunction(
+			'get_site_url',
+			array( 'return' => 'https://www.example.com' )
+		);
+		\WP_Mock::userFunction(
+			'sanitize_text_field',
+			array(
+				'args'   => array( \Mockery::any() ),
+				'return' => function ( $input ) {
+					return $input;
+				},
+			)
+		);
+
+		$first  = FacebookParamBuilder::get_fbp();
+		$second = FacebookParamBuilder::get_fbp();
+
+		$this->assertSame( $first, $second );
+	}
+
+	/**
+	 * Tests that get_fbc returns the same value on repeated calls.
+	 */
+	public function testGetFbcReturnsSameValueOnRepeatedCalls() {
+		\WP_Mock::userFunction(
+			'get_site_url',
+			array( 'return' => 'https://www.example.com' )
+		);
+		\WP_Mock::userFunction(
+			'sanitize_text_field',
+			array(
+				'args'   => array( \Mockery::any() ),
+				'return' => function ( $input ) {
+					return $input;
+				},
+			)
+		);
+
+		$first  = FacebookParamBuilder::get_fbc();
+		$second = FacebookParamBuilder::get_fbc();
+
+		$this->assertSame( $first, $second );
+	}
+
+	/**
 	 * Tests that get_instance returns the same singleton instance.
 	 */
 	public function testGetInstanceReturnsSingleton() {

--- a/__tests__/core/FacebookParamBuilderTest.php
+++ b/__tests__/core/FacebookParamBuilderTest.php
@@ -20,6 +20,7 @@
 namespace FacebookPixelPlugin\Tests\Core;
 
 use FacebookPixelPlugin\Core\FacebookParamBuilder;
+use FacebookPixelPlugin\Core\FacebookSignalState;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 
 /**
@@ -38,12 +39,24 @@ final class FacebookParamBuilderTest extends FacebookWordpressTestBase {
 		// Reset the static singleton via reflection.
 		$reflection = new \ReflectionClass( FacebookParamBuilder::class );
 		$instance   = $reflection->getProperty( 'instance' );
-		$instance->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$instance->setAccessible( true );
+		}
 		$instance->setValue( null, null );
 
 		$setup_done = $reflection->getProperty( 'server_setup_done' );
-		$setup_done->setAccessible( true );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$setup_done->setAccessible( true );
+		}
 		$setup_done->setValue( null, false );
+
+		foreach ( array( 'resolved_fbc', 'resolved_fbp' ) as $cache_prop ) {
+			$prop = $reflection->getProperty( $cache_prop );
+			if ( PHP_VERSION_ID < 80100 ) {
+				$prop->setAccessible( true );
+			}
+			$prop->setValue( null, false );
+		}
 	}
 
 	/**
@@ -263,6 +276,25 @@ final class FacebookParamBuilderTest extends FacebookWordpressTestBase {
 		$this->assertStringContainsString( 'meta-capi-param-builder-clientjs', $tag );
 		$this->assertStringContainsString( 'processAndCollectAllParams', $tag );
 		$this->assertStringContainsString( '<script', $tag );
+	}
+
+	/**
+	 * Tests that server_setup skips cookie-setting when tracking is paused.
+	 */
+	public function testServerSetupSkipsWhenPaused() {
+		FacebookSignalState::pause();
+
+		FacebookParamBuilder::server_setup();
+
+		$reflection = new \ReflectionClass( FacebookParamBuilder::class );
+		$instance   = $reflection->getProperty( 'instance' );
+		if ( PHP_VERSION_ID < 80100 ) {
+			$instance->setAccessible( true );
+		}
+		$this->assertNull(
+			$instance->getValue(),
+			'ParamBuilder instance should not be created when tracking is paused'
+		);
 	}
 
 	/**

--- a/__tests__/core/FacebookSignalStateTest.php
+++ b/__tests__/core/FacebookSignalStateTest.php
@@ -30,55 +30,55 @@ use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
  */
 final class FacebookSignalStateTest extends FacebookWordpressTestBase {
 
-	public function setUp(): void {
-		parent::setUp();
-		FacebookSignalState::reset_queue();
-	}
+    public function setUp(): void {
+        parent::setUp();
+        FacebookSignalState::reset_queue();
+    }
 
-	public function testSetAndGetAttributionData() {
-		FacebookSignalState::set_attribution_data( 'fbc', 'fb.1.123.abc' );
-		FacebookSignalState::set_attribution_data( 'fbp', 'fb.1.456.def' );
+    public function testSetAndGetAttributionData() {
+        FacebookSignalState::set_attribution_data( 'fbc', 'fb.1.123.abc' );
+        FacebookSignalState::set_attribution_data( 'fbp', 'fb.1.456.def' );
 
-		$this->assertEquals( 'fb.1.123.abc', FacebookSignalState::get_attribution_data( 'fbc' ) );
-		$this->assertEquals( 'fb.1.456.def', FacebookSignalState::get_attribution_data( 'fbp' ) );
-	}
+        $this->assertEquals( 'fb.1.123.abc', FacebookSignalState::get_attribution_data( 'fbc' ) );
+        $this->assertEquals( 'fb.1.456.def', FacebookSignalState::get_attribution_data( 'fbp' ) );
+    }
 
-	public function testGetAttributionDataReturnsNullForMissingKey() {
-		$this->assertNull( FacebookSignalState::get_attribution_data( 'nonexistent' ) );
-	}
+    public function testGetAttributionDataReturnsNullForMissingKey() {
+        $this->assertNull( FacebookSignalState::get_attribution_data( 'nonexistent' ) );
+    }
 
-	public function testSetAttributionDataOverwritesPreviousValue() {
-		FacebookSignalState::set_attribution_data( 'fbc', 'old_value' );
-		FacebookSignalState::set_attribution_data( 'fbc', 'new_value' );
+    public function testSetAttributionDataOverwritesPreviousValue() {
+        FacebookSignalState::set_attribution_data( 'fbc', 'old_value' );
+        FacebookSignalState::set_attribution_data( 'fbc', 'new_value' );
 
-		$this->assertEquals( 'new_value', FacebookSignalState::get_attribution_data( 'fbc' ) );
-	}
+        $this->assertEquals( 'new_value', FacebookSignalState::get_attribution_data( 'fbc' ) );
+    }
 
-	public function testResetQueueClearsAttributionData() {
-		FacebookSignalState::set_attribution_data( 'fbc', 'fb.1.123.abc' );
-		FacebookSignalState::set_attribution_data( 'fbp', 'fb.1.456.def' );
+    public function testResetQueueClearsAttributionData() {
+        FacebookSignalState::set_attribution_data( 'fbc', 'fb.1.123.abc' );
+        FacebookSignalState::set_attribution_data( 'fbp', 'fb.1.456.def' );
 
-		FacebookSignalState::reset_queue();
+        FacebookSignalState::reset_queue();
 
-		$this->assertNull( FacebookSignalState::get_attribution_data( 'fbc' ) );
-		$this->assertNull( FacebookSignalState::get_attribution_data( 'fbp' ) );
-	}
+        $this->assertNull( FacebookSignalState::get_attribution_data( 'fbc' ) );
+        $this->assertNull( FacebookSignalState::get_attribution_data( 'fbp' ) );
+    }
 
-	public function testAttributionDataStoresDomains() {
-		FacebookSignalState::set_attribution_data( 'fbp_domain', 'example.com' );
-		FacebookSignalState::set_attribution_data( 'fbc_domain', 'example.com' );
+    public function testAttributionDataStoresDomains() {
+        FacebookSignalState::set_attribution_data( 'fbp_domain', 'example.com' );
+        FacebookSignalState::set_attribution_data( 'fbc_domain', 'example.com' );
 
-		$this->assertEquals( 'example.com', FacebookSignalState::get_attribution_data( 'fbp_domain' ) );
-		$this->assertEquals( 'example.com', FacebookSignalState::get_attribution_data( 'fbc_domain' ) );
-	}
+        $this->assertEquals( 'example.com', FacebookSignalState::get_attribution_data( 'fbp_domain' ) );
+        $this->assertEquals( 'example.com', FacebookSignalState::get_attribution_data( 'fbc_domain' ) );
+    }
 
-	public function testPauseAndResumeToggleState() {
-		$this->assertFalse( FacebookSignalState::is_held() );
+    public function testPauseAndResumeToggleState() {
+        $this->assertFalse( FacebookSignalState::is_held() );
 
-		FacebookSignalState::hold();
-		$this->assertTrue( FacebookSignalState::is_held() );
+        FacebookSignalState::hold();
+        $this->assertTrue( FacebookSignalState::is_held() );
 
-		FacebookSignalState::release();
-		$this->assertFalse( FacebookSignalState::is_held() );
-	}
+        FacebookSignalState::release();
+        $this->assertFalse( FacebookSignalState::is_held() );
+    }
 }

--- a/__tests__/core/FacebookSignalStateTest.php
+++ b/__tests__/core/FacebookSignalStateTest.php
@@ -73,12 +73,12 @@ final class FacebookSignalStateTest extends FacebookWordpressTestBase {
 	}
 
 	public function testPauseAndResumeToggleState() {
-		$this->assertFalse( FacebookSignalState::is_paused() );
+		$this->assertFalse( FacebookSignalState::is_held() );
 
-		FacebookSignalState::pause();
-		$this->assertTrue( FacebookSignalState::is_paused() );
+		FacebookSignalState::hold();
+		$this->assertTrue( FacebookSignalState::is_held() );
 
-		FacebookSignalState::resume();
-		$this->assertFalse( FacebookSignalState::is_paused() );
+		FacebookSignalState::release();
+		$this->assertFalse( FacebookSignalState::is_held() );
 	}
 }

--- a/__tests__/core/FacebookSignalStateTest.php
+++ b/__tests__/core/FacebookSignalStateTest.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * Facebook Pixel Plugin FacebookSignalStateTest class.
+ *
+ * @package FacebookPixelPlugin
+ */
+
+/**
+ * Copyright (C) 2017-present, Meta, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+namespace FacebookPixelPlugin\Tests\Core;
+
+use FacebookPixelPlugin\Core\FacebookSignalState;
+use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
+
+/**
+ * FacebookSignalStateTest class.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class FacebookSignalStateTest extends FacebookWordpressTestBase {
+
+	public function setUp(): void {
+		parent::setUp();
+		FacebookSignalState::reset_queue();
+	}
+
+	public function testSetAndGetAttributionData() {
+		FacebookSignalState::set_attribution_data( 'fbc', 'fb.1.123.abc' );
+		FacebookSignalState::set_attribution_data( 'fbp', 'fb.1.456.def' );
+
+		$this->assertEquals( 'fb.1.123.abc', FacebookSignalState::get_attribution_data( 'fbc' ) );
+		$this->assertEquals( 'fb.1.456.def', FacebookSignalState::get_attribution_data( 'fbp' ) );
+	}
+
+	public function testGetAttributionDataReturnsNullForMissingKey() {
+		$this->assertNull( FacebookSignalState::get_attribution_data( 'nonexistent' ) );
+	}
+
+	public function testSetAttributionDataOverwritesPreviousValue() {
+		FacebookSignalState::set_attribution_data( 'fbc', 'old_value' );
+		FacebookSignalState::set_attribution_data( 'fbc', 'new_value' );
+
+		$this->assertEquals( 'new_value', FacebookSignalState::get_attribution_data( 'fbc' ) );
+	}
+
+	public function testResetQueueClearsAttributionData() {
+		FacebookSignalState::set_attribution_data( 'fbc', 'fb.1.123.abc' );
+		FacebookSignalState::set_attribution_data( 'fbp', 'fb.1.456.def' );
+
+		FacebookSignalState::reset_queue();
+
+		$this->assertNull( FacebookSignalState::get_attribution_data( 'fbc' ) );
+		$this->assertNull( FacebookSignalState::get_attribution_data( 'fbp' ) );
+	}
+
+	public function testAttributionDataStoresDomains() {
+		FacebookSignalState::set_attribution_data( 'fbp_domain', 'example.com' );
+		FacebookSignalState::set_attribution_data( 'fbc_domain', 'example.com' );
+
+		$this->assertEquals( 'example.com', FacebookSignalState::get_attribution_data( 'fbp_domain' ) );
+		$this->assertEquals( 'example.com', FacebookSignalState::get_attribution_data( 'fbc_domain' ) );
+	}
+
+	public function testPauseAndResumeToggleState() {
+		$this->assertFalse( FacebookSignalState::is_paused() );
+
+		FacebookSignalState::pause();
+		$this->assertTrue( FacebookSignalState::is_paused() );
+
+		FacebookSignalState::resume();
+		$this->assertFalse( FacebookSignalState::is_paused() );
+	}
+}

--- a/__tests__/core/FacebookWordpressOptionsTest.php
+++ b/__tests__/core/FacebookWordpressOptionsTest.php
@@ -321,7 +321,9 @@ final class FacebookWordpressOptionsTest extends FacebookWordpressTestBase {
       $enable_aam = false,
       $aam_fields = array()
     ) {
-      define( 'MINUTE_IN_SECONDS', 60 );
+      if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+        define( 'MINUTE_IN_SECONDS', 60 );
+      }
       \WP_Mock::userFunction(
         'get_transient',
         array(

--- a/__tests__/core/FacebookWordpressPixelInjectionTest.php
+++ b/__tests__/core/FacebookWordpressPixelInjectionTest.php
@@ -248,6 +248,8 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
       )
     );
 
+    FacebookSignalState::set_attribution_data( 'fbp', 'fb.1.123.test' );
+
     $injection_obj = new FacebookWordpressPixelInjection();
 
     ob_start();
@@ -268,8 +270,8 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
    */
   public function testHeldInitCodeIncludesCapturedAttribution() {
     FacebookSignalState::hold();
-    $_COOKIE['_fbp'] = 'fb.1.123.browser';
-    $_COOKIE['_fbc'] = 'fb.1.123.click';
+    FacebookSignalState::set_attribution_data( 'fbp', 'fb.1.123.browser' );
+    FacebookSignalState::set_attribution_data( 'fbc', 'fb.1.123.click' );
     FacebookWordpressPixelInjection::$render_cache = array();
     FacebookPixel::set_pixel_id( '1234' );
 

--- a/__tests__/core/FacebookWordpressPixelInjectionTest.php
+++ b/__tests__/core/FacebookWordpressPixelInjectionTest.php
@@ -178,7 +178,9 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
     $enable_aam = false,
     $aam_fields = array()
   ) {
-    define( 'MINUTE_IN_SECONDS', 60 );
+    if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+      define( 'MINUTE_IN_SECONDS', 60 );
+    }
     \WP_Mock::userFunction(
       'get_transient',
       array(

--- a/__tests__/core/ServerEventFactoryTest.php
+++ b/__tests__/core/ServerEventFactoryTest.php
@@ -29,6 +29,7 @@ namespace FacebookPixelPlugin\Tests\Core;
 
 use FacebookPixelPlugin\Core\AAMSettingsFields;
 use FacebookPixelPlugin\Core\FacebookParamBuilder;
+use FacebookPixelPlugin\Core\FacebookSignalState;
 use FacebookPixelPlugin\Core\ServerEventFactory;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 
@@ -592,6 +593,194 @@ final class ServerEventFactoryTest extends FacebookWordpressTestBase {
       $this->assertEquals( $param_builder_fbp, $fbp );
     } else {
       $this->assertEquals( '_fbp_value', $fbp );
+    }
+  }
+
+  /**
+   * Tests that ParamBuilder fbp takes priority over cookie fbp.
+   */
+  public function testParamBuilderFbpTakesPriorityOverCookie() {
+    $_COOKIE['_fbp'] = 'cookie_fbp_value';
+
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+
+    $param_builder_fbp = FacebookParamBuilder::get_fbp();
+
+    $event     = ServerEventFactory::new_event( 'PageView' );
+    $event_fbp = $event->getUserData()->getFbp();
+
+    if ( ! empty( $param_builder_fbp ) ) {
+      $this->assertEquals( $param_builder_fbp, $event_fbp );
+    } else {
+      $this->assertEquals( 'cookie_fbp_value', $event_fbp );
+    }
+  }
+
+  /**
+   * Tests that ParamBuilder fbc takes priority over cookie fbc.
+   */
+  public function testParamBuilderFbcTakesPriorityOverCookie() {
+    $_COOKIE['_fbc'] = 'fb.1.100.old_fbclid';
+
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+
+    $param_builder_fbc = FacebookParamBuilder::get_fbc();
+
+    $event     = ServerEventFactory::new_event( 'PageView' );
+    $event_fbc = $event->getUserData()->getFbc();
+
+    if ( ! empty( $param_builder_fbc ) ) {
+      $this->assertEquals( $param_builder_fbc, $event_fbc );
+    } else {
+      $this->assertEquals( 'fb.1.100.old_fbclid', $event_fbc );
+    }
+  }
+
+  /**
+   * Tests that fbc is constructed from fbclid when cookie fbclid changed.
+   */
+  public function testFbcReconstructedWhenCookieFbclidChanged() {
+    $_COOKIE['_fbc'] = 'fb.1.100.old_fbclid';
+    $_GET['fbclid']  = 'new_fbclid';
+
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+
+    $event     = ServerEventFactory::new_event( 'Lead' );
+    $event_fbc = $event->getUserData()->getFbc();
+
+    $this->assertNotNull( $event_fbc );
+    $this->assertStringContainsString( 'new_fbclid', $event_fbc );
+  }
+
+  /**
+   * Tests that fbc cookie is used when fbclid has not changed.
+   */
+  public function testFbcCookieUsedWhenFbclidUnchanged() {
+    $_COOKIE['_fbc'] = 'fb.1.100.same_fbclid';
+    $_GET['fbclid']  = 'same_fbclid';
+
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+
+    $param_builder_fbc = FacebookParamBuilder::get_fbc();
+    $event             = ServerEventFactory::new_event( 'Lead' );
+    $event_fbc         = $event->getUserData()->getFbc();
+
+    if ( ! empty( $param_builder_fbc ) ) {
+      $this->assertEquals( $param_builder_fbc, $event_fbc );
+    } else {
+      $this->assertEquals( 'fb.1.100.same_fbclid', $event_fbc );
+    }
+  }
+
+  /**
+   * Tests that fbc is not written to session when paused.
+   */
+  public function testFbcNotSavedToSessionWhenPaused() {
+    $_GET['fbclid'] = 'test_fbclid';
+    $_SESSION       = array();
+
+    FacebookSignalState::pause();
+
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+
+    ServerEventFactory::new_event( 'Lead' );
+
+    $this->assertArrayNotHasKey( '_fbc', $_SESSION );
+  }
+
+  /**
+   * Tests that fbc is saved to session when not paused.
+   */
+  public function testFbcSavedToSessionWhenNotPaused() {
+    $_GET['fbclid'] = 'test_fbclid';
+    $_SESSION       = array();
+
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+
+    $event     = ServerEventFactory::new_event( 'Lead' );
+    $event_fbc = $event->getUserData()->getFbc();
+
+    if ( ! empty( $event_fbc ) ) {
+      $this->assertArrayHasKey( '_fbc', $_SESSION );
+      $this->assertEquals( $event_fbc, $_SESSION['_fbc'] );
+    } else {
+      $this->assertArrayNotHasKey( '_fbc', $_SESSION );
+    }
+  }
+
+  /**
+   * Tests that fbc falls back to session when no other source is available.
+   */
+  public function testFbcFallsBackToSession() {
+    $_SESSION['_fbc'] = 'fb.1.999.session_fbclid';
+
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+
+    $param_builder_fbc = FacebookParamBuilder::get_fbc();
+
+    $event     = ServerEventFactory::new_event( 'Lead' );
+    $event_fbc = $event->getUserData()->getFbc();
+
+    if ( ! empty( $param_builder_fbc ) ) {
+      $this->assertEquals( $param_builder_fbc, $event_fbc );
+    } else {
+      $this->assertEquals( 'fb.1.999.session_fbclid', $event_fbc );
     }
   }
 

--- a/__tests__/core/ServerEventFactoryTest.php
+++ b/__tests__/core/ServerEventFactoryTest.php
@@ -711,7 +711,7 @@ final class ServerEventFactoryTest extends FacebookWordpressTestBase {
     $_GET['fbclid'] = 'test_fbclid';
     $_SESSION       = array();
 
-    FacebookSignalState::pause();
+    FacebookSignalState::hold();
 
     \WP_Mock::userFunction(
       'sanitize_text_field',

--- a/__tests__/core/ServerEventFactoryTest.php
+++ b/__tests__/core/ServerEventFactoryTest.php
@@ -521,8 +521,8 @@ final class ServerEventFactoryTest extends FacebookWordpressTestBase {
 
     $event_fbc = $event->getUserData()->getFbc();
 
-    $this->assertEquals( true, str_starts_with( $event_fbc, 'fb.1.' ) );
-    $this->assertEquals( true, str_ends_with( $event_fbc, '.fbclid_str' ) );
+    $this->assertStringStartsWith( 'fb.1.', $event_fbc );
+    $this->assertStringContainsString( 'fbclid_str', $event_fbc );
   }
 
   /**

--- a/__tests__/core/ServerEventFactoryTest.php
+++ b/__tests__/core/ServerEventFactoryTest.php
@@ -28,6 +28,7 @@
 namespace FacebookPixelPlugin\Tests\Core;
 
 use FacebookPixelPlugin\Core\AAMSettingsFields;
+use FacebookPixelPlugin\Core\FacebookParamBuilder;
 use FacebookPixelPlugin\Core\ServerEventFactory;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 
@@ -573,16 +574,6 @@ final class ServerEventFactoryTest extends FacebookWordpressTestBase {
     $_COOKIE['_fbp'] = '_fbp_value';
 
     \WP_Mock::userFunction(
-      'wp_unslash',
-      array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-      )
-    );
-
-    \WP_Mock::userFunction(
       'sanitize_text_field',
       array(
         'args'   => array( \Mockery::any() ),
@@ -594,7 +585,14 @@ final class ServerEventFactoryTest extends FacebookWordpressTestBase {
 
     $event = ServerEventFactory::new_event( 'Lead' );
 
-    $this->assertEquals( '_fbp_value', $event->getUserData()->getFbp() );
+    $fbp = $event->getUserData()->getFbp();
+    $this->assertNotNull( $fbp );
+    $param_builder_fbp = FacebookParamBuilder::get_fbp();
+    if ( ! empty( $param_builder_fbp ) ) {
+      $this->assertEquals( $param_builder_fbp, $fbp );
+    } else {
+      $this->assertEquals( '_fbp_value', $fbp );
+    }
   }
 
   /**

--- a/__tests_sdk__/FacebookAdsTest/Object/ServerSide/ServerSideEventTest.php
+++ b/__tests_sdk__/FacebookAdsTest/Object/ServerSide/ServerSideEventTest.php
@@ -28,7 +28,7 @@ use FacebookPixelPlugin\FacebookAdsTest\AbstractUnitTestCase;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
 
 
-class ServerSideNormalizeTest extends AbstractUnitTestCase {
+class ServerSideEventTest extends AbstractUnitTestCase {
 
   public function testEventData(){
     $testName = 'Test123Event';

--- a/build.xml
+++ b/build.xml
@@ -48,7 +48,7 @@
             <fileset refid="sourcedir" />
         </copy>
         <echo msg="Copy complete" />
-        <echo msg="Run compose install..." />
+        <echo msg="Run composer install..." />
         <composer command="install">
             <arg value="--working-dir=${buildsourcedir}" />
             <arg value="--no-dev" />

--- a/build.xml
+++ b/build.xml
@@ -44,6 +44,8 @@
     <target name="Build" description="rebuilds this package" depends="Clean">
         <echo msg="Running Build..." />
         <echo msg="Copy files into build folder..." />
+        <mkdir dir="${builddir}" />
+        <mkdir dir="${buildsourcedir}" />
         <copy todir="${buildsourcedir}">
             <fileset refid="sourcedir" />
         </copy>

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
   "license": "GPL",
   "require": {
     "php": ">=7.4",
-    "techcrunch/wp-async-task": "dev-master"
+    "techcrunch/wp-async-task": "dev-master",
+    "facebook/capi-param-builder-php": "^1.2.1"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
     },
     "classmap": [
       "./"
+    ],
+    "exclude-from-classmap": [
+      "/build/"
     ]
   },
   "autoload-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ea4336cc3c25bc2e0d30086f5b213753",
+    "content-hash": "ec347124124aa9c7ee442c5be7c99fb0",
     "packages": [
         {
             "name": "facebook/capi-param-builder-php",
@@ -3851,5 +3851,8 @@
         "php": ">=7.4"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "7.4"
+    },
     "plugin-api-version": "2.9.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,42 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "3bd3e2af4a274ae9c74b2ab67c80b0a6",
+    "content-hash": "ea4336cc3c25bc2e0d30086f5b213753",
     "packages": [
+        {
+            "name": "facebook/capi-param-builder-php",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/facebook/capi-param-builder.git",
+                "reference": "0502e762127deca4fce9b3e2e1b6ff38b392f526"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/facebook/capi-param-builder/zipball/0502e762127deca4fce9b3e2e1b6ff38b392f526",
+                "reference": "0502e762127deca4fce9b3e2e1b6ff38b392f526",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "FacebookAds\\": "php/capi-param-builder/src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "description": "Parameter builder SDK for Conversion API events",
+            "support": {
+                "issues": "https://github.com/facebook/capi-param-builder/issues",
+                "source": "https://github.com/facebook/capi-param-builder/tree/v1.2.1"
+            },
+            "time": "2026-01-26T22:36:05+00:00"
+        },
         {
             "name": "techcrunch/wp-async-task",
             "version": "dev-master",
@@ -3817,8 +3851,5 @@
         "php": ">=7.4"
     },
     "platform-dev": {},
-    "platform-overrides": {
-        "php": "7.4"
-    },
     "plugin-api-version": "2.9.0"
 }

--- a/core/class-facebookparambuilder.php
+++ b/core/class-facebookparambuilder.php
@@ -88,7 +88,8 @@ class FacebookParamBuilder {
 						: null
 				);
 			} catch ( \Throwable $exception ) {
-				error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				FacebookPluginUtils::log_once_daily(
+					'init',
 					'Meta Pixel: Error initializing CAPI Parameter Builder: '
 					. $exception->getMessage()
 				);
@@ -153,7 +154,8 @@ class FacebookParamBuilder {
 				}
 			}
 		} catch ( \Throwable $exception ) {
-			error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+			FacebookPluginUtils::log_once_daily(
+				'setup',
 				'Meta Pixel: Error setting ParamBuilder cookies: '
 				. $exception->getMessage()
 			);
@@ -180,7 +182,11 @@ class FacebookParamBuilder {
 				}
 			}
 		} catch ( \Throwable $exception ) {
-			// Silently fail — fallback to other methods.
+			FacebookPluginUtils::log_once_daily(
+				'fbc',
+				'Meta Pixel: Error getting FBC from ParamBuilder: '
+				. $exception->getMessage()
+			);
 		}
 		return self::$resolved_fbc;
 	}
@@ -205,7 +211,11 @@ class FacebookParamBuilder {
 				}
 			}
 		} catch ( \Throwable $exception ) {
-			// Silently fail — fallback to other methods.
+			FacebookPluginUtils::log_once_daily(
+				'fbp',
+				'Meta Pixel: Error getting FBP from ParamBuilder: '
+				. $exception->getMessage()
+			);
 		}
 		return self::$resolved_fbp;
 	}

--- a/core/class-facebookparambuilder.php
+++ b/core/class-facebookparambuilder.php
@@ -111,10 +111,6 @@ class FacebookParamBuilder {
 		}
 		self::$server_setup_done = true;
 
-		if ( FacebookSignalState::is_held() ) {
-			return;
-		}
-
 		try {
 			$param_builder = self::get_instance();
 			if ( null === $param_builder ) {
@@ -122,6 +118,28 @@ class FacebookParamBuilder {
 			}
 
 			$cookies_to_set = $param_builder->getCookiesToSet();
+
+			if ( FacebookSignalState::is_held() ) {
+				$fbc = self::get_fbc();
+				$fbp = self::get_fbp();
+
+				if ( ! empty( $fbc ) ) {
+					FacebookSignalState::set_attribution_data( 'fbc', $fbc );
+				}
+				if ( ! empty( $fbp ) ) {
+					FacebookSignalState::set_attribution_data( 'fbp', $fbp );
+				}
+
+				foreach ( $cookies_to_set as $cookie ) {
+					if ( '_fbp' === $cookie->name ) {
+						FacebookSignalState::set_attribution_data( 'fbp_domain', $cookie->domain );
+					} elseif ( '_fbc' === $cookie->name ) {
+						FacebookSignalState::set_attribution_data( 'fbc_domain', $cookie->domain );
+					}
+				}
+
+				return;
+			}
 
 			if ( ! headers_sent() ) {
 				foreach ( $cookies_to_set as $cookie ) {

--- a/core/class-facebookparambuilder.php
+++ b/core/class-facebookparambuilder.php
@@ -147,9 +147,14 @@ class FacebookParamBuilder {
 					setcookie(
 						$cookie->name,
 						$cookie->value,
-						time() + $cookie->max_age,
-						'/',
-						$cookie->domain
+						array(
+							'expires'  => time() + $cookie->max_age,
+							'path'     => '/',
+							'domain'   => $cookie->domain,
+							'secure'   => is_ssl(),
+							'httponly' => false,
+							'samesite' => 'Lax',
+						)
 					);
 				}
 			}

--- a/core/class-facebookparambuilder.php
+++ b/core/class-facebookparambuilder.php
@@ -62,6 +62,20 @@ class FacebookParamBuilder {
 	private static $server_setup_done = false;
 
 	/**
+	 * Resolved _fbc value for this request. False means not yet resolved.
+	 *
+	 * @var string|null|false
+	 */
+	private static $resolved_fbc = false;
+
+	/**
+	 * Resolved _fbp value for this request. False means not yet resolved.
+	 *
+	 * @var string|null|false
+	 */
+	private static $resolved_fbp = false;
+
+	/**
 	 * Gets or creates the ParamBuilder singleton instance.
 	 *
 	 * Initializes the ParamBuilder with the site URL and processes
@@ -110,6 +124,10 @@ class FacebookParamBuilder {
 			return;
 		}
 		self::$server_setup_done = true;
+
+		if ( FacebookSignalState::is_paused() ) {
+			return;
+		}
 
 		try {
 			$param_builder = self::get_instance();
@@ -168,18 +186,23 @@ class FacebookParamBuilder {
 	 * @return string|null The _fbc value, or null if unavailable.
 	 */
 	public static function get_fbc() {
+		if ( false !== self::$resolved_fbc ) {
+			return self::$resolved_fbc;
+		}
+
+		self::$resolved_fbc = null;
 		try {
 			$param_builder = self::get_instance();
 			if ( null !== $param_builder ) {
 				$fbc = $param_builder->getFbc();
 				if ( ! empty( $fbc ) ) {
-					return $fbc;
+					self::$resolved_fbc = $fbc;
 				}
 			}
 		} catch ( \Exception $exception ) {
 			// Silently fail — fallback to other methods.
 		}
-		return null;
+		return self::$resolved_fbc;
 	}
 
 	/**
@@ -188,17 +211,22 @@ class FacebookParamBuilder {
 	 * @return string|null The _fbp value, or null if unavailable.
 	 */
 	public static function get_fbp() {
+		if ( false !== self::$resolved_fbp ) {
+			return self::$resolved_fbp;
+		}
+
+		self::$resolved_fbp = null;
 		try {
 			$param_builder = self::get_instance();
 			if ( null !== $param_builder ) {
 				$fbp = $param_builder->getFbp();
 				if ( ! empty( $fbp ) ) {
-					return $fbp;
+					self::$resolved_fbp = $fbp;
 				}
 			}
 		} catch ( \Exception $exception ) {
 			// Silently fail — fallback to other methods.
 		}
-		return null;
+		return self::$resolved_fbp;
 	}
 }

--- a/core/class-facebookparambuilder.php
+++ b/core/class-facebookparambuilder.php
@@ -87,7 +87,7 @@ class FacebookParamBuilder {
 						)
 						: null
 				);
-			} catch ( \Exception $exception ) {
+			} catch ( \Throwable $exception ) {
 				error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 					'Meta Pixel: Error initializing CAPI Parameter Builder: '
 					. $exception->getMessage()
@@ -134,7 +134,7 @@ class FacebookParamBuilder {
 					);
 				}
 			}
-		} catch ( \Exception $exception ) {
+		} catch ( \Throwable $exception ) {
 			error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 				'Meta Pixel: Error setting ParamBuilder cookies: '
 				. $exception->getMessage()
@@ -161,7 +161,7 @@ class FacebookParamBuilder {
 					self::$resolved_fbc = $fbc;
 				}
 			}
-		} catch ( \Exception $exception ) {
+		} catch ( \Throwable $exception ) {
 			// Silently fail — fallback to other methods.
 		}
 		return self::$resolved_fbc;
@@ -186,7 +186,7 @@ class FacebookParamBuilder {
 					self::$resolved_fbp = $fbp;
 				}
 			}
-		} catch ( \Exception $exception ) {
+		} catch ( \Throwable $exception ) {
 			// Silently fail — fallback to other methods.
 		}
 		return self::$resolved_fbp;

--- a/core/class-facebookparambuilder.php
+++ b/core/class-facebookparambuilder.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * Facebook Pixel Plugin FacebookParamBuilder class.
+ *
+ * This file contains the ParamBuilder integration logic for
+ * the CAPI Parameter Builder SDK.
+ *
+ * @package FacebookPixelPlugin
+ */
+
+/*
+* Copyright (C) 2017-present, Meta, Inc.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; version 2 of the License.
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*/
+
+namespace FacebookPixelPlugin\Core;
+
+defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
+
+/**
+ * Class FacebookParamBuilder
+ *
+ * Manages the CAPI Parameter Builder SDK integration.
+ * Provides server-side cookie management and client-side JS enqueue
+ * to improve _fbc and _fbp coverage for Conversions API events.
+ */
+class FacebookParamBuilder {
+
+	/**
+	 * URL for the client-side CAPI param builder script.
+	 *
+	 * @var string
+	 */
+	const CLIENT_JS_URL = 'https://unpkg.com/meta-capi-param-builder-clientjs/dist/clientParamBuilder.bundle.js';
+
+	/**
+	 * Script handle for the client-side param builder.
+	 *
+	 * @var string
+	 */
+	const CLIENT_JS_HANDLE = 'meta-capi-param-builder';
+
+	/**
+	 * Shared ParamBuilder instance.
+	 *
+	 * @var \FacebookAds\ParamBuilder|null
+	 */
+	private static $instance = null;
+
+	/**
+	 * Whether the server-side setup has been completed.
+	 *
+	 * @var bool
+	 */
+	private static $server_setup_done = false;
+
+	/**
+	 * Gets or creates the ParamBuilder singleton instance.
+	 *
+	 * Initializes the ParamBuilder with the site URL and processes
+	 * the current request to extract _fbc/_fbp parameters.
+	 *
+	 * @return \FacebookAds\ParamBuilder|null The ParamBuilder instance,
+	 *                                        or null on error.
+	 */
+	public static function get_instance() {
+		if ( null === self::$instance ) {
+			try {
+				$site_url       = get_site_url();
+				self::$instance = new \FacebookAds\ParamBuilder(
+					array( $site_url )
+				);
+				self::$instance->processRequest(
+					$site_url,
+					$_GET, // phpcs:ignore WordPress.Security.NonceVerification
+					$_COOKIE,
+					isset( $_SERVER['HTTP_REFERER'] )
+						? sanitize_text_field(
+							wp_unslash( $_SERVER['HTTP_REFERER'] )
+						)
+						: null
+				);
+			} catch ( \Exception $exception ) {
+				error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+					'Meta Pixel: Error initializing CAPI Parameter Builder: '
+					. $exception->getMessage()
+				);
+				self::$instance = null;
+			}
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Server-side setup: sets cookies from ParamBuilder.
+	 *
+	 * Must be called early in the request lifecycle before
+	 * headers are sent.
+	 */
+	public static function server_setup() {
+		if ( self::$server_setup_done ) {
+			return;
+		}
+		self::$server_setup_done = true;
+
+		try {
+			$param_builder = self::get_instance();
+			if ( null === $param_builder ) {
+				return;
+			}
+
+			$cookies_to_set = $param_builder->getCookiesToSet();
+
+			if ( ! headers_sent() ) {
+				foreach ( $cookies_to_set as $cookie ) {
+					setcookie(
+						$cookie->name,
+						$cookie->value,
+						time() + $cookie->max_age,
+						'/',
+						$cookie->domain
+					);
+				}
+			}
+		} catch ( \Exception $exception ) {
+			error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+				'Meta Pixel: Error setting ParamBuilder cookies: '
+				. $exception->getMessage()
+			);
+		}
+	}
+
+	/**
+	 * Client-side setup: enqueues the ParamBuilder JS script.
+	 *
+	 * Should be hooked to wp_enqueue_scripts.
+	 */
+	public static function client_setup() {
+		$pixel_id = FacebookWordpressOptions::get_pixel_id();
+		if ( ! FacebookPluginUtils::is_positive_integer( $pixel_id ) ) {
+			return;
+		}
+
+		wp_enqueue_script(
+			self::CLIENT_JS_HANDLE,
+			self::CLIENT_JS_URL,
+			array(),
+			null, // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
+			true
+		);
+
+		wp_add_inline_script(
+			self::CLIENT_JS_HANDLE,
+			'if (typeof clientParamBuilder !== "undefined") {' .
+				'clientParamBuilder.processAndCollectAllParams(window.location.href);' .
+			'}'
+		);
+	}
+
+	/**
+	 * Gets the _fbc value from ParamBuilder.
+	 *
+	 * @return string|null The _fbc value, or null if unavailable.
+	 */
+	public static function get_fbc() {
+		try {
+			$param_builder = self::get_instance();
+			if ( null !== $param_builder ) {
+				$fbc = $param_builder->getFbc();
+				if ( ! empty( $fbc ) ) {
+					return $fbc;
+				}
+			}
+		} catch ( \Exception $exception ) {
+			// Silently fail — fallback to other methods.
+		}
+		return null;
+	}
+
+	/**
+	 * Gets the _fbp value from ParamBuilder.
+	 *
+	 * @return string|null The _fbp value, or null if unavailable.
+	 */
+	public static function get_fbp() {
+		try {
+			$param_builder = self::get_instance();
+			if ( null !== $param_builder ) {
+				$fbp = $param_builder->getFbp();
+				if ( ! empty( $fbp ) ) {
+					return $fbp;
+				}
+			}
+		} catch ( \Exception $exception ) {
+			// Silently fail — fallback to other methods.
+		}
+		return null;
+	}
+}

--- a/core/class-facebookparambuilder.php
+++ b/core/class-facebookparambuilder.php
@@ -33,195 +33,195 @@ defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
  */
 class FacebookParamBuilder {
 
-	/**
-	 * Shared ParamBuilder instance.
-	 *
-	 * @var \FacebookAds\ParamBuilder|null
-	 */
-	private static $instance = null;
+    /**
+     * Shared ParamBuilder instance.
+     *
+     * @var \FacebookAds\ParamBuilder|null
+     */
+    private static $instance = null;
 
-	/**
-	 * Whether the server-side setup has been completed.
-	 *
-	 * @var bool
-	 */
-	private static $server_setup_done = false;
+    /**
+     * Whether the server-side setup has been completed.
+     *
+     * @var bool
+     */
+    private static $server_setup_done = false;
 
-	/**
-	 * Resolved _fbc value for this request. False means not yet resolved.
-	 *
-	 * @var string|null|false
-	 */
-	private static $resolved_fbc = false;
+    /**
+     * Resolved _fbc value for this request. False means not yet resolved.
+     *
+     * @var string|null|false
+     */
+    private static $resolved_fbc = false;
 
-	/**
-	 * Resolved _fbp value for this request. False means not yet resolved.
-	 *
-	 * @var string|null|false
-	 */
-	private static $resolved_fbp = false;
+    /**
+     * Resolved _fbp value for this request. False means not yet resolved.
+     *
+     * @var string|null|false
+     */
+    private static $resolved_fbp = false;
 
-	/**
-	 * Gets or creates the ParamBuilder singleton instance.
-	 *
-	 * Initializes the ParamBuilder with the site URL and processes
-	 * the current request to extract _fbc/_fbp parameters.
-	 *
-	 * @return \FacebookAds\ParamBuilder|null The ParamBuilder instance,
-	 *                                        or null on error.
-	 */
-	public static function get_instance() {
-		if ( null === self::$instance ) {
-			try {
-				$site_url       = get_site_url();
-				self::$instance = new \FacebookAds\ParamBuilder(
-					array( $site_url )
-				);
-				self::$instance->processRequest(
-					$site_url,
-					$_GET, // phpcs:ignore WordPress.Security.NonceVerification
-					$_COOKIE,
-					isset( $_SERVER['HTTP_REFERER'] )
-						? sanitize_text_field(
-							wp_unslash( $_SERVER['HTTP_REFERER'] )
-						)
-						: null
-				);
-			} catch ( \Throwable $exception ) {
-				FacebookPluginUtils::log_once_daily(
-					'init',
-					'Meta Pixel: Error initializing CAPI Parameter Builder: '
-					. $exception->getMessage()
-				);
-				self::$instance = null;
-			}
-		}
+    /**
+     * Gets or creates the ParamBuilder singleton instance.
+     *
+     * Initializes the ParamBuilder with the site URL and processes
+     * the current request to extract _fbc/_fbp parameters.
+     *
+     * @return \FacebookAds\ParamBuilder|null The ParamBuilder instance,
+     *                                        or null on error.
+     */
+    public static function get_instance() {
+        if ( null === self::$instance ) {
+            try {
+                $site_url       = get_site_url();
+                self::$instance = new \FacebookAds\ParamBuilder(
+                    array( $site_url )
+                );
+                self::$instance->processRequest(
+                    $site_url,
+                    $_GET, // phpcs:ignore WordPress.Security.NonceVerification
+                    $_COOKIE,
+                    isset( $_SERVER['HTTP_REFERER'] )
+                        ? sanitize_text_field(
+                            wp_unslash( $_SERVER['HTTP_REFERER'] )
+                        )
+                        : null
+                );
+            } catch ( \Throwable $exception ) {
+                FacebookPluginUtils::log_once_daily(
+                    'init',
+                    'Meta Pixel: Error initializing CAPI Parameter Builder: '
+                    . $exception->getMessage()
+                );
+                self::$instance = null;
+            }
+        }
 
-		return self::$instance;
-	}
+        return self::$instance;
+    }
 
-	/**
-	 * Server-side setup: sets cookies from ParamBuilder.
-	 *
-	 * Must be called early in the request lifecycle before
-	 * headers are sent.
-	 */
-	public static function server_setup() {
-		if ( self::$server_setup_done ) {
-			return;
-		}
-		self::$server_setup_done = true;
+    /**
+     * Server-side setup: sets cookies from ParamBuilder.
+     *
+     * Must be called early in the request lifecycle before
+     * headers are sent.
+     */
+    public static function server_setup() {
+        if ( self::$server_setup_done ) {
+            return;
+        }
+        self::$server_setup_done = true;
 
-		try {
-			$param_builder = self::get_instance();
-			if ( null === $param_builder ) {
-				return;
-			}
+        try {
+            $param_builder = self::get_instance();
+            if ( null === $param_builder ) {
+                return;
+            }
 
-			$cookies_to_set = $param_builder->getCookiesToSet();
+            $cookies_to_set = $param_builder->getCookiesToSet();
 
-			if ( FacebookSignalState::is_held() ) {
-				$fbc = self::get_fbc();
-				$fbp = self::get_fbp();
+            if ( FacebookSignalState::is_held() ) {
+                $fbc = self::get_fbc();
+                $fbp = self::get_fbp();
 
-				if ( ! empty( $fbc ) ) {
-					FacebookSignalState::set_attribution_data( 'fbc', $fbc );
-				}
-				if ( ! empty( $fbp ) ) {
-					FacebookSignalState::set_attribution_data( 'fbp', $fbp );
-				}
+                if ( ! empty( $fbc ) ) {
+                    FacebookSignalState::set_attribution_data( 'fbc', $fbc );
+                }
+                if ( ! empty( $fbp ) ) {
+                    FacebookSignalState::set_attribution_data( 'fbp', $fbp );
+                }
 
-				foreach ( $cookies_to_set as $cookie ) {
-					if ( '_fbp' === $cookie->name ) {
-						FacebookSignalState::set_attribution_data( 'fbp_domain', $cookie->domain );
-					} elseif ( '_fbc' === $cookie->name ) {
-						FacebookSignalState::set_attribution_data( 'fbc_domain', $cookie->domain );
-					}
-				}
+                foreach ( $cookies_to_set as $cookie ) {
+                    if ( '_fbp' === $cookie->name ) {
+                        FacebookSignalState::set_attribution_data( 'fbp_domain', $cookie->domain );
+                    } elseif ( '_fbc' === $cookie->name ) {
+                        FacebookSignalState::set_attribution_data( 'fbc_domain', $cookie->domain );
+                    }
+                }
 
-				return;
-			}
+                return;
+            }
 
-			if ( ! headers_sent() ) {
-				foreach ( $cookies_to_set as $cookie ) {
-					setcookie(
-						$cookie->name,
-						$cookie->value,
-						array(
-							'expires'  => time() + $cookie->max_age,
-							'path'     => '/',
-							'domain'   => $cookie->domain,
-							'secure'   => is_ssl(),
-							'httponly' => false,
-							'samesite' => 'Lax',
-						)
-					);
-				}
-			}
-		} catch ( \Throwable $exception ) {
-			FacebookPluginUtils::log_once_daily(
-				'setup',
-				'Meta Pixel: Error setting ParamBuilder cookies: '
-				. $exception->getMessage()
-			);
-		}
-	}
+            if ( ! headers_sent() ) {
+                foreach ( $cookies_to_set as $cookie ) {
+                    setcookie(
+                        $cookie->name,
+                        $cookie->value,
+                        array(
+                            'expires'  => time() + $cookie->max_age,
+                            'path'     => '/',
+                            'domain'   => $cookie->domain,
+                            'secure'   => is_ssl(),
+                            'httponly' => false,
+                            'samesite' => 'Lax',
+                        )
+                    );
+                }
+            }
+        } catch ( \Throwable $exception ) {
+            FacebookPluginUtils::log_once_daily(
+                'setup',
+                'Meta Pixel: Error setting ParamBuilder cookies: '
+                . $exception->getMessage()
+            );
+        }
+    }
 
-	/**
-	 * Gets the _fbc value from ParamBuilder.
-	 *
-	 * @return string|null The _fbc value, or null if unavailable.
-	 */
-	public static function get_fbc() {
-		if ( false !== self::$resolved_fbc ) {
-			return self::$resolved_fbc;
-		}
+    /**
+     * Gets the _fbc value from ParamBuilder.
+     *
+     * @return string|null The _fbc value, or null if unavailable.
+     */
+    public static function get_fbc() {
+        if ( false !== self::$resolved_fbc ) {
+            return self::$resolved_fbc;
+        }
 
-		self::$resolved_fbc = null;
-		try {
-			$param_builder = self::get_instance();
-			if ( null !== $param_builder ) {
-				$fbc = $param_builder->getFbc();
-				if ( ! empty( $fbc ) ) {
-					self::$resolved_fbc = $fbc;
-				}
-			}
-		} catch ( \Throwable $exception ) {
-			FacebookPluginUtils::log_once_daily(
-				'fbc',
-				'Meta Pixel: Error getting FBC from ParamBuilder: '
-				. $exception->getMessage()
-			);
-		}
-		return self::$resolved_fbc;
-	}
+        self::$resolved_fbc = null;
+        try {
+            $param_builder = self::get_instance();
+            if ( null !== $param_builder ) {
+                $fbc = $param_builder->getFbc();
+                if ( ! empty( $fbc ) ) {
+                    self::$resolved_fbc = $fbc;
+                }
+            }
+        } catch ( \Throwable $exception ) {
+            FacebookPluginUtils::log_once_daily(
+                'fbc',
+                'Meta Pixel: Error getting FBC from ParamBuilder: '
+                . $exception->getMessage()
+            );
+        }
+        return self::$resolved_fbc;
+    }
 
-	/**
-	 * Gets the _fbp value from ParamBuilder.
-	 *
-	 * @return string|null The _fbp value, or null if unavailable.
-	 */
-	public static function get_fbp() {
-		if ( false !== self::$resolved_fbp ) {
-			return self::$resolved_fbp;
-		}
+    /**
+     * Gets the _fbp value from ParamBuilder.
+     *
+     * @return string|null The _fbp value, or null if unavailable.
+     */
+    public static function get_fbp() {
+        if ( false !== self::$resolved_fbp ) {
+            return self::$resolved_fbp;
+        }
 
-		self::$resolved_fbp = null;
-		try {
-			$param_builder = self::get_instance();
-			if ( null !== $param_builder ) {
-				$fbp = $param_builder->getFbp();
-				if ( ! empty( $fbp ) ) {
-					self::$resolved_fbp = $fbp;
-				}
-			}
-		} catch ( \Throwable $exception ) {
-			FacebookPluginUtils::log_once_daily(
-				'fbp',
-				'Meta Pixel: Error getting FBP from ParamBuilder: '
-				. $exception->getMessage()
-			);
-		}
-		return self::$resolved_fbp;
-	}
+        self::$resolved_fbp = null;
+        try {
+            $param_builder = self::get_instance();
+            if ( null !== $param_builder ) {
+                $fbp = $param_builder->getFbp();
+                if ( ! empty( $fbp ) ) {
+                    self::$resolved_fbp = $fbp;
+                }
+            }
+        } catch ( \Throwable $exception ) {
+            FacebookPluginUtils::log_once_daily(
+                'fbp',
+                'Meta Pixel: Error getting FBP from ParamBuilder: '
+                . $exception->getMessage()
+            );
+        }
+        return self::$resolved_fbp;
+    }
 }

--- a/core/class-facebookparambuilder.php
+++ b/core/class-facebookparambuilder.php
@@ -34,20 +34,6 @@ defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 class FacebookParamBuilder {
 
 	/**
-	 * URL for the client-side CAPI param builder script.
-	 *
-	 * @var string
-	 */
-	const CLIENT_JS_URL = 'https://unpkg.com/meta-capi-param-builder-clientjs/dist/clientParamBuilder.bundle.js';
-
-	/**
-	 * Script handle for the client-side param builder.
-	 *
-	 * @var string
-	 */
-	const CLIENT_JS_HANDLE = 'meta-capi-param-builder';
-
-	/**
 	 * Shared ParamBuilder instance.
 	 *
 	 * @var \FacebookAds\ParamBuilder|null
@@ -125,7 +111,7 @@ class FacebookParamBuilder {
 		}
 		self::$server_setup_done = true;
 
-		if ( FacebookSignalState::is_paused() ) {
+		if ( FacebookSignalState::is_held() ) {
 			return;
 		}
 
@@ -154,30 +140,6 @@ class FacebookParamBuilder {
 				. $exception->getMessage()
 			);
 		}
-	}
-
-	/**
-	 * Returns the client-side ParamBuilder script tag for inline injection.
-	 *
-	 * This script loads BEFORE fbevents.js so that ParamBuilder takes
-	 * priority for _fbc/_fbp cookie management on the client side.
-	 *
-	 * @return string The script HTML, or empty string if pixel is not configured.
-	 */
-	public static function get_client_script_tag() {
-		$pixel_id = FacebookWordpressOptions::get_pixel_id();
-		if ( ! FacebookPluginUtils::is_positive_integer( $pixel_id ) ) {
-			return '';
-		}
-
-		$url = esc_url( self::CLIENT_JS_URL );
-		return "<!-- Meta CAPI Param Builder -->\n"
-			. "<script type='text/javascript' src='{$url}'></script>\n"
-			. "<script type='text/javascript'>\n"
-			. "if (typeof clientParamBuilder !== 'undefined') {\n"
-			. "  clientParamBuilder.processAndCollectAllParams(window.location.href);\n"
-			. "}\n"
-			. "</script>\n";
 	}
 
 	/**

--- a/core/class-facebookparambuilder.php
+++ b/core/class-facebookparambuilder.php
@@ -139,30 +139,27 @@ class FacebookParamBuilder {
 	}
 
 	/**
-	 * Client-side setup: enqueues the ParamBuilder JS script.
+	 * Returns the client-side ParamBuilder script tag for inline injection.
 	 *
-	 * Should be hooked to wp_enqueue_scripts.
+	 * This script loads BEFORE fbevents.js so that ParamBuilder takes
+	 * priority for _fbc/_fbp cookie management on the client side.
+	 *
+	 * @return string The script HTML, or empty string if pixel is not configured.
 	 */
-	public static function client_setup() {
+	public static function get_client_script_tag() {
 		$pixel_id = FacebookWordpressOptions::get_pixel_id();
 		if ( ! FacebookPluginUtils::is_positive_integer( $pixel_id ) ) {
-			return;
+			return '';
 		}
 
-		wp_enqueue_script(
-			self::CLIENT_JS_HANDLE,
-			self::CLIENT_JS_URL,
-			array(),
-			null, // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion
-			true
-		);
-
-		wp_add_inline_script(
-			self::CLIENT_JS_HANDLE,
-			'if (typeof clientParamBuilder !== "undefined") {' .
-				'clientParamBuilder.processAndCollectAllParams(window.location.href);' .
-			'}'
-		);
+		$url = esc_url( self::CLIENT_JS_URL );
+		return "<!-- Meta CAPI Param Builder -->\n"
+			. "<script type='text/javascript' src='{$url}'></script>\n"
+			. "<script type='text/javascript'>\n"
+			. "if (typeof clientParamBuilder !== 'undefined') {\n"
+			. "  clientParamBuilder.processAndCollectAllParams(window.location.href);\n"
+			. "}\n"
+			. "</script>\n";
 	}
 
 	/**

--- a/core/class-facebookpixel.php
+++ b/core/class-facebookpixel.php
@@ -478,54 +478,12 @@ src="https://www.facebook.com/tr?id=%s&ev=%s%s&noscript=1" />
         $tracking_name = '',
         $with_script_tag = true
     ) {
-        $cookie_sync = '';
-        if ( ! empty( self::$pixel_id ) && ! self::is_tracking_paused() ) {
-            $cookie_sync = self::get_cookie_sync_js( '_fbp', FacebookParamBuilder::get_fbp() )
-                . self::get_cookie_sync_js( '_fbc', FacebookParamBuilder::get_fbc() );
-        }
-
-        if ( empty( $cookie_sync ) ) {
-            return self::get_pixel_track_code(
-                self::PAGEVIEW,
-                $param,
-                $tracking_name,
-                $with_script_tag
-            );
-        }
-
-        $track = self::get_pixel_track_code(
+        return self::get_pixel_track_code(
             self::PAGEVIEW,
             $param,
             $tracking_name,
-            false
+            $with_script_tag
         );
-
-        $combined = $cookie_sync . "\n" . $track;
-        return $with_script_tag
-            ? "<script type='text/javascript'>" . $combined . '</script>'
-            : $combined;
-    }
-
-    /**
-     * Generates JS to sync a cookie with a server-side value.
-     *
-     * @param string      $cookie_name  Cookie name (e.g. '_fbp', '_fbc').
-     * @param string|null $server_value Server-resolved value.
-     *
-     * @return string JS snippet, or empty string if no sync needed.
-     */
-    private static function get_cookie_sync_js( $cookie_name, $server_value ) {
-        if ( empty( $server_value ) ) {
-            return '';
-        }
-
-        return "if(typeof fbq!=='undefined'){"
-            . "var _c=(document.cookie.match(/(?:^|;\\s*)"
-            . $cookie_name . "=([^;]*)/)||[])[1];"
-            . "if(_c&&_c!=='" . $server_value . "'){"
-            . "document.cookie='" . $cookie_name . "=" . $server_value
-            . ";path=/;max-age=7776000;SameSite=Lax';"
-            . "}}";
     }
 
     /**

--- a/core/class-facebookpixel.php
+++ b/core/class-facebookpixel.php
@@ -478,12 +478,54 @@ src="https://www.facebook.com/tr?id=%s&ev=%s%s&noscript=1" />
         $tracking_name = '',
         $with_script_tag = true
     ) {
-        return self::get_pixel_track_code(
+        $cookie_sync = '';
+        if ( ! empty( self::$pixel_id ) && ! self::is_tracking_paused() ) {
+            $cookie_sync = self::get_cookie_sync_js( '_fbp', FacebookParamBuilder::get_fbp() )
+                . self::get_cookie_sync_js( '_fbc', FacebookParamBuilder::get_fbc() );
+        }
+
+        if ( empty( $cookie_sync ) ) {
+            return self::get_pixel_track_code(
+                self::PAGEVIEW,
+                $param,
+                $tracking_name,
+                $with_script_tag
+            );
+        }
+
+        $track = self::get_pixel_track_code(
             self::PAGEVIEW,
             $param,
             $tracking_name,
-            $with_script_tag
+            false
         );
+
+        $combined = $cookie_sync . "\n" . $track;
+        return $with_script_tag
+            ? "<script type='text/javascript'>" . $combined . '</script>'
+            : $combined;
+    }
+
+    /**
+     * Generates JS to sync a cookie with a server-side value.
+     *
+     * @param string      $cookie_name  Cookie name (e.g. '_fbp', '_fbc').
+     * @param string|null $server_value Server-resolved value.
+     *
+     * @return string JS snippet, or empty string if no sync needed.
+     */
+    private static function get_cookie_sync_js( $cookie_name, $server_value ) {
+        if ( empty( $server_value ) ) {
+            return '';
+        }
+
+        return "if(typeof fbq!=='undefined'){"
+            . "var _c=(document.cookie.match(/(?:^|;\\s*)"
+            . $cookie_name . "=([^;]*)/)||[])[1];"
+            . "if(_c&&_c!=='" . $server_value . "'){"
+            . "document.cookie='" . $cookie_name . "=" . $server_value
+            . ";path=/;max-age=7776000;SameSite=Lax';"
+            . "}}";
     }
 
     /**

--- a/core/class-facebookpluginutils.php
+++ b/core/class-facebookpluginutils.php
@@ -133,4 +133,22 @@ class FacebookPluginUtils {
     public static function string_contains( $haystack, $needle ) {
         return (bool) strstr( $haystack, $needle );
     }
+
+    /**
+     * Logs a message at most once per day per key.
+     *
+     * Uses a WordPress transient to throttle repeated error
+     * messages from flooding the logs.
+     *
+     * @param string $key     Short identifier for the error.
+     * @param string $message The message to log.
+     */
+    public static function log_once_daily( $key, $message ) {
+        $transient = 'fbpix_err_' . $key;
+        if ( false !== get_transient( $transient ) ) {
+            return;
+        }
+        set_transient( $transient, 1, DAY_IN_SECONDS );
+        error_log( $message ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
+    }
 }

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -134,9 +134,6 @@ class FacebookWordpressPixelInjection {
         }
 
         self::$render_cache[ FacebookPluginConfig::IS_PIXEL_RENDERED ] = true;
-        if ( ! FacebookSignalState::is_paused() ) {
-            echo FacebookParamBuilder::get_client_script_tag(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-        }
         echo FacebookPixel::get_pixel_base_code(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         $capi_integration_status =
         FacebookWordpressOptions::get_capi_integration_status();

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -71,6 +71,11 @@ class FacebookWordpressPixelInjection {
                 'wp_body_open',
                 array( $this, 'inject_pixel_noscript_code' )
             );
+            // Enqueue CAPI ParamBuilder client-side JS.
+            add_action(
+                'wp_enqueue_scripts',
+                array( 'FacebookPixelPlugin\Core\FacebookParamBuilder', 'client_setup' )
+            );
             foreach (
                 FacebookPluginConfig::integration_config() as $key => $value
                 ) {

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -141,7 +141,6 @@ class FacebookWordpressPixelInjection {
         $user_info = FacebookPluginUtils::is_internal_user() ?
             array() : FacebookWordpressOptions::get_user_info();
         if ( FacebookSignalState::is_held() ) {
-            $this->capture_held_attribution();
             echo "<script type='text/javascript'>fbq('consent', 'revoke');</script>"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         }
         echo FacebookPixel::get_pixel_init_code( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -184,30 +183,12 @@ class FacebookWordpressPixelInjection {
             'facebook-signal',
             'facebookSignalConfig',
             array(
-                'cookieName'    => Signals::COOKIE_NAME,
+                'cookieName'    => FacebookPixelSignals::COOKIE_NAME,
                 'ajaxUrl'       => admin_url( 'admin-ajax.php' ),
-                'signalsAction' => Signals::AJAX_ACTION,
-                'signalsNonce'  => wp_create_nonce( Signals::NONCE_ACTION ),
+                'signalsAction' => FacebookPixelSignals::AJAX_ACTION,
+                'signalsNonce'  => wp_create_nonce( FacebookPixelSignals::NONCE_ACTION ),
             )
         );
-    }
-
-    /**
-     * Capture fbp/fbc attribution while signals are held so the release
-     * flow can forward it once signals are released.
-     *
-     * @return void
-     */
-    private function capture_held_attribution() {
-        $fbp = ServerEventFactory::get_fbp_value();
-        if ( ! empty( $fbp ) ) {
-            FacebookSignalState::set_attribution_data( 'fbp', $fbp );
-        }
-
-        $fbc = ServerEventFactory::get_fbc_value();
-        if ( ! empty( $fbc ) ) {
-            FacebookSignalState::set_attribution_data( 'fbc', $fbc );
-        }
     }
 
     /**
@@ -221,14 +202,28 @@ class FacebookWordpressPixelInjection {
             'ajaxUrl'       => admin_url( 'admin-ajax.php' ),
             'releaseAction' => ReleaseSignalsAjax::ACTION,
             'releaseNonce'  => wp_create_nonce( ReleaseSignalsAjax::NONCE_ACTION ),
-            'pixelId'       => FacebookPixel::get_pixel_id(),
+            'pixelId'      => FacebookPixel::get_pixel_id(),
         );
 
-        if ( FacebookSignalState::is_held() ) {
-            $config['attribution'] = array(
-                'fbp' => FacebookSignalState::get_attribution_data( 'fbp' ),
-                'fbc' => FacebookSignalState::get_attribution_data( 'fbc' ),
-            );
+        $attribution = array(
+            'fbp'       => FacebookSignalState::get_attribution_data( 'fbp' ),
+            'fbc'       => FacebookSignalState::get_attribution_data( 'fbc' ),
+            'fbpDomain' => FacebookSignalState::get_attribution_data( 'fbp_domain' ),
+            'fbcDomain' => FacebookSignalState::get_attribution_data( 'fbc_domain' ),
+        );
+
+        if ( ! FacebookSignalState::is_held() ) {
+            if ( empty( $attribution['fbp'] ) ) {
+                $attribution['fbp'] = FacebookParamBuilder::get_fbp();
+            }
+            if ( empty( $attribution['fbc'] ) ) {
+                $attribution['fbc'] = FacebookParamBuilder::get_fbc();
+            }
+        }
+
+        $attribution = array_filter( $attribution );
+        if ( ! empty( $attribution ) ) {
+            $config['attribution'] = $attribution;
         }
 
         return "<script type='text/javascript'>FacebookSignal.init(" .

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -202,7 +202,7 @@ class FacebookWordpressPixelInjection {
             'ajaxUrl'       => admin_url( 'admin-ajax.php' ),
             'releaseAction' => ReleaseSignalsAjax::ACTION,
             'releaseNonce'  => wp_create_nonce( ReleaseSignalsAjax::NONCE_ACTION ),
-            'pixelId'      => FacebookPixel::get_pixel_id(),
+            'pixelId'       => FacebookPixel::get_pixel_id(),
         );
 
         if ( FacebookSignalState::is_held() ) {

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -71,11 +71,6 @@ class FacebookWordpressPixelInjection {
                 'wp_body_open',
                 array( $this, 'inject_pixel_noscript_code' )
             );
-            // Enqueue CAPI ParamBuilder client-side JS.
-            add_action(
-                'wp_enqueue_scripts',
-                array( 'FacebookPixelPlugin\Core\FacebookParamBuilder', 'client_setup' )
-            );
             foreach (
                 FacebookPluginConfig::integration_config() as $key => $value
                 ) {
@@ -139,6 +134,7 @@ class FacebookWordpressPixelInjection {
         }
 
         self::$render_cache[ FacebookPluginConfig::IS_PIXEL_RENDERED ] = true;
+        echo FacebookParamBuilder::get_client_script_tag(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         echo FacebookPixel::get_pixel_base_code(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         $capi_integration_status =
         FacebookWordpressOptions::get_capi_integration_status();

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -205,25 +205,18 @@ class FacebookWordpressPixelInjection {
             'pixelId'      => FacebookPixel::get_pixel_id(),
         );
 
-        $attribution = array(
-            'fbp'       => FacebookSignalState::get_attribution_data( 'fbp' ),
-            'fbc'       => FacebookSignalState::get_attribution_data( 'fbc' ),
-            'fbpDomain' => FacebookSignalState::get_attribution_data( 'fbp_domain' ),
-            'fbcDomain' => FacebookSignalState::get_attribution_data( 'fbc_domain' ),
-        );
-
-        if ( ! FacebookSignalState::is_held() ) {
-            if ( empty( $attribution['fbp'] ) ) {
-                $attribution['fbp'] = FacebookParamBuilder::get_fbp();
+        if ( FacebookSignalState::is_held() ) {
+            $attribution = array_filter(
+                array(
+                    'fbp'       => FacebookSignalState::get_attribution_data( 'fbp' ),
+                    'fbc'       => FacebookSignalState::get_attribution_data( 'fbc' ),
+                    'fbpDomain' => FacebookSignalState::get_attribution_data( 'fbp_domain' ),
+                    'fbcDomain' => FacebookSignalState::get_attribution_data( 'fbc_domain' ),
+                )
+            );
+            if ( ! empty( $attribution ) ) {
+                $config['attribution'] = $attribution;
             }
-            if ( empty( $attribution['fbc'] ) ) {
-                $attribution['fbc'] = FacebookParamBuilder::get_fbc();
-            }
-        }
-
-        $attribution = array_filter( $attribution );
-        if ( ! empty( $attribution ) ) {
-            $config['attribution'] = $attribution;
         }
 
         return "<script type='text/javascript'>FacebookSignal.init(" .

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -134,7 +134,9 @@ class FacebookWordpressPixelInjection {
         }
 
         self::$render_cache[ FacebookPluginConfig::IS_PIXEL_RENDERED ] = true;
-        echo FacebookParamBuilder::get_client_script_tag(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        if ( ! FacebookSignalState::is_paused() ) {
+            echo FacebookParamBuilder::get_client_script_tag(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        }
         echo FacebookPixel::get_pixel_base_code(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         $capi_integration_status =
         FacebookWordpressOptions::get_capi_integration_status();

--- a/core/class-servereventfactory.php
+++ b/core/class-servereventfactory.php
@@ -156,20 +156,16 @@ class ServerEventFactory {
      * Retrieves the Facebook Browser ID (FBP).
      *
      * Resolution order:
-     * 1. _fbp cookie (set by fbevents.js or ParamBuilder)
-     * 2. ParamBuilder server-side extraction
+     * 1. ParamBuilder server-side extraction
+     * 2. _fbp cookie (set by fbevents.js)
      *
      * @return string|null The FBP value, or null if unavailable.
      */
     private static function get_fbp() {
-        $fbp = null;
+        $fbp = FacebookParamBuilder::get_fbp();
 
-        if ( ! empty( $_COOKIE['_fbp'] ) ) {
+        if ( ! $fbp && ! empty( $_COOKIE['_fbp'] ) ) {
             $fbp = sanitize_text_field( wp_unslash( $_COOKIE['_fbp'] ) );
-        }
-
-        if ( ! $fbp ) {
-            $fbp = FacebookParamBuilder::get_fbp();
         }
 
         return $fbp;
@@ -188,35 +184,33 @@ class ServerEventFactory {
      * Retrieves the Facebook Click ID (FBC).
      *
      * Resolution order:
-     * 1. If _fbc cookie exists AND fbclid hasn't changed, reuse cookie
-     * 2. ParamBuilder server-side value (always used when fbclid changed
-     *    or no cookie exists)
+     * 1. ParamBuilder server-side extraction
+     * 2. _fbc cookie (if fbclid hasn't changed)
      * 3. Constructed from fbclid query parameter
      * 4. Session fallback
      *
      * @return string|null The FBC value, or null if unavailable.
      */
     private static function get_fbc() {
-        $fbc = null;
-
-        $cookie_fbc  = ! empty( $_COOKIE['_fbc'] )
-            ? sanitize_text_field( wp_unslash( $_COOKIE['_fbc'] ) )
-            : null;
-        $request_fbclid = isset( $_GET['fbclid'] ) // phpcs:ignore WordPress.Security.NonceVerification
-            ? sanitize_text_field( wp_unslash( $_GET['fbclid'] ) ) // phpcs:ignore WordPress.Security.NonceVerification
-            : null;
-
-        if ( $cookie_fbc && ! self::has_fbclid_changed( $cookie_fbc, $request_fbclid ) ) {
-            $fbc = $cookie_fbc;
-        }
+        $fbc = FacebookParamBuilder::get_fbc();
 
         if ( ! $fbc ) {
-            $fbc = FacebookParamBuilder::get_fbc();
-        }
+            $cookie_fbc = ! empty( $_COOKIE['_fbc'] )
+                ? sanitize_text_field( wp_unslash( $_COOKIE['_fbc'] ) )
+                : null;
+				
+            $request_fbclid = isset( $_GET['fbclid'] ) // phpcs:ignore WordPress.Security.NonceVerification
+                ? sanitize_text_field( wp_unslash( $_GET['fbclid'] ) ) // phpcs:ignore WordPress.Security.NonceVerification
+                : null;
 
-        if ( ! $fbc && $request_fbclid ) {
-            $cur_time = (int) ( microtime( true ) * 1000 );
-            $fbc      = 'fb.1.' . $cur_time . '.' . rawurldecode( $request_fbclid );
+            if ( $cookie_fbc && ! self::has_fbclid_changed( $cookie_fbc, $request_fbclid ) ) {
+                $fbc = $cookie_fbc;
+            }
+
+            if ( ! $fbc && $request_fbclid ) {
+                $cur_time = (int) ( microtime( true ) * 1000 );
+                $fbc      = 'fb.1.' . $cur_time . '.' . rawurldecode( $request_fbclid );
+            }
         }
 
         if ( ! $fbc && isset( $_SESSION['_fbc'] ) ) {

--- a/core/class-servereventfactory.php
+++ b/core/class-servereventfactory.php
@@ -200,12 +200,14 @@ class ServerEventFactory {
                 : null;
 
             $request_fbclid = isset( $_GET['fbclid'] ) // phpcs:ignore WordPress.Security.NonceVerification
-                ? sanitize_text_field( wp_unslash( $_GET['fbclid'] ) ) // phpcs:ignore WordPress.Security.NonceVerification
+                ? self::sanitize_fbclid(
+                    wp_unslash( $_GET['fbclid'] ) // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+                )
                 : null;
 
             if ( $request_fbclid && ( empty( $cookie_fbc ) || self::has_fbclid_changed( $cookie_fbc, $request_fbclid ) ) ) {
                 $cur_time = (int) ( microtime( true ) * 1000 );
-                $fbc      = 'fb.1.' . $cur_time . '.' . rawurldecode( $request_fbclid );
+                $fbc      = 'fb.1.' . $cur_time . '.' . $request_fbclid;
             }
 
             if ( empty( $fbc ) && ! empty( $cookie_fbc ) ) {
@@ -256,6 +258,25 @@ class ServerEventFactory {
 
         $cookie_fbclid = implode( '.', array_slice( $parts, 3 ) );
         return $cookie_fbclid !== $request_fbclid;
+    }
+
+    /**
+     * Decodes and validates an fbclid value.
+     *
+     * Decodes URL encoding first, then validates against an
+     * allowlist of safe characters. Returns null if the value
+     * contains unexpected characters.
+     *
+     * @param string $raw_fbclid The raw fbclid from the query string.
+     *
+     * @return string|null The sanitized fbclid, or null if invalid.
+     */
+    private static function sanitize_fbclid( $raw_fbclid ) {
+        $decoded = rawurldecode( $raw_fbclid );
+        if ( preg_match( '/^[A-Za-z0-9_-]+$/', $decoded ) ) {
+            return $decoded;
+        }
+        return null;
     }
 
     /**

--- a/core/class-servereventfactory.php
+++ b/core/class-servereventfactory.php
@@ -153,25 +153,27 @@ class ServerEventFactory {
     }
 
     /**
-     * Retrieves the Facebook Browser ID (FBP) cookie.
+     * Retrieves the Facebook Browser ID (FBP).
      *
-     * This function returns the value of the FBP cookie, which
-     * is a unique identifier assigned to a user by Facebook.
-     * The FBP cookie is used by the Facebook pixel to track
-     * user behavior across multiple sites and sessions.
+     * Resolution order:
+     * 1. _fbp cookie (set by fbevents.js or ParamBuilder)
+     * 2. ParamBuilder server-side extraction
      *
-     * @return string|null The value of the FBP cookie, or
-     * null if the cookie is not present.
+     * @return string|null The FBP value, or null if unavailable.
      */
     private static function get_fbp() {
-      $fbp = null;
+        $fbp = null;
 
-      if ( ! empty( $_COOKIE['_fbp'] ) ) {
-          $fbp = sanitize_text_field( wp_unslash( $_COOKIE['_fbp'] ) );
-      }
+        if ( ! empty( $_COOKIE['_fbp'] ) ) {
+            $fbp = sanitize_text_field( wp_unslash( $_COOKIE['_fbp'] ) );
+        }
 
-      return $fbp;
-  }
+        if ( ! $fbp ) {
+            $fbp = FacebookParamBuilder::get_fbp();
+        }
+
+        return $fbp;
+    }
 
     /**
      * Public wrapper for the current request's FBP value.
@@ -183,17 +185,16 @@ class ServerEventFactory {
     }
 
     /**
-     * Retrieves the Facebook Click ID (FBC) cookie or session variable.
+     * Retrieves the Facebook Click ID (FBC).
      *
-     * This function returns the value of the FBC cookie or session variable,
-     * which is a unique identifier assigned to a user by Facebook. The FBC
-     * cookie is used by the Facebook pixel to track user behavior across
-     * multiple sites and sessions. If the FBC cookie is not present, the
-     * function will attempt to generate an FBC value from the fbclid query
-     * parameter, if present.
+     * Resolution order:
+     * 1. _fbc cookie (set by fbevents.js or ParamBuilder)
+     * 2. Session cache
+     * 3. ParamBuilder server-side extraction
+     * 4. Constructed from fbclid query parameter
+     * 5. Session fallback
      *
-     * @return string|null The value of the FBC cookie or session variable, or
-     *                     null if neither is present.
+     * @return string|null The FBC value, or null if unavailable.
      */
     private static function get_fbc() {
         $fbc = null;
@@ -203,6 +204,10 @@ class ServerEventFactory {
                 wp_unslash( $_COOKIE['_fbc'] )
             );
             $_SESSION['_fbc'] = $fbc;
+        }
+
+        if ( ! $fbc ) {
+            $fbc = FacebookParamBuilder::get_fbc();
         }
 
         if ( ! $fbc && isset( $_GET['fbclid'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification

--- a/core/class-servereventfactory.php
+++ b/core/class-servereventfactory.php
@@ -164,7 +164,7 @@ class ServerEventFactory {
     private static function get_fbp() {
         $fbp = FacebookParamBuilder::get_fbp();
 
-        if ( ! $fbp && ! empty( $_COOKIE['_fbp'] ) ) {
+        if ( empty( $fbp ) && ! empty( $_COOKIE['_fbp'] ) ) {
             $fbp = sanitize_text_field( wp_unslash( $_COOKIE['_fbp'] ) );
         }
 
@@ -194,30 +194,30 @@ class ServerEventFactory {
     private static function get_fbc() {
         $fbc = FacebookParamBuilder::get_fbc();
 
-        if ( ! $fbc ) {
+        if ( empty( $fbc ) ) {
             $cookie_fbc = ! empty( $_COOKIE['_fbc'] )
                 ? sanitize_text_field( wp_unslash( $_COOKIE['_fbc'] ) )
                 : null;
-				
+
             $request_fbclid = isset( $_GET['fbclid'] ) // phpcs:ignore WordPress.Security.NonceVerification
                 ? sanitize_text_field( wp_unslash( $_GET['fbclid'] ) ) // phpcs:ignore WordPress.Security.NonceVerification
                 : null;
 
-            if ( $cookie_fbc && ! self::has_fbclid_changed( $cookie_fbc, $request_fbclid ) ) {
-                $fbc = $cookie_fbc;
-            }
-
-            if ( ! $fbc && $request_fbclid ) {
+            if ( $request_fbclid && ( empty( $cookie_fbc ) || self::has_fbclid_changed( $cookie_fbc, $request_fbclid ) ) ) {
                 $cur_time = (int) ( microtime( true ) * 1000 );
                 $fbc      = 'fb.1.' . $cur_time . '.' . rawurldecode( $request_fbclid );
             }
+
+            if ( empty( $fbc ) && ! empty( $cookie_fbc ) ) {
+                $fbc = $cookie_fbc;
+            }
+
+            if ( empty( $fbc ) && isset( $_SESSION['_fbc'] ) ) {
+                $fbc = sanitize_text_field( $_SESSION['_fbc'] );
+            }
         }
 
-        if ( ! $fbc && isset( $_SESSION['_fbc'] ) ) {
-            $fbc = sanitize_text_field( $_SESSION['_fbc'] );
-        }
-
-        if ( $fbc ) {
+        if ( ! empty( $fbc ) && ! FacebookSignalState::is_held() ) {
             $_SESSION['_fbc'] = $fbc;
         }
 

--- a/core/class-servereventfactory.php
+++ b/core/class-servereventfactory.php
@@ -188,32 +188,35 @@ class ServerEventFactory {
      * Retrieves the Facebook Click ID (FBC).
      *
      * Resolution order:
-     * 1. _fbc cookie (set by fbevents.js or ParamBuilder)
-     * 2. Session cache
-     * 3. ParamBuilder server-side extraction
-     * 4. Constructed from fbclid query parameter
-     * 5. Session fallback
+     * 1. If _fbc cookie exists AND fbclid hasn't changed, reuse cookie
+     * 2. ParamBuilder server-side value (always used when fbclid changed
+     *    or no cookie exists)
+     * 3. Constructed from fbclid query parameter
+     * 4. Session fallback
      *
      * @return string|null The FBC value, or null if unavailable.
      */
     private static function get_fbc() {
         $fbc = null;
 
-        if ( ! empty( $_COOKIE['_fbc'] ) ) {
-            $fbc              = sanitize_text_field(
-                wp_unslash( $_COOKIE['_fbc'] )
-            );
-            $_SESSION['_fbc'] = $fbc;
+        $cookie_fbc  = ! empty( $_COOKIE['_fbc'] )
+            ? sanitize_text_field( wp_unslash( $_COOKIE['_fbc'] ) )
+            : null;
+        $request_fbclid = isset( $_GET['fbclid'] ) // phpcs:ignore WordPress.Security.NonceVerification
+            ? sanitize_text_field( wp_unslash( $_GET['fbclid'] ) ) // phpcs:ignore WordPress.Security.NonceVerification
+            : null;
+
+        if ( $cookie_fbc && ! self::has_fbclid_changed( $cookie_fbc, $request_fbclid ) ) {
+            $fbc = $cookie_fbc;
         }
 
         if ( ! $fbc ) {
             $fbc = FacebookParamBuilder::get_fbc();
         }
 
-        if ( ! $fbc && isset( $_GET['fbclid'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification
-            $fbclid   = sanitize_text_field( wp_unslash( $_GET['fbclid'] ) ); // phpcs:ignore WordPress.Security.NonceVerification
+        if ( ! $fbc && $request_fbclid ) {
             $cur_time = (int) ( microtime( true ) * 1000 );
-            $fbc      = 'fb.1.' . $cur_time . '.' . rawurldecode( $fbclid );
+            $fbc      = 'fb.1.' . $cur_time . '.' . rawurldecode( $request_fbclid );
         }
 
         if ( ! $fbc && isset( $_SESSION['_fbc'] ) ) {
@@ -234,6 +237,31 @@ class ServerEventFactory {
      */
     public static function get_fbc_value() {
         return self::get_fbc();
+    }
+
+    /**
+     * Checks whether the fbclid in the current request differs from
+     * the one stored in the existing _fbc cookie.
+     *
+     * @param string      $cookie_fbc The current _fbc cookie value
+     *                                (format: fb.{subdomain}.{timestamp}.{fbclid}).
+     * @param string|null $request_fbclid The fbclid from the current request,
+     *                                    or null if not present.
+     *
+     * @return bool True if fbclid has changed, false otherwise.
+     */
+    private static function has_fbclid_changed( $cookie_fbc, $request_fbclid ) {
+        if ( null === $request_fbclid ) {
+            return false;
+        }
+
+        $parts = explode( '.', $cookie_fbc );
+        if ( count( $parts ) < 4 ) {
+            return true;
+        }
+
+        $cookie_fbclid = implode( '.', array_slice( $parts, 3 ) );
+        return $cookie_fbclid !== $request_fbclid;
     }
 
     /**

--- a/facebook-for-wordpress.php
+++ b/facebook-for-wordpress.php
@@ -50,6 +50,7 @@ use FacebookPixelPlugin\Core\FacebookWordpressPixelInjection;
 use FacebookPixelPlugin\Core\FacebookWordpressSettingsPage;
 use FacebookPixelPlugin\Core\FacebookWordpressSettingsRecorder;
 use FacebookPixelPlugin\Core\ReleaseSignalsAjax;
+use FacebookPixelPlugin\Core\FacebookParamBuilder;
 use FacebookPixelPlugin\Core\ServerEventAsyncTask;
 
 /**
@@ -78,6 +79,9 @@ class FacebookForWordpress {
     if ( Signals::should_hold_signals() ) {
         FacebookSignalState::hold();
     }
+
+    // Initialize ParamBuilder server-side before pixel injection.
+    FacebookParamBuilder::server_setup();
 
     add_action( 'init', array( $this, 'register_pixel_injection' ), 0 );
     add_action( 'parse_request', array( $this, 'handle_events_request' ), 0 );

--- a/js/facebook_signal.js
+++ b/js/facebook_signal.js
@@ -29,11 +29,35 @@ window.FacebookSignal = window.FacebookSignal || {
     this._config = config || {};
     this._held = !!this._config.held;
 
+    var attr = this._config.attribution || {};
+    if (!this._held && typeof fbq !== 'undefined') {
+      this._syncCookie('_fbp', attr.fbp, attr.fbpDomain);
+      this._syncCookie('_fbc', attr.fbc, attr.fbcDomain);
+    }
+
     try {
       var raw = window.sessionStorage.getItem('fbpix_seen_event_ids');
       this._seenEventIds = raw ? JSON.parse(raw) : {};
     } catch (e) {
       this._seenEventIds = this._seenEventIds || {};
+    }
+  },
+
+  _syncCookie: function (name, serverValue, domain) {
+    if (!serverValue) {
+      return;
+    }
+    var match = document.cookie.match(
+      new RegExp('(?:^|;\\s*)' + name + '=([^;]*)'),
+    );
+    var current = match ? match[1] : null;
+    if (current && current !== serverValue) {
+      var cookie =
+        name + '=' + serverValue + ';path=/;max-age=7776000;SameSite=Lax';
+      if (domain) {
+        cookie += ';domain=' + domain;
+      }
+      document.cookie = cookie;
     }
   },
 
@@ -141,18 +165,26 @@ window.FacebookSignal = window.FacebookSignal || {
   },
 
   _handleReleaseResponse: function (data) {
-    if (data.fbp) {
-      document.cookie =
-        '_fbp=' +
-        encodeURIComponent(data.fbp) +
-        ';path=/;max-age=7776000;SameSite=Lax';
+    var attr = this._config.attribution || {};
+    var fbpValue = data.fbp || attr.fbp;
+    var fbcValue = data.fbc || attr.fbc;
+
+    if (fbpValue) {
+      var fbpCookie =
+        '_fbp=' + fbpValue + ';path=/;max-age=7776000;SameSite=Lax';
+      if (attr.fbpDomain) {
+        fbpCookie += ';domain=' + attr.fbpDomain;
+      }
+      document.cookie = fbpCookie;
     }
 
-    if (data.fbc) {
-      document.cookie =
-        '_fbc=' +
-        encodeURIComponent(data.fbc) +
-        ';path=/;max-age=7776000;SameSite=Lax';
+    if (fbcValue) {
+      var fbcCookie =
+        '_fbc=' + fbcValue + ';path=/;max-age=7776000;SameSite=Lax';
+      if (attr.fbcDomain) {
+        fbcCookie += ';domain=' + attr.fbcDomain;
+      }
+      document.cookie = fbcCookie;
     }
 
     fbq('consent', 'grant');

--- a/js/facebook_signal.js
+++ b/js/facebook_signal.js
@@ -47,13 +47,14 @@ window.FacebookSignal = window.FacebookSignal || {
     if (!serverValue) {
       return;
     }
+    var encoded = encodeURIComponent(serverValue);
     var match = document.cookie.match(
       new RegExp('(?:^|;\\s*)' + name + '=([^;]*)'),
     );
     var current = match ? match[1] : null;
-    if (current && current !== serverValue) {
+    if (current && current !== encoded) {
       var cookie =
-        name + '=' + encodeURIComponent(serverValue) + ';path=/;max-age=7776000;SameSite=Lax';
+        name + '=' + encoded + ';path=/;max-age=7776000;SameSite=Lax';
       if (domain) {
         cookie += ';domain=' + domain;
       }

--- a/js/facebook_signal.js
+++ b/js/facebook_signal.js
@@ -53,7 +53,7 @@ window.FacebookSignal = window.FacebookSignal || {
     var current = match ? match[1] : null;
     if (current && current !== serverValue) {
       var cookie =
-        name + '=' + serverValue + ';path=/;max-age=7776000;SameSite=Lax';
+        name + '=' + encodeURIComponent(serverValue) + ';path=/;max-age=7776000;SameSite=Lax';
       if (domain) {
         cookie += ';domain=' + domain;
       }
@@ -171,7 +171,7 @@ window.FacebookSignal = window.FacebookSignal || {
 
     if (fbpValue) {
       var fbpCookie =
-        '_fbp=' + fbpValue + ';path=/;max-age=7776000;SameSite=Lax';
+        '_fbp=' + encodeURIComponent(fbpValue) + ';path=/;max-age=7776000;SameSite=Lax';
       if (attr.fbpDomain) {
         fbpCookie += ';domain=' + attr.fbpDomain;
       }
@@ -180,7 +180,7 @@ window.FacebookSignal = window.FacebookSignal || {
 
     if (fbcValue) {
       var fbcCookie =
-        '_fbc=' + fbcValue + ';path=/;max-age=7776000;SameSite=Lax';
+        '_fbc=' + encodeURIComponent(fbcValue) + ';path=/;max-age=7776000;SameSite=Lax';
       if (attr.fbcDomain) {
         fbcCookie += ';domain=' + attr.fbcDomain;
       }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,9 +6,9 @@
     <rule ref="WordPress">
         <!-- Exclude conflicting indentation rules from WordPress -->
         <exclude name="Generic.WhiteSpace.ScopeIndent" />
-        <exclude name="Generic.WhiteSpace.DisallowTabIndent" />
         <exclude name="Universal.WhiteSpace.PrecisionAlignment" />
         <exclude name="WordPress.Arrays.ArrayIndentation" />
+        <exclude name="Generic.WhiteSpace.DisallowSpaceIndent" />
     </rule>
 
     <!-- Force 4 spaces for indentation -->
@@ -26,11 +26,6 @@
 
     <!-- Ensure no tabs are used for indentation -->
     <rule ref="Generic.WhiteSpace.DisallowTabIndent" />
-
-    <!-- Explicitly allow spaces for indentation -->
-    <rule ref="Generic.WhiteSpace.DisallowSpaceIndent">
-        <exclude name="Generic.WhiteSpace.DisallowSpaceIndent.SpacesUsed" />
-    </rule>
 
     <!-- Enforce a max line length of 80 characters -->
     <rule ref="Generic.Files.LineLength">

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -59,6 +59,7 @@
 
     <!-- Exclude specific directories -->
     <exclude-pattern>vendor/*</exclude-pattern>
+    <exclude-pattern>build/*</exclude-pattern>
     <exclude-pattern>node_modules/*</exclude-pattern>
     <exclude-pattern>task/*</exclude-pattern>
     <exclude-pattern>__tests__/*</exclude-pattern>

--- a/task/class-facebookwordpressaddversionnumbertask.php
+++ b/task/class-facebookwordpressaddversionnumbertask.php
@@ -52,10 +52,12 @@ class FacebookWordpressAddVersionNumberTask extends BaseTask {
      */
     public function main() {
         $this->setABSPATH();
-        $version = FacebookPluginConfig::PLUGIN_VERSION;
+        $version   = FacebookPluginConfig::PLUGIN_VERSION;
+        $base_dir  = $this->getProject()->getBasedir();
+        $full_path = $base_dir . DIRECTORY_SEPARATOR . $this->path;
         echo 'The current version is ' . $version . " \n";
-        $file_contents = file_get_contents( $this->path );
+        $file_contents = file_get_contents( $full_path );
         $file_contents = str_replace( '{*VERSION_NUMBER*}', $version, $file_contents );
-        file_put_contents( $this->path, $file_contents );
+        file_put_contents( $full_path, $file_contents );
     }
 }


### PR DESCRIPTION
## Description

Integrate the CAPI Parameter Builder SDK (`facebook/capi-param-builder-php`) into the Meta Pixel for WordPress plugin to improve `_fbc` and `_fbp` cookie coverage for Conversions API events.

This mirrors the ParamBuilder integration already shipped in the Facebook for WooCommerce plugin ([#3549](https://github.com/facebook/facebook-for-woocommerce/pull/3549), [#3617](https://github.com/facebook/facebook-for-woocommerce/pull/3617), [#3895](https://github.com/facebook/facebook-for-woocommerce/pull/3895)), which boosted FBC and FBP coverage.

### Changes

1. **`composer.json`** — Added `facebook/capi-param-builder-php: ^1.2.1` dependency; added `exclude-from-classmap` for `build/`
2. **`core/class-facebookparambuilder.php`** (new) — Singleton wrapper for ParamBuilder SDK:
   - `server_setup()`: Initializes ParamBuilder with site URL, processes request, sets cookies via `setcookie()` with `SameSite=Lax` and `is_ssl()`. When signals are held, stores attribution data (fbc, fbp, cookie domains) via `FacebookSignalState::set_attribution_data()` instead of setting cookies
   - `get_fbc()` / `get_fbp()`: Safe wrappers with per-request value caching to ensure consistent values across multiple calls. Catches `\Throwable` with daily-throttled logging via `FacebookPluginUtils::log_once_daily()`
3. **`core/class-servereventfactory.php`** — ParamBuilder is now the **primary** source for `get_fbc()` and `get_fbp()`, with cookies/fbclid/session as fallbacks. Added `sanitize_fbclid()` to decode and validate fbclid against base64url allowlist before use. Session writes guarded by `is_held()` check
4. **`core/class-facebookwordpresspixelinjection.php`** — Init config passes `attribution` data (fbp, fbc, domains) from `FacebookSignalState` when signals are held, omits it when active
5. **`core/class-facebookpluginutils.php`** — Added `log_once_daily()` for transient-throttled error logging
6. **`js/facebook_signal.js`** — Added `_syncCookie()` method and attribution-aware cookie setting in `_handleReleaseResponse()` with `encodeURIComponent` and domain support
7. **`facebook-for-wordpress.php`** — Call `FacebookParamBuilder::server_setup()` early in constructor
8. **`build.xml`** — Fixed version task path resolution; create `build/` directory before copy
9. **`phpcs.xml`** — Added `build/*` exclusion; fixed `DisallowTabIndent` rule (was silently inactive due to conflict with `DisallowSpaceIndent`)
10. **`task/class-facebookwordpressaddversionnumbertask.php`** — Use project basedir for absolute path resolution
11. **`__tests__/`** — Added `FacebookParamBuilderTest` (11 tests), `FacebookSignalStateTest` (6 tests), 7 new tests in `ServerEventFactoryTest`; defined missing WP time constants in bootstrap; fixed pre-existing test failures

### How it works

ParamBuilder operates **server-side only** (no client-side JS):

- On each request, `processRequest()` extracts `_fbc`/`_fbp` from URL params, cookies, and referrer
- When signals are **active**: `getCookiesToSet()` returns cookies set via PHP `setcookie()`
- When signals are **held**: fbc/fbp values and cookie domains are stored via `FacebookSignalState::set_attribution_data()` and passed to the JS init config. On release, the JS sets cookies with proper domains before calling `fbq('consent', 'grant')`

Resolution order for `_fbc`: ParamBuilder → cookie (if fbclid unchanged) → fbclid construction → session.
Resolution order for `_fbp`: ParamBuilder → cookie.

### Type of change

- Add (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas, if any.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I have added tests and all the new and existing unit tests pass locally with my changes.

## Test Plan

1. Install the plugin on a WordPress site with the Meta Pixel configured
2. Open any page in **incognito mode** (new visitor, no fbclick):
   - Verify `_fbp` cookie is set (should have `AQ` suffix from ParamBuilder)
   - Check Events Manager → CAPI events include `fbp` parameter
3. Open any page in **incognito mode with `?fbclid=test123`**:
   - Verify `_fbc` cookie is set with validated fbclid
   - Check Events Manager → CAPI events include `fbc` parameter
4. **Signal hold/release flow**:
   - Hold signals → verify no `_fbp`/`_fbc` cookies are set
   - Release signals → verify cookies are set with correct domains before `fbq('consent', 'grant')`
   - Verify CAPI events replayed on release contain correct attribution
5. Visit **admin pages** — verify no errors or JS issues
6. Check that existing pixel events (PageView, ViewContent, AddToCart, Purchase) still fire correctly with deduplication
7. Run `vendor/bin/phing` — verify clean build with no PHP errors

Task: T253774482