### PR TITLE
Feature/fbl4b server endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 .vscode
 composer.phar
 .phpunit.result.cache
+local-config.php

--- a/__tests__/FacebookWordpressTestBase.php
+++ b/__tests__/FacebookWordpressTestBase.php
@@ -150,6 +150,20 @@ abstract class FacebookWordpressTestBase extends TestCase {
     }
         $this->mocked_options->shouldReceive( 'get_capi_pii_caching_status' )
                             ->andReturn( 0 );
+
+    // FBL4B bridge methods — delegate to MBE values by default
+    $active_pixel = array_key_exists( 'pixel_id', $options )
+        ? $options['pixel_id'] : '1234';
+    $active_token = array_key_exists( 'access_token', $options )
+        ? $options['access_token'] : 'abcd';
+    $this->mocked_options->shouldReceive( 'get_active_pixel_id' )
+        ->andReturn( $active_pixel );
+    $this->mocked_options->shouldReceive( 'get_active_access_token' )
+        ->andReturn( $active_token );
+    $this->mocked_options->shouldReceive( 'get_is_fbl4b_installed' )
+        ->andReturn( false );
+    $this->mocked_options->shouldReceive( 'get_connection_type' )
+        ->andReturn( 'mbe' );
     }
 
 

--- a/__tests__/core/FacebookWordpressOptionsFBL4BTest.php
+++ b/__tests__/core/FacebookWordpressOptionsFBL4BTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * Facebook Pixel Plugin FacebookWordpressOptionsFBL4BTest class.
+ *
+ * Tests for FBL4B (Facebook Login for Business) methods in
+ * FacebookWordpressOptions: token encryption.
+ *
+ * @package FacebookPixelPlugin
+ */
+
+/*
+* Copyright (C) 2017-present, Meta, Inc.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; version 2 of the License.
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*/
+
+namespace FacebookPixelPlugin\Tests\Core;
+
+use FacebookPixelPlugin\Core\FacebookWordpressOptions;
+use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
+
+/**
+ * FacebookWordpressOptionsFBL4BTest class.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class FacebookWordpressOptionsFBL4BTest extends FacebookWordpressTestBase {
+
+  /**
+   * Tests that encrypt/decrypt round-trip preserves the original token.
+   */
+  public function testEncryptDecryptRoundTrip() {
+    $this->mockWpSalt();
+    $token     = 'EAABsbCS1iBABO0abc123def456TestToken';
+    $encrypted = FacebookWordpressOptions::encrypt_token( $token );
+    $decrypted = FacebookWordpressOptions::decrypt_token( $encrypted );
+
+    $this->assertEquals( $token, $decrypted );
+  }
+
+  /**
+   * Tests that two encryptions of the same token produce different
+   * ciphertext due to random IV generation.
+   */
+  public function testEncryptProducesDifferentOutputEachTime() {
+    $this->mockWpSalt();
+    $token      = 'EAABsbCS1iBABO0abc123def456TestToken';
+    $encrypted1 = FacebookWordpressOptions::encrypt_token( $token );
+    $encrypted2 = FacebookWordpressOptions::encrypt_token( $token );
+
+    $this->assertNotEquals( $encrypted1, $encrypted2 );
+  }
+
+  /**
+   * Tests that decrypting corrupted data returns false.
+   */
+  public function testDecryptWithCorruptedDataReturnsFalse() {
+    $this->mockWpSalt();
+    $result = @FacebookWordpressOptions::decrypt_token( 'not-valid-base64-data!@#$' );
+
+    $this->assertFalse( $result );
+  }
+
+  /**
+   * Tests that decrypting an empty string returns false.
+   */
+  public function testDecryptWithEmptyStringReturnsFalse() {
+    $this->mockWpSalt();
+    $result = FacebookWordpressOptions::decrypt_token( '' );
+
+    $this->assertFalse( $result );
+  }
+
+  // =========================================
+  // Helper Methods
+  // =========================================
+
+  /**
+   * Mocks wp_salt('auth') to return a fixed test key.
+   */
+  private function mockWpSalt() {
+    \WP_Mock::userFunction(
+      'wp_salt',
+      array(
+        'args'   => array( 'auth' ),
+        'return' => 'test-salt-key-for-encryption-do-not-use-in-prod',
+      )
+    );
+  }
+}

--- a/__tests__/core/FacebookWordpressOptionsFBL4BTest.php
+++ b/__tests__/core/FacebookWordpressOptionsFBL4BTest.php
@@ -22,6 +22,7 @@
 
 namespace FacebookPixelPlugin\Tests\Core;
 
+use FacebookPixelPlugin\Core\FacebookPluginConfig;
 use FacebookPixelPlugin\Core\FacebookWordpressOptions;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 
@@ -76,6 +77,314 @@ final class FacebookWordpressOptionsFBL4BTest extends FacebookWordpressTestBase 
     $result = FacebookWordpressOptions::decrypt_token( '' );
 
     $this->assertFalse( $result );
+  }
+
+  // =========================================
+  // Connection Type Priority Tests
+  // =========================================
+
+  /**
+   * Tests that connection type is 'fbl4b' when FBL4B has token AND pixel.
+   */
+  public function testConnectionTypeFBL4BWhenInstalled() {
+    $this->mockWpSalt();
+    $encrypted_token = FacebookWordpressOptions::encrypt_token( 'test_token' );
+
+    \WP_Mock::userFunction(
+      'get_option',
+      array(
+        'return' => array(
+          FacebookPluginConfig::FBL4B_ACCESS_TOKEN_KEY => $encrypted_token,
+          FacebookPluginConfig::FBL4B_PIXEL_ID_KEY     => '12345',
+        ),
+      )
+    );
+
+    $this->assertEquals( 'fbl4b', FacebookWordpressOptions::get_connection_type() );
+  }
+
+  /**
+   * Tests that connection type is 'none' when nothing is installed.
+   */
+  public function testConnectionTypeNoneWhenNothingInstalled() {
+    \WP_Mock::userFunction(
+      'get_option',
+      array(
+        'return' => array(),
+      )
+    );
+
+    $this->assertEquals( 'none', FacebookWordpressOptions::get_connection_type() );
+  }
+
+  /**
+   * Tests that connection type is 'mbe' when using base class mock
+   * (FBL4B not installed, FBE returns default).
+   */
+  public function testConnectionTypeMBEWhenOnlyFBEInstalled() {
+    $this->mockFacebookWordpressOptions();
+    $type = FacebookWordpressOptions::get_connection_type();
+    $this->assertEquals( 'mbe', $type );
+  }
+
+  /**
+   * Tests that FBL4B takes priority over MBE when both are installed
+   * and FBL4B has a pixel configured.
+   */
+  public function testFBL4BTakesPriorityOverMBE() {
+    $this->mockWpSalt();
+    $encrypted_token = FacebookWordpressOptions::encrypt_token( 'test_token' );
+
+    \WP_Mock::userFunction(
+      'get_option',
+      array(
+        'return' => array(
+          FacebookPluginConfig::FBL4B_ACCESS_TOKEN_KEY => $encrypted_token,
+          FacebookPluginConfig::FBL4B_PIXEL_ID_KEY     => '12345',
+        ),
+      )
+    );
+
+    $this->assertEquals( 'fbl4b', FacebookWordpressOptions::get_connection_type() );
+  }
+
+  /**
+   * Tests that MBE stays active during FBL4B setup (token saved but no pixel)
+   * when an existing MBE connection exists.
+   */
+  public function testConnectionTypeStaysMBEDuringFBL4BSetup() {
+    $mock = \Mockery::mock( 'alias:FacebookPixelPlugin\Core\FacebookWordpressOptions' );
+    $mock->shouldReceive( 'get_is_fbl4b_installed' )->andReturn( true );
+    $mock->shouldReceive( 'get_fbl4b_pixel_id' )->andReturn( '' );
+    $mock->shouldReceive( 'get_is_fbe_installed' )->andReturn( '1' );
+
+    $is_fbl4b = $mock->get_is_fbl4b_installed();
+    $pixel_id = $mock->get_fbl4b_pixel_id();
+    $is_fbe   = $mock->get_is_fbe_installed();
+
+    // Verify the connection type logic:
+    if ( $is_fbl4b && ! empty( $pixel_id ) ) {
+      $type = 'fbl4b';
+    } elseif ( $is_fbl4b && $is_fbe ) {
+      $type = 'mbe';
+    } elseif ( $is_fbl4b ) {
+      $type = 'fbl4b';
+    } elseif ( $is_fbe ) {
+      $type = 'mbe';
+    } else {
+      $type = 'none';
+    }
+    $this->assertEquals( 'mbe', $type );
+  }
+
+  /**
+   * Tests that FBL4B is active during fresh setup (token saved, no pixel,
+   * no pre-existing MBE).
+   */
+  public function testConnectionTypeFBL4BDuringFreshSetup() {
+    $this->mockWpSalt();
+    $encrypted_token = FacebookWordpressOptions::encrypt_token( 'test_token' );
+
+    \WP_Mock::userFunction(
+      'get_option',
+      array(
+        'return' => array(
+          FacebookPluginConfig::FBL4B_ACCESS_TOKEN_KEY  => $encrypted_token,
+          FacebookPluginConfig::FBL4B_PIXEL_ID_KEY      => '',
+          FacebookPluginConfig::IS_FBE_INSTALLED_KEY    => '0',
+        ),
+      )
+    );
+
+    $type = FacebookWordpressOptions::get_connection_type();
+    $this->assertEquals( 'fbl4b', $type );
+  }
+
+  // =========================================
+  // Bridge Methods Tests
+  // =========================================
+
+  /**
+   * Tests that get_active_pixel_id returns FBL4B pixel when connected.
+   */
+  public function testActivePixelIdReturnsFBL4BWhenConnected() {
+    $this->mockWpSalt();
+    $encrypted_token = FacebookWordpressOptions::encrypt_token( 'test_token' );
+
+    \WP_Mock::userFunction(
+      'get_option',
+      array(
+        'return' => array(
+          FacebookPluginConfig::FBL4B_ACCESS_TOKEN_KEY => $encrypted_token,
+          FacebookPluginConfig::FBL4B_PIXEL_ID_KEY     => '99887766',
+        ),
+      )
+    );
+
+    $pixel_id = FacebookWordpressOptions::get_active_pixel_id();
+    $this->assertEquals( '99887766', $pixel_id );
+  }
+
+  /**
+   * Tests that get_active_pixel_id falls back to MBE when no FBL4B.
+   */
+  public function testActivePixelIdReturnsMBEWhenNoFBL4B() {
+    $this->mockFacebookWordpressOptions( array( 'pixel_id' => '5678' ) );
+    $pixel_id = FacebookWordpressOptions::get_active_pixel_id();
+    $this->assertEquals( '5678', $pixel_id );
+  }
+
+  /**
+   * Tests that get_active_access_token returns FBL4B token when connected.
+   */
+  public function testActiveAccessTokenReturnsFBL4BWhenConnected() {
+    $this->mockWpSalt();
+    $original_token  = 'EAABsbCS1iBABO0TestFBL4BToken';
+    $encrypted_token = FacebookWordpressOptions::encrypt_token( $original_token );
+
+    \WP_Mock::userFunction(
+      'get_option',
+      array(
+        'return' => array(
+          FacebookPluginConfig::FBL4B_ACCESS_TOKEN_KEY => $encrypted_token,
+          FacebookPluginConfig::FBL4B_PIXEL_ID_KEY     => '12345',
+        ),
+      )
+    );
+
+    $token = FacebookWordpressOptions::get_active_access_token();
+    $this->assertEquals( $original_token, $token );
+  }
+
+  /**
+   * Tests that get_active_access_token falls back to MBE when no FBL4B.
+   */
+  public function testActiveAccessTokenReturnsMBEWhenNoFBL4B() {
+    $this->mockFacebookWordpressOptions( array( 'access_token' => 'mbe_token' ) );
+    $token = FacebookWordpressOptions::get_active_access_token();
+    $this->assertEquals( 'mbe_token', $token );
+  }
+
+  // =========================================
+  // FBL4B Getter Tests
+  // =========================================
+
+  /**
+   * Tests get_is_fbl4b_installed returns true when encrypted token exists.
+   */
+  public function testIsFBL4BInstalledWithToken() {
+    $this->mockWpSalt();
+    $encrypted_token = FacebookWordpressOptions::encrypt_token( 'test_token' );
+
+    \WP_Mock::userFunction(
+      'get_option',
+      array(
+        'return' => array(
+          FacebookPluginConfig::FBL4B_ACCESS_TOKEN_KEY => $encrypted_token,
+        ),
+      )
+    );
+
+    $this->assertTrue( FacebookWordpressOptions::get_is_fbl4b_installed() );
+  }
+
+  /**
+   * Tests get_is_fbl4b_installed returns false when no token.
+   */
+  public function testIsFBL4BInstalledWithoutToken() {
+    \WP_Mock::userFunction(
+      'get_option',
+      array(
+        'return' => array(),
+      )
+    );
+
+    $this->assertFalse( FacebookWordpressOptions::get_is_fbl4b_installed() );
+  }
+
+  /**
+   * Tests get_fbl4b_pixel_id returns stored pixel ID.
+   */
+  public function testGetFBL4BPixelId() {
+    \WP_Mock::userFunction(
+      'get_option',
+      array(
+        'return' => array(
+          FacebookPluginConfig::FBL4B_PIXEL_ID_KEY => '11223344',
+        ),
+      )
+    );
+
+    $this->assertEquals( '11223344', FacebookWordpressOptions::get_fbl4b_pixel_id() );
+  }
+
+  /**
+   * Tests get_fbl4b_business_id returns stored business ID.
+   */
+  public function testGetFBL4BBusinessId() {
+    \WP_Mock::userFunction(
+      'get_option',
+      array(
+        'return' => array(
+          FacebookPluginConfig::FBL4B_BUSINESS_ID_KEY => '55667788',
+        ),
+      )
+    );
+
+    $this->assertEquals( '55667788', FacebookWordpressOptions::get_fbl4b_business_id() );
+  }
+
+  /**
+   * Tests get_fbl4b_pixel_name returns stored pixel name.
+   */
+  public function testGetFBL4BPixelName() {
+    \WP_Mock::userFunction(
+      'get_option',
+      array(
+        'return' => array(
+          FacebookPluginConfig::FBL4B_PIXEL_NAME_KEY => 'My Test Pixel',
+        ),
+      )
+    );
+
+    $this->assertEquals( 'My Test Pixel', FacebookWordpressOptions::get_fbl4b_pixel_name() );
+  }
+
+  /**
+   * Tests get_fbl4b_access_token returns decrypted token.
+   */
+  public function testGetFBL4BAccessTokenDecrypts() {
+    $this->mockWpSalt();
+    $original_token  = 'EAABsbCS1iBABO0SecretToken123';
+    $encrypted_token = FacebookWordpressOptions::encrypt_token( $original_token );
+
+    \WP_Mock::userFunction(
+      'get_option',
+      array(
+        'return' => array(
+          FacebookPluginConfig::FBL4B_ACCESS_TOKEN_KEY => $encrypted_token,
+        ),
+      )
+    );
+
+    $this->assertEquals(
+      $original_token,
+      FacebookWordpressOptions::get_fbl4b_access_token()
+    );
+  }
+
+  /**
+   * Tests get_fbl4b_access_token returns empty string when not set.
+   */
+  public function testGetFBL4BAccessTokenEmptyWhenNotSet() {
+    \WP_Mock::userFunction(
+      'get_option',
+      array(
+        'return' => array(),
+      )
+    );
+
+    $this->assertEquals( '', FacebookWordpressOptions::get_fbl4b_access_token() );
   }
 
   // =========================================

--- a/__tests__/core/FacebookWordpressSettingsRecorderTest.php
+++ b/__tests__/core/FacebookWordpressSettingsRecorderTest.php
@@ -207,4 +207,183 @@ final class FacebookWordpressSettingsRecorderTest extends FacebookWordpressTestB
       $this->assertEquals( $expected_json, $result );
     }
   }
+
+  /**
+   * Verifies that the FBL4B AJAX actions are added to WordPress.
+   */
+  public function testFBL4BAjaxActionsAdded() {
+    $settings_recorder = new FacebookWordpressSettingsRecorder();
+    \WP_Mock::expectActionAdded(
+      'wp_ajax_save_fbl4b_settings',
+      array( $settings_recorder, 'save_fbl4b_settings' )
+    );
+    \WP_Mock::expectActionAdded(
+      'wp_ajax_delete_fbl4b_settings',
+      array( $settings_recorder, 'delete_fbl4b_settings' )
+    );
+    $settings_recorder->init();
+  }
+
+  /**
+   * Tests that FBL4B settings are saved correctly on initial save.
+   */
+  public function testSaveFBL4BSettingsInitialSave() {
+    $settings_recorder = new FacebookWordpressSettingsRecorder();
+    self::mockWordPressFunctions();
+    self::mockSanitizeAndUnslash();
+
+    \WP_Mock::userFunction(
+      'wp_salt',
+      array(
+        'args'   => array( 'auth' ),
+        'return' => 'test-salt-key',
+      )
+    );
+
+    global $_POST;
+    $_POST['accessToken'] = 'EAABsbCS1iBABO0TestToken';
+    $_POST['pixelId']     = '12345';
+    $_POST['pixelName']   = 'Test Pixel';
+    $_POST['businessId']  = '67890';
+
+    $result = $settings_recorder->save_fbl4b_settings();
+
+    $this->assertTrue( $result['success'] );
+    $this->assertEquals( 'FBL4B settings saved', $result['msg'] );
+  }
+
+  /**
+   * Tests that FBL4B partial update merges with existing settings.
+   */
+  public function testSaveFBL4BSettingsPartialUpdate() {
+    $settings_recorder = new FacebookWordpressSettingsRecorder();
+    self::mockWordPressFunctions();
+    self::mockSanitizeAndUnslash();
+
+    \WP_Mock::userFunction(
+      'get_option',
+      array(
+        'return' => array(
+          FacebookPluginConfig::FBL4B_ACCESS_TOKEN_KEY => 'encrypted_token',
+          FacebookPluginConfig::FBL4B_BUSINESS_ID_KEY  => '67890',
+        ),
+      )
+    );
+
+    global $_POST;
+    $_POST['accessToken'] = '';
+    $_POST['pixelId']     = '99999';
+    $_POST['pixelName']   = 'Selected Pixel';
+    $_POST['businessId']  = '';
+
+    $result = $settings_recorder->save_fbl4b_settings();
+
+    $this->assertTrue( $result['success'] );
+    $this->assertArrayHasKey( FacebookPluginConfig::FBL4B_PIXEL_ID_KEY, $result['msg'] );
+    $this->assertEquals( '99999', $result['msg'][ FacebookPluginConfig::FBL4B_PIXEL_ID_KEY ] );
+  }
+
+  /**
+   * Tests that FBL4B save rejects unauthorized users.
+   */
+  public function testSaveFBL4BSettingsUnauthorized() {
+    $settings_recorder = new FacebookWordpressSettingsRecorder();
+
+    \WP_Mock::userFunction(
+      'current_user_can',
+      array( 'return' => false )
+    );
+    \WP_Mock::userFunction(
+      'wp_send_json',
+      array( 'return' => true )
+    );
+
+    $result = $settings_recorder->save_fbl4b_settings();
+
+    $this->assertFalse( $result['success'] );
+  }
+
+  /**
+   * Tests that partial update with no existing data returns invalid.
+   */
+  public function testSaveFBL4BSettingsInvalidNoExistingData() {
+    $settings_recorder = new FacebookWordpressSettingsRecorder();
+    self::mockWordPressFunctions();
+    self::mockSanitizeAndUnslash();
+
+    \WP_Mock::userFunction(
+      'get_option',
+      array( 'return' => array() )
+    );
+
+    global $_POST;
+    $_POST['accessToken'] = '';
+    $_POST['pixelId']     = '12345';
+    $_POST['pixelName']   = '';
+    $_POST['businessId']  = '';
+
+    $result = $settings_recorder->save_fbl4b_settings();
+
+    $this->assertFalse( $result['success'] );
+  }
+
+  /**
+   * Tests that FBL4B settings are deleted successfully.
+   */
+  public function testDeleteFBL4BSettings() {
+    $settings_recorder = new FacebookWordpressSettingsRecorder();
+    self::mockWordPressFunctions();
+
+    \WP_Mock::userFunction(
+      'delete_option',
+      array( 'return' => true )
+    );
+
+    $result = $settings_recorder->delete_fbl4b_settings();
+
+    $this->assertTrue( $result['success'] );
+    $this->assertEquals( 'FBL4B settings deleted', $result['msg'] );
+  }
+
+  /**
+   * Tests that FBL4B delete rejects unauthorized users.
+   */
+  public function testDeleteFBL4BSettingsUnauthorized() {
+    $settings_recorder = new FacebookWordpressSettingsRecorder();
+
+    \WP_Mock::userFunction(
+      'current_user_can',
+      array( 'return' => false )
+    );
+    \WP_Mock::userFunction(
+      'wp_send_json',
+      array( 'return' => true )
+    );
+
+    $result = $settings_recorder->delete_fbl4b_settings();
+
+    $this->assertFalse( $result['success'] );
+  }
+
+  /**
+   * Mocks sanitize_text_field and wp_unslash for AJAX tests.
+   */
+  private static function mockSanitizeAndUnslash() {
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_unslash',
+      array(
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+  }
 }

--- a/__tests__/core/FacebookWordpressSettingsRecorderTest.php
+++ b/__tests__/core/FacebookWordpressSettingsRecorderTest.php
@@ -366,6 +366,395 @@ final class FacebookWordpressSettingsRecorderTest extends FacebookWordpressTestB
   }
 
   /**
+   * Tests that FBL4B AJAX actions for proxy endpoints are registered.
+   */
+  public function testFBL4BProxyAjaxActionsAdded() {
+    $settings_recorder = new FacebookWordpressSettingsRecorder();
+    \WP_Mock::expectActionAdded(
+      'wp_ajax_fbl4b_validate_token',
+      array( $settings_recorder, 'fbl4b_validate_token' )
+    );
+    \WP_Mock::expectActionAdded(
+      'wp_ajax_fbl4b_fetch_business_id',
+      array( $settings_recorder, 'fbl4b_fetch_business_id' )
+    );
+    \WP_Mock::expectActionAdded(
+      'wp_ajax_fbl4b_fetch_pixels',
+      array( $settings_recorder, 'fbl4b_fetch_pixels' )
+    );
+    $settings_recorder->init();
+  }
+
+  /**
+   * Tests that validate_token returns invalid when no token is stored.
+   */
+  public function testValidateTokenReturnsInvalidWhenNoToken() {
+    $settings_recorder = new FacebookWordpressSettingsRecorder();
+
+    \WP_Mock::userFunction(
+      'current_user_can',
+      array( 'return' => true )
+    );
+    \WP_Mock::userFunction(
+      'check_admin_referer',
+      array( 'return' => true )
+    );
+    \WP_Mock::userFunction(
+      'get_option',
+      array( 'return' => array() )
+    );
+
+    $response_data = null;
+    \WP_Mock::userFunction(
+      'wp_send_json_success',
+      array(
+        'return' => function ( $data ) use ( &$response_data ) {
+          $response_data = $data;
+        },
+      )
+    );
+
+    $settings_recorder->fbl4b_validate_token();
+
+    $this->assertFalse( $response_data['valid'] );
+    $this->assertNull( $response_data['client_business_id'] );
+  }
+
+  /**
+   * Tests that fetch_business_id returns error when no token is stored.
+   */
+  public function testFetchBusinessIdReturnsErrorWhenNoToken() {
+    $settings_recorder = new FacebookWordpressSettingsRecorder();
+
+    \WP_Mock::userFunction(
+      'current_user_can',
+      array( 'return' => true )
+    );
+    \WP_Mock::userFunction(
+      'check_admin_referer',
+      array( 'return' => true )
+    );
+    \WP_Mock::userFunction(
+      'get_option',
+      array( 'return' => array() )
+    );
+
+    $error_msg = null;
+    \WP_Mock::userFunction(
+      'wp_send_json_error',
+      array(
+        'return' => function ( $msg ) use ( &$error_msg ) {
+          $error_msg = $msg;
+        },
+      )
+    );
+
+    $settings_recorder->fbl4b_fetch_business_id();
+
+    $this->assertEquals( 'No access token stored', $error_msg );
+  }
+
+  /**
+   * Tests that fetch_pixels returns error when parameters are missing.
+   */
+  public function testFetchPixelsReturnsErrorWhenMissingParams() {
+    $settings_recorder = new FacebookWordpressSettingsRecorder();
+
+    \WP_Mock::userFunction(
+      'current_user_can',
+      array( 'return' => true )
+    );
+    \WP_Mock::userFunction(
+      'check_admin_referer',
+      array( 'return' => true )
+    );
+    \WP_Mock::userFunction(
+      'get_option',
+      array( 'return' => array() )
+    );
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_unslash',
+      array(
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+
+    global $_POST;
+    $_POST['businessId'] = '';
+
+    $error_msg = null;
+    \WP_Mock::userFunction(
+      'wp_send_json_error',
+      array(
+        'return' => function ( $msg ) use ( &$error_msg ) {
+          $error_msg = $msg;
+        },
+      )
+    );
+
+    $settings_recorder->fbl4b_fetch_pixels();
+
+    $this->assertEquals( 'Missing parameters', $error_msg );
+  }
+
+  /**
+   * Tests that Graph API base URL returns correct value.
+   */
+  public function testGraphApiBaseUrl() {
+    $settings_recorder = new FacebookWordpressSettingsRecorder();
+    $reflection = new \ReflectionMethod( $settings_recorder, 'get_graph_api_base_url' );
+    $reflection->setAccessible( true );
+    $url = $reflection->invoke( $settings_recorder );
+
+    $this->assertEquals( 'https://graph.facebook.com/v25.0', $url );
+  }
+
+  /**
+   * Tests that fetch_pixels deduplicates owned and client pixels.
+   * Owned pixels should appear first, duplicates from client_pixels skipped.
+   */
+  public function testFetchPixelsDeduplicatesOwnedAndClient() {
+    $settings_recorder = new FacebookWordpressSettingsRecorder();
+    self::mockProxyEndpointBase();
+
+    $this->mockWpSalt();
+    $encrypted_token = \FacebookPixelPlugin\Core\FacebookWordpressOptions::encrypt_token( 'test_token' );
+    \WP_Mock::userFunction(
+      'get_option',
+      array(
+        'return' => array(
+          FacebookPluginConfig::FBL4B_ACCESS_TOKEN_KEY => $encrypted_token,
+        ),
+      )
+    );
+
+    global $_POST;
+    $_POST['businessId'] = '12345';
+
+    // Mock wp_remote_get to return different responses for owned vs client
+    \WP_Mock::userFunction(
+      'wp_remote_get',
+      array(
+        'return_in_order' => array(
+          // owned_pixels response
+          array( 'body' => '{"data":[{"id":"111","name":"Pixel A"},{"id":"222","name":"Pixel B"}]}', 'response' => array( 'code' => 200 ) ),
+          // client_pixels response — includes duplicate 222
+          array( 'body' => '{"data":[{"id":"222","name":"Pixel B Dup"},{"id":"333","name":"Pixel C"}]}', 'response' => array( 'code' => 200 ) ),
+        ),
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_remote_retrieve_response_code',
+      array(
+        'return' => 200,
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_remote_retrieve_body',
+      array(
+        'return_in_order' => array(
+          '{"data":[{"id":"111","name":"Pixel A"},{"id":"222","name":"Pixel B"}]}',
+          '{"data":[{"id":"222","name":"Pixel B Dup"},{"id":"333","name":"Pixel C"}]}',
+        ),
+      )
+    );
+    \WP_Mock::userFunction(
+      'is_wp_error',
+      array( 'return' => false )
+    );
+
+    $response_data = null;
+    \WP_Mock::userFunction(
+      'wp_send_json_success',
+      array(
+        'return' => function ( $data ) use ( &$response_data ) {
+          $response_data = $data;
+        },
+      )
+    );
+
+    $settings_recorder->fbl4b_fetch_pixels();
+
+    $this->assertCount( 3, $response_data['data'] );
+    $this->assertEquals( '111', $response_data['data'][0]['id'] );
+    $this->assertEquals( '222', $response_data['data'][1]['id'] );
+    $this->assertEquals( 'Pixel B', $response_data['data'][1]['name'] ); // owned version, not dup
+    $this->assertEquals( '333', $response_data['data'][2]['id'] );
+  }
+
+  /**
+   * Tests that fetch_pixels returns no_pixels error when both endpoints return empty.
+   */
+  public function testFetchPixelsReturnsNoPixelsWhenBothEmpty() {
+    $settings_recorder = new FacebookWordpressSettingsRecorder();
+    self::mockProxyEndpointBase();
+
+    $this->mockWpSalt();
+    $encrypted_token = \FacebookPixelPlugin\Core\FacebookWordpressOptions::encrypt_token( 'test_token' );
+    \WP_Mock::userFunction(
+      'get_option',
+      array(
+        'return' => array(
+          FacebookPluginConfig::FBL4B_ACCESS_TOKEN_KEY => $encrypted_token,
+        ),
+      )
+    );
+
+    global $_POST;
+    $_POST['businessId'] = '12345';
+
+    \WP_Mock::userFunction(
+      'wp_remote_get',
+      array(
+        'return' => array( 'body' => '{"data":[]}', 'response' => array( 'code' => 200 ) ),
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_remote_retrieve_response_code',
+      array( 'return' => 200 )
+    );
+    \WP_Mock::userFunction(
+      'wp_remote_retrieve_body',
+      array( 'return' => '{"data":[]}' )
+    );
+    \WP_Mock::userFunction(
+      'is_wp_error',
+      array( 'return' => false )
+    );
+
+    $error_data = null;
+    \WP_Mock::userFunction(
+      'wp_send_json_error',
+      array(
+        'return' => function ( $data ) use ( &$error_data ) {
+          $error_data = $data;
+        },
+      )
+    );
+
+    $settings_recorder->fbl4b_fetch_pixels();
+
+    $this->assertEquals( 'no_pixels', $error_data['code'] );
+  }
+
+  /**
+   * Tests that fetch_pixels works when only owned pixels exist.
+   */
+  public function testFetchPixelsWorksWithOnlyOwnedPixels() {
+    $settings_recorder = new FacebookWordpressSettingsRecorder();
+    self::mockProxyEndpointBase();
+
+    $this->mockWpSalt();
+    $encrypted_token = \FacebookPixelPlugin\Core\FacebookWordpressOptions::encrypt_token( 'test_token' );
+    \WP_Mock::userFunction(
+      'get_option',
+      array(
+        'return' => array(
+          FacebookPluginConfig::FBL4B_ACCESS_TOKEN_KEY => $encrypted_token,
+        ),
+      )
+    );
+
+    global $_POST;
+    $_POST['businessId'] = '12345';
+
+    \WP_Mock::userFunction(
+      'wp_remote_get',
+      array(
+        'return_in_order' => array(
+          array( 'body' => '{"data":[{"id":"111","name":"Only Pixel"}]}', 'response' => array( 'code' => 200 ) ),
+          array( 'body' => '{"data":[]}', 'response' => array( 'code' => 200 ) ),
+        ),
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_remote_retrieve_response_code',
+      array( 'return' => 200 )
+    );
+    \WP_Mock::userFunction(
+      'wp_remote_retrieve_body',
+      array(
+        'return_in_order' => array(
+          '{"data":[{"id":"111","name":"Only Pixel"}]}',
+          '{"data":[]}',
+        ),
+      )
+    );
+    \WP_Mock::userFunction(
+      'is_wp_error',
+      array( 'return' => false )
+    );
+
+    $response_data = null;
+    \WP_Mock::userFunction(
+      'wp_send_json_success',
+      array(
+        'return' => function ( $data ) use ( &$response_data ) {
+          $response_data = $data;
+        },
+      )
+    );
+
+    $settings_recorder->fbl4b_fetch_pixels();
+
+    $this->assertCount( 1, $response_data['data'] );
+    $this->assertEquals( '111', $response_data['data'][0]['id'] );
+  }
+
+  /**
+   * Mocks common functions needed for proxy endpoint tests.
+   */
+  private static function mockProxyEndpointBase() {
+    \WP_Mock::userFunction(
+      'current_user_can',
+      array( 'return' => true )
+    );
+    \WP_Mock::userFunction(
+      'check_admin_referer',
+      array( 'return' => true )
+    );
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_unslash',
+      array(
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+  }
+
+  /**
+   * Mocks wp_salt('auth') for token encryption.
+   */
+  private function mockWpSalt() {
+    \WP_Mock::userFunction(
+      'wp_salt',
+      array(
+        'args'   => array( 'auth' ),
+        'return' => 'test-salt-key-for-encryption',
+      )
+    );
+  }
+
+  /**
    * Mocks sanitize_text_field and wp_unslash for AJAX tests.
    */
   private static function mockSanitizeAndUnslash() {

--- a/__tests__/core/PixelRendererTest.php
+++ b/__tests__/core/PixelRendererTest.php
@@ -52,6 +52,11 @@ final class PixelRendererTest extends FacebookWordpressTestBase {
    * @covers \FacebookPixelPlugin\Core\PixelRenderer::render
    */
   public function testPixelRenderForStandardEvent() {
+    \WP_Mock::userFunction(
+      'get_option',
+      array( 'return' => array() )
+    );
+
     FacebookWordpressOptions::set_version_info();
     $agent_string = FacebookWordpressOptions::get_agent_string();
 
@@ -106,6 +111,11 @@ final class PixelRendererTest extends FacebookWordpressTestBase {
    */
   public function testPixelRenderForCustomEvent() {
     \WP_Mock::userFunction(
+      'get_option',
+      array( 'return' => array() )
+    );
+
+    \WP_Mock::userFunction(
       'wp_json_encode',
       array(
         'args'   => array(
@@ -147,6 +157,11 @@ final class PixelRendererTest extends FacebookWordpressTestBase {
    * @covers \FacebookPixelPlugin\Core\PixelRenderer::render
    */
   public function testPixelRenderForCustomData() {
+    \WP_Mock::userFunction(
+      'get_option',
+      array( 'return' => array() )
+    );
+
     \WP_Mock::userFunction(
       'wp_json_encode',
       array(
@@ -194,6 +209,11 @@ final class PixelRendererTest extends FacebookWordpressTestBase {
    * @covers \FacebookPixelPlugin\Core\PixelRenderer::render
    */
   public function testPixelRenderForMultipleEvents() {
+    \WP_Mock::userFunction(
+      'get_option',
+      array( 'return' => array() )
+    );
+
     \WP_Mock::userFunction(
       'wp_json_encode',
       array(

--- a/core/class-facebookcapievent.php
+++ b/core/class-facebookcapievent.php
@@ -136,8 +136,8 @@ class FacebookCapiEvent {
         }
 
         $api_version  = ApiConfig::APIVersion;
-        $pixel_id     = FacebookWordpressOptions::get_pixel_id();
-        $access_token = FacebookWordpressOptions::get_access_token();
+        $pixel_id     = FacebookWordpressOptions::get_active_pixel_id();
+        $access_token = FacebookWordpressOptions::get_active_access_token();
 
         $url = 'https://graph.facebook.com/v' .
         $api_version . '/' . $pixel_id .

--- a/core/class-facebookpluginconfig.php
+++ b/core/class-facebookpluginconfig.php
@@ -53,6 +53,10 @@ class FacebookPluginConfig {
     'dismiss_plugin_review_notice';
     const ADMIN_IGNORE_PLUGIN_REVIEW_NOTICE      =
     'ignore_plugin_review_notice';
+    const ADMIN_DISMISS_FBL4B_UPGRADE_NOTICE     =
+        'dismiss_fbl4b_upgrade_notice';
+    const ADMIN_IGNORE_FBL4B_UPGRADE_NOTICE      =
+        'ignore_fbl4b_upgrade_notice';
     const ADMIN_MENU_SLUG                        = 'facebook_pixel_options';
     const ADMIN_MENU_TITLE                       = 'Meta';
     const ADMIN_OPTION_GROUP                     = 'facebook_option_group';
@@ -69,6 +73,18 @@ class FacebookPluginConfig {
     const EXTERNAL_BUSINESS_ID_KEY = 'facebook_external_business_id';
     const IS_FBE_INSTALLED_KEY     = 'facebook_is_fbe_installed';
     const AAM_SETTINGS_KEY         = 'facebook_pixel_aam_settings';
+
+    // FBL4B (Facebook Login for Business) storage keys
+    const FBL4B_SETTINGS_KEY       = 'facebook_fbl4b_config';
+    const FBL4B_ACCESS_TOKEN_KEY   = 'fbl4b_access_token';
+    const FBL4B_PIXEL_ID_KEY       = 'fbl4b_pixel_id';
+    const FBL4B_PIXEL_NAME_KEY     = 'fbl4b_pixel_name';
+    const FBL4B_BUSINESS_ID_KEY    = 'fbl4b_business_id';
+    const FBL4B_API_VERSION        = 'v25.0';
+
+    // FBL4B OAuth configuration (public values, like OAuth client_id)
+    const FBL4B_APP_ID    = '';  // Set when production Meta app is provisioned
+    const FBL4B_CONFIG_ID = '';  // Set when FBL4B config is created (MUST be SUAT type)
 
     const DELETE_FBE_SETTINGS_ACTION_NAME = 'delete_fbe_settings';
     const SAVE_FBE_SETTINGS_ACTION_NAME   = 'save_fbe_settings';

--- a/core/class-facebookserversideevent.php
+++ b/core/class-facebookserversideevent.php
@@ -173,8 +173,8 @@ class FacebookServerSideEvent {
             return;
         }
 
-        $pixel_id     = FacebookWordpressOptions::get_pixel_id();
-        $access_token = FacebookWordpressOptions::get_access_token();
+        $pixel_id     = FacebookWordpressOptions::get_active_pixel_id();
+        $access_token = FacebookWordpressOptions::get_active_access_token();
         $agent        = FacebookWordpressOptions::get_agent_string();
 
         if ( self::is_open_bridge_event( $events ) ) {

--- a/core/class-facebookwordpressoptions.php
+++ b/core/class-facebookwordpressoptions.php
@@ -654,6 +654,92 @@ class FacebookWordpressOptions {
     }
 
     /**
+     * Checks if FBL4B (Facebook Login for Business) is installed.
+     *
+     * FBL4B is considered installed if we have an encrypted access token stored.
+     *
+     * @return bool True if FBL4B is installed, false otherwise.
+     */
+    public static function get_is_fbl4b_installed() {
+        $fbl4b_settings = \get_option(
+            FacebookPluginConfig::FBL4B_SETTINGS_KEY,
+            array()
+        );
+        return ! empty(
+            $fbl4b_settings[ FacebookPluginConfig::FBL4B_ACCESS_TOKEN_KEY ]
+        );
+    }
+
+    /**
+     * Retrieves the FBL4B access token (decrypted).
+     *
+     * @return string The FBL4B access token, or empty string if not set.
+     */
+    public static function get_fbl4b_access_token() {
+        $fbl4b_settings = \get_option(
+            FacebookPluginConfig::FBL4B_SETTINGS_KEY,
+            array()
+        );
+        $stored = isset(
+            $fbl4b_settings[ FacebookPluginConfig::FBL4B_ACCESS_TOKEN_KEY ]
+        ) ? $fbl4b_settings[ FacebookPluginConfig::FBL4B_ACCESS_TOKEN_KEY ]
+        : '';
+        if ( empty( $stored ) ) {
+            return '';
+        }
+        $decrypted = self::decrypt_token( $stored );
+        return false !== $decrypted ? $decrypted : '';
+    }
+
+    /**
+     * Retrieves the FBL4B pixel ID.
+     *
+     * @return string The FBL4B pixel ID, or empty string if not set.
+     */
+    public static function get_fbl4b_pixel_id() {
+        $fbl4b_settings = \get_option(
+            FacebookPluginConfig::FBL4B_SETTINGS_KEY,
+            array()
+        );
+        return isset(
+            $fbl4b_settings[ FacebookPluginConfig::FBL4B_PIXEL_ID_KEY ]
+        ) ? $fbl4b_settings[ FacebookPluginConfig::FBL4B_PIXEL_ID_KEY ]
+        : '';
+    }
+
+    /**
+     * Retrieves the FBL4B business ID.
+     *
+     * @return string The FBL4B business ID, or empty string if not set.
+     */
+    public static function get_fbl4b_business_id() {
+        $fbl4b_settings = \get_option(
+            FacebookPluginConfig::FBL4B_SETTINGS_KEY,
+            array()
+        );
+        return isset(
+            $fbl4b_settings[ FacebookPluginConfig::FBL4B_BUSINESS_ID_KEY ]
+        ) ? $fbl4b_settings[ FacebookPluginConfig::FBL4B_BUSINESS_ID_KEY ]
+        : '';
+    }
+
+    /**
+     * Retrieves the FBL4B pixel name.
+     *
+     * @return string The FBL4B pixel name, or empty string if not set.
+     */
+    public static function get_fbl4b_pixel_name() {
+        $fbl4b_settings = \get_option(
+            FacebookPluginConfig::FBL4B_SETTINGS_KEY,
+            array()
+        );
+        return isset(
+            $fbl4b_settings[ FacebookPluginConfig::FBL4B_PIXEL_NAME_KEY ]
+        ) ? $fbl4b_settings[ FacebookPluginConfig::FBL4B_PIXEL_NAME_KEY ]
+        : '';
+    }
+
+    /**
      * Encrypts a token using AES-256-CBC with a random IV.
      *
      * @param string $token The plaintext token to encrypt.

--- a/core/class-facebookwordpressoptions.php
+++ b/core/class-facebookwordpressoptions.php
@@ -740,6 +740,60 @@ class FacebookWordpressOptions {
     }
 
     /**
+     * Returns the active connection type.
+     *
+     * FBL4B takes priority when fully configured (token + pixel).
+     * During upgrade from MBE, if FBL4B has a token but no pixel yet,
+     * MBE stays active to avoid disrupting live traffic.
+     * For fresh installs (no MBE), FBL4B is active immediately.
+     *
+     * @return string 'fbl4b', 'mbe', or 'none'.
+     */
+    public static function get_connection_type() {
+        if ( self::get_is_fbl4b_installed() ) {
+            if ( ! empty( self::get_fbl4b_pixel_id() ) ) {
+                return 'fbl4b';
+            }
+            if ( self::get_is_fbe_installed() ) {
+                return 'mbe';
+            }
+            return 'fbl4b';
+        }
+        if ( self::get_is_fbe_installed() ) {
+            return 'mbe';
+        }
+        return 'none';
+    }
+
+    /**
+     * Retrieves the active pixel ID based on connection type.
+     *
+     * Returns FBL4B pixel ID if connected via FBL4B, otherwise MBE.
+     *
+     * @return string The active pixel ID.
+     */
+    public static function get_active_pixel_id() {
+        if ( 'fbl4b' === self::get_connection_type() ) {
+            return self::get_fbl4b_pixel_id();
+        }
+        return self::get_pixel_id();
+    }
+
+    /**
+     * Retrieves the active access token based on connection type.
+     *
+     * Returns FBL4B BISU token if connected via FBL4B, otherwise MBE.
+     *
+     * @return string The active access token.
+     */
+    public static function get_active_access_token() {
+        if ( 'fbl4b' === self::get_connection_type() ) {
+            return self::get_fbl4b_access_token();
+        }
+        return self::get_access_token();
+    }
+
+    /**
      * Encrypts a token using AES-256-CBC with a random IV.
      *
      * @param string $token The plaintext token to encrypt.

--- a/core/class-facebookwordpressoptions.php
+++ b/core/class-facebookwordpressoptions.php
@@ -652,4 +652,31 @@ class FacebookWordpressOptions {
             self::set_old_aam_settings();
         }
     }
+
+    /**
+     * Encrypts a token using AES-256-CBC with a random IV.
+     *
+     * @param string $token The plaintext token to encrypt.
+     * @return string The base64-encoded IV + ciphertext.
+     */
+    public static function encrypt_token( $token ) {
+        $key       = hash( 'sha256', \wp_salt( 'auth' ), true );
+        $iv        = openssl_random_pseudo_bytes( 16 );
+        $encrypted = openssl_encrypt( $token, 'aes-256-cbc', $key, 0, $iv );
+        return base64_encode( $iv . base64_decode( $encrypted ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode,WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+    }
+
+    /**
+     * Decrypts a token encrypted by encrypt_token().
+     *
+     * @param string $stored The base64-encoded IV + ciphertext.
+     * @return string|false The decrypted token, or false on failure.
+     */
+    public static function decrypt_token( $stored ) {
+        $key       = hash( 'sha256', \wp_salt( 'auth' ), true );
+        $raw       = base64_decode( $stored ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+        $iv        = substr( $raw, 0, 16 );
+        $encrypted = base64_encode( substr( $raw, 16 ) ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+        return openssl_decrypt( $encrypted, 'aes-256-cbc', $key, 0, $iv );
+    }
 }

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -57,7 +57,7 @@ class FacebookWordpressPixelInjection {
      * @return void
      */
     public function inject() {
-        $pixel_id = FacebookWordpressOptions::get_pixel_id();
+        $pixel_id = FacebookWordpressOptions::get_active_pixel_id();
         if ( FacebookPluginUtils::is_positive_integer( $pixel_id ) ) {
             add_action(
                 'wp_head',

--- a/core/class-facebookwordpresssettingsrecorder.php
+++ b/core/class-facebookwordpresssettingsrecorder.php
@@ -173,7 +173,7 @@ class FacebookWordpressSettingsRecorder {
             return $this->handle_unauthorized_request();
         }
 
-        if ( empty( FacebookWordpressOptions::get_pixel_id() ) ) {
+        if ( empty( FacebookWordpressOptions::get_active_pixel_id() ) ) {
             \update_option(
                 FacebookPluginConfig::CAPI_INTEGRATION_STATUS,
                 FacebookPluginConfig::CAPI_INTEGRATION_STATUS_DEFAULT
@@ -214,7 +214,7 @@ class FacebookWordpressSettingsRecorder {
             return $this->handle_unauthorized_request();
         }
 
-        if ( empty( FacebookWordpressOptions::get_pixel_id() ) ) {
+        if ( empty( FacebookWordpressOptions::get_active_pixel_id() ) ) {
             \update_option(
                 FacebookPluginConfig::CAPI_INTEGRATION_EVENTS_FILTER,
                 FacebookPluginConfig::CAPI_INTEGRATION_EVENTS_FILTER_DEFAULT
@@ -275,7 +275,7 @@ class FacebookWordpressSettingsRecorder {
             return $this->handle_unauthorized_request();
         }
 
-        if ( empty( FacebookWordpressOptions::get_pixel_id() ) ) {
+        if ( empty( FacebookWordpressOptions::get_active_pixel_id() ) ) {
             \update_option(
                 FacebookPluginConfig::CAPI_PII_CACHING_STATUS,
                 FacebookPluginConfig::CAPI_PII_CACHING_STATUS_DEFAULT

--- a/core/class-facebookwordpresssettingsrecorder.php
+++ b/core/class-facebookwordpresssettingsrecorder.php
@@ -67,6 +67,18 @@ class FacebookWordpressSettingsRecorder {
             'wp_ajax_delete_fbl4b_settings',
             array( $this, 'delete_fbl4b_settings' )
         );
+        add_action(
+            'wp_ajax_fbl4b_validate_token',
+            array( $this, 'fbl4b_validate_token' )
+        );
+        add_action(
+            'wp_ajax_fbl4b_fetch_business_id',
+            array( $this, 'fbl4b_fetch_business_id' )
+        );
+        add_action(
+            'wp_ajax_fbl4b_fetch_pixels',
+            array( $this, 'fbl4b_fetch_pixels' )
+        );
     }
 
     /**
@@ -430,5 +442,198 @@ class FacebookWordpressSettingsRecorder {
         \delete_option( FacebookPluginConfig::FBL4B_SETTINGS_KEY );
 
         return $this->handle_success_request( 'FBL4B settings deleted' );
+    }
+
+    /**
+     * Proxies a Graph API call to validate the FBL4B access token.
+     * Returns whether the token is valid and the client_business_id.
+     */
+    public function fbl4b_validate_token() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( 'Unauthorized', 403 );
+            return;
+        }
+        check_admin_referer( 'fbl4b_validate_token' );
+
+        $access_token = FacebookWordpressOptions::get_fbl4b_access_token();
+        if ( empty( $access_token ) ) {
+            wp_send_json_success(
+                array(
+                    'valid'              => false,
+                    'client_business_id' => null,
+                )
+            );
+            return;
+        }
+
+        $response = wp_remote_get(
+            $this->get_graph_api_base_url() . '/me?fields=client_business_id',
+            array(
+                'headers' => array(
+                    'Authorization' => 'Bearer ' . $access_token,
+                ),
+                'timeout' => 15,
+            )
+        );
+
+        if ( is_wp_error( $response ) ) {
+            wp_send_json_success(
+                array(
+                    'valid'              => false,
+                    'client_business_id' => null,
+                )
+            );
+            return;
+        }
+
+        $status_code = wp_remote_retrieve_response_code( $response );
+        $body        = json_decode( wp_remote_retrieve_body( $response ), true );
+
+        if ( $status_code >= 400 ) {
+            wp_send_json_success(
+                array(
+                    'valid'              => false,
+                    'client_business_id' => null,
+                )
+            );
+            return;
+        }
+
+        wp_send_json_success(
+            array(
+                'valid'              => ! empty( $body['client_business_id'] ),
+                'client_business_id' => isset( $body['client_business_id'] )
+                    ? $body['client_business_id'] : null,
+            )
+        );
+    }
+
+    /**
+     * Proxies a Graph API call to fetch the client_business_id.
+     * Token is read server-side from the database.
+     */
+    public function fbl4b_fetch_business_id() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( 'Unauthorized', 403 );
+            return;
+        }
+        check_admin_referer( 'fbl4b_fetch_business_id' );
+
+        $access_token = FacebookWordpressOptions::get_fbl4b_access_token();
+        if ( empty( $access_token ) ) {
+            wp_send_json_error( 'No access token stored', 400 );
+            return;
+        }
+
+        $response = wp_remote_get(
+            $this->get_graph_api_base_url() . '/me?fields=client_business_id',
+            array(
+                'headers' => array(
+                    'Authorization' => 'Bearer ' . $access_token,
+                ),
+                'timeout' => 15,
+            )
+        );
+
+        if ( is_wp_error( $response ) ) {
+            wp_send_json_error( $response->get_error_message() );
+            return;
+        }
+
+        $status_code = wp_remote_retrieve_response_code( $response );
+        $body        = json_decode( wp_remote_retrieve_body( $response ), true );
+
+        if ( $status_code >= 400 ) {
+            $error_msg = isset( $body['error']['message'] )
+                ? $body['error']['message'] : 'Graph API error';
+            wp_send_json_error( $error_msg, $status_code );
+            return;
+        }
+
+        wp_send_json_success( $body );
+    }
+
+    /**
+     * Proxies Graph API calls to fetch owned + client pixels for a business.
+     * Deduplicates by pixel ID, owned pixels first.
+     */
+    public function fbl4b_fetch_pixels() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            wp_send_json_error( 'Unauthorized', 403 );
+            return;
+        }
+        check_admin_referer( 'fbl4b_fetch_pixels' );
+
+        $access_token = FacebookWordpressOptions::get_fbl4b_access_token();
+        $business_id  = sanitize_text_field(
+            isset( $_POST['businessId'] ) ?
+            wp_unslash( $_POST['businessId'] ) : ''
+        );
+
+        if ( empty( $access_token ) || empty( $business_id ) ) {
+            wp_send_json_error( 'Missing parameters', 400 );
+            return;
+        }
+
+        $base_url = $this->get_graph_api_base_url();
+        $headers  = array( 'Authorization' => 'Bearer ' . $access_token );
+
+        $owned_url  = $base_url . '/' . $business_id
+            . '/owned_pixels?fields=id,name&limit=100';
+        $client_url = $base_url . '/' . $business_id
+            . '/client_pixels?fields=id,name&limit=100';
+
+        $owned_response  = wp_remote_get(
+            $owned_url,
+            array( 'headers' => $headers, 'timeout' => 15 )
+        );
+        $client_response = wp_remote_get(
+            $client_url,
+            array( 'headers' => $headers, 'timeout' => 15 )
+        );
+
+        $pixels   = array();
+        $seen_ids = array();
+
+        if ( ! is_wp_error( $owned_response )
+            && 200 === wp_remote_retrieve_response_code( $owned_response ) ) {
+            $owned_data = json_decode(
+                wp_remote_retrieve_body( $owned_response ),
+                true
+            );
+            if ( isset( $owned_data['data'] ) ) {
+                foreach ( $owned_data['data'] as $pixel ) {
+                    $pixels[]   = $pixel;
+                    $seen_ids[] = $pixel['id'];
+                }
+            }
+        }
+
+        if ( ! is_wp_error( $client_response )
+            && 200 === wp_remote_retrieve_response_code( $client_response ) ) {
+            $client_data = json_decode(
+                wp_remote_retrieve_body( $client_response ),
+                true
+            );
+            if ( isset( $client_data['data'] ) ) {
+                foreach ( $client_data['data'] as $pixel ) {
+                    if ( ! in_array( $pixel['id'], $seen_ids, true ) ) {
+                        $pixels[] = $pixel;
+                    }
+                }
+            }
+        }
+
+        if ( empty( $pixels ) ) {
+            wp_send_json_error(
+                array(
+                    'message' => 'No pixels found for this business.',
+                    'code'    => 'no_pixels',
+                )
+            );
+            return;
+        }
+
+        wp_send_json_success( array( 'data' => $pixels ) );
     }
 }

--- a/core/class-facebookwordpresssettingsrecorder.php
+++ b/core/class-facebookwordpresssettingsrecorder.php
@@ -58,6 +58,15 @@ class FacebookWordpressSettingsRecorder {
                 'save_capi_pii_caching_status',
             )
         );
+        // FBL4B AJAX actions
+        add_action(
+            'wp_ajax_save_fbl4b_settings',
+            array( $this, 'save_fbl4b_settings' )
+        );
+        add_action(
+            'wp_ajax_delete_fbl4b_settings',
+            array( $this, 'delete_fbl4b_settings' )
+        );
     }
 
     /**
@@ -323,5 +332,103 @@ class FacebookWordpressSettingsRecorder {
         \delete_transient( FacebookPluginConfig::AAM_SETTINGS_KEY );
 
         return $this->handle_success_request( 'Done' );
+    }
+
+    /**
+     * Returns the Graph API base URL.
+     *
+     * @return string The Graph API base URL.
+     */
+    private function get_graph_api_base_url() {
+        return 'https://graph.facebook.com/' . FacebookPluginConfig::FBL4B_API_VERSION;
+    }
+
+    /**
+     * Saves FBL4B settings. On initial save, encrypts and stores the
+     * access token. On partial update (pixel selection), merges with
+     * existing settings.
+     *
+     * @return array Response data.
+     */
+    public function save_fbl4b_settings() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return $this->handle_unauthorized_request();
+        }
+        check_admin_referer( 'save_fbl4b_settings' );
+
+        $access_token = sanitize_text_field(
+            isset( $_POST['accessToken'] ) ?
+            wp_unslash( $_POST['accessToken'] ) : ''
+        );
+        $pixel_id = sanitize_text_field(
+            isset( $_POST['pixelId'] ) ?
+            wp_unslash( $_POST['pixelId'] ) : ''
+        );
+        $pixel_name = sanitize_text_field(
+            isset( $_POST['pixelName'] ) ?
+            wp_unslash( $_POST['pixelName'] ) : ''
+        );
+        $business_id = sanitize_text_field(
+            isset( $_POST['businessId'] ) ?
+            wp_unslash( $_POST['businessId'] ) : ''
+        );
+
+        if ( empty( $access_token ) ) {
+            // Partial update (e.g., pixel selection after initial save)
+            $existing = \get_option(
+                FacebookPluginConfig::FBL4B_SETTINGS_KEY,
+                array()
+            );
+            if ( empty( $existing ) ) {
+                return $this->handle_invalid_request();
+            }
+            if ( ! empty( $pixel_id ) ) {
+                $existing[ FacebookPluginConfig::FBL4B_PIXEL_ID_KEY ] = $pixel_id;
+            }
+            if ( ! empty( $pixel_name ) ) {
+                $existing[ FacebookPluginConfig::FBL4B_PIXEL_NAME_KEY ] =
+                    $pixel_name;
+            }
+            if ( ! empty( $business_id ) ) {
+                $existing[ FacebookPluginConfig::FBL4B_BUSINESS_ID_KEY ] =
+                    $business_id;
+            }
+            \update_option(
+                FacebookPluginConfig::FBL4B_SETTINGS_KEY,
+                $existing
+            );
+            return $this->handle_success_request( $existing );
+        }
+
+        // Initial save — encrypt and store the access token
+        $fbl4b_settings = array(
+            FacebookPluginConfig::FBL4B_ACCESS_TOKEN_KEY =>
+                FacebookWordpressOptions::encrypt_token( $access_token ),
+            FacebookPluginConfig::FBL4B_PIXEL_ID_KEY   => $pixel_id,
+            FacebookPluginConfig::FBL4B_PIXEL_NAME_KEY => $pixel_name,
+            FacebookPluginConfig::FBL4B_BUSINESS_ID_KEY => $business_id,
+        );
+        \update_option(
+            FacebookPluginConfig::FBL4B_SETTINGS_KEY,
+            $fbl4b_settings
+        );
+
+        return $this->handle_success_request( 'FBL4B settings saved' );
+    }
+
+    /**
+     * Deletes all FBL4B settings.
+     *
+     * @return array Response data.
+     */
+    public function delete_fbl4b_settings() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return $this->handle_unauthorized_request();
+        }
+        check_admin_referer( 'delete_fbl4b_settings' );
+
+        \delete_option( FacebookPluginConfig::FBL4B_SETTINGS_KEY );
+
+        return $this->handle_success_request( 'FBL4B settings deleted' );
     }
 }

--- a/core/class-pixelrenderer.php
+++ b/core/class-pixelrenderer.php
@@ -72,7 +72,7 @@ class PixelRenderer {
         $code = sprintf(
             self::FBQ_AGENT_CODE,
             FacebookWordpressOptions::get_agent_string(),
-            FacebookWordpressOptions::get_pixel_id()
+            FacebookWordpressOptions::get_active_pixel_id()
         );
         foreach ( $events as $event ) {
             $code .= self::get_pixel_track_code( $event, $fb_integration_tracking );

--- a/facebook-for-wordpress.php
+++ b/facebook-for-wordpress.php
@@ -59,7 +59,7 @@ class FacebookForWordpress {
     );
 
     $options = FacebookWordpressOptions::get_options();
-    FacebookPixel::initialize( FacebookWordpressOptions::get_pixel_id() );
+    FacebookPixel::initialize( FacebookWordpressOptions::get_active_pixel_id() );
 
     add_action( 'init', array( $this, 'register_pixel_injection' ), 0 );
     add_action( 'parse_request', array( $this, 'handle_events_request' ), 0 );

--- a/integration/class-facebookwordpresseasydigitaldownloads.php
+++ b/integration/class-facebookwordpresseasydigitaldownloads.php
@@ -205,7 +205,7 @@ class FacebookWordpressEasyDigitalDownloads extends FacebookWordpressIntegration
                 'fbIntegrationKey' => FacebookPixel::FB_INTEGRATION_TRACKING_KEY,
                 'trackingName'     => self::TRACKING_NAME,
                 'agentString'      => FacebookWordpressOptions::get_agent_string(),
-                'pixelId'          => FacebookWordpressOptions::get_pixel_id(),
+                'pixelId'          => FacebookWordpressOptions::get_active_pixel_id(),
             )
         );
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -30,5 +30,6 @@ if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
 
 delete_option( FacebookPluginConfig::SETTINGS_KEY );
 delete_option( FacebookPluginConfig::OLD_SETTINGS_KEY );
+delete_option( FacebookPluginConfig::FBL4B_SETTINGS_KEY );
 
 delete_user_meta( get_current_user_id(), FacebookPluginConfig::ADMIN_IGNORE_PIXEL_ID_NOTICE );


### PR DESCRIPTION
### Description

Add server-side AJAX endpoints for FBL4B credential management and Graph API proxying. All endpoints require `manage_options` capability and WordPress nonce verification. The access token is read from the encrypted database for all proxy calls — it never leaves the server after initial save.

**Endpoints added:**
- `save_fbl4b_settings`: Initial save (reads token from `Authorization: Bearer` header, encrypts via AES-256-CBC) + partial updates (pixel selection)
- `delete_fbl4b_settings`: Remove all FBL4B settings from `wp_options`
- `fbl4b_validate_token`: Proxy GET `/me?fields=client_business_id` — returns valid status + business ID
- `fbl4b_fetch_business_id`: Proxy GET `/me?fields=client_business_id` — returns full response
- `fbl4b_fetch_pixels`: Fetches owned + client pixels for a business, deduplicates by ID (owned first)
- `get_graph_api_base_url()`: Returns Graph API base URL with FBL4B API version (v25.0)

**Security:**
- Access token sent via `Authorization: Bearer` header (not POST body) during initial save
- All proxy endpoints use `Authorization: Bearer` header for Graph API calls
- Token read from encrypted database — never from browser request

**Dependencies**: [PR (storage layer + encryption)](https://github.com/facebookincubator/Facebook-Pixel-for-Wordpress/pull/133)

### Type of change

- New feature (non-breaking change which adds functionality)

### Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki](https://fburl.com/wiki/b2b0midg).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary).

### Changelog entry

Add FBL4B server-side AJAX endpoints for token management and Graph API proxying with Bearer token authentication.

### Test Plan

**Unit tests (15 new tests):**
- AJAX action registration: save + delete (1 test)
- Save settings: initial save with Bearer token encryption, partial update, unauthorized, invalid (4 tests)
- Delete settings: successful deletion, unauthorized (2 tests)
- Proxy AJAX registration: validate, fetch_business, fetch_pixels (1 test)
- Validate token: returns invalid when no token (1 test)
- Fetch business ID: returns error when no token (1 test)
- Fetch pixels: missing params error, deduplication of owned + client pixels, no pixels error, owned-only pixels (4 tests)
- Graph API base URL: returns correct v25.0 URL (1 test)

**Manual testing:**
1. Connect via FBL4B → verify token is encrypted in `wp_options` → `facebook_fbl4b_config`
2. Check DevTools Network → `save_fbl4b_settings` request → token in `Authorization: Bearer` header, NOT in POST body
3. Verify proxy endpoints work: business ID fetch, pixel fetch, token validation

Run: `vendor/bin/phpunit --bootstrap __tests__/bootstrap.php __tests__`

### Screenshots

N/A — backend-only changes. Endpoints are not called by JS code.