### PR TITLE
Fix build artifact leak and set-stable-tag comparison

### DIFF
--- a/.github/workflows/set-stable-tag.yml
+++ b/.github/workflows/set-stable-tag.yml
@@ -76,9 +76,12 @@ jobs:
           unzip -q "$TEMP_DIR/marketplace.zip" -d "$TEMP_DIR/wp"
           unzip -q "$ARTIFACT_ZIP" -d "$TEMP_DIR/gh"
 
-          # Compare directories (ignore .gitignore)
+          # Compare directories (ignore files that differ only due to build context)
           echo "Comparing archives..."
-          DIFF_OUTPUT=$(diff -rq --exclude='.gitignore' "$TEMP_DIR/wp" "$TEMP_DIR/gh" 2>&1 || true)
+          DIFF_OUTPUT=$(diff -rq \
+            --exclude='.gitignore' \
+            --exclude='installed.php' \
+            "$TEMP_DIR/wp" "$TEMP_DIR/gh" 2>&1 || true)
 
           # For .pot files, check if differences are only timestamps
           REAL_DIFFS=""

--- a/build.xml
+++ b/build.xml
@@ -24,6 +24,8 @@
         <exclude name="js/lib/**" />
         <exclude name=".githooks/**" />
         <exclude name=".github/**" />
+        <exclude name=".phpunit.result.cache" />
+        <exclude name="report/**" />
     </fileset>
 
     <!-- ============================================  -->


### PR DESCRIPTION
## Summary
- Exclude `.phpunit.result.cache` and `report/` from Phing build fileset — the default phing target runs tests before build, leaking test artifacts into the release zip
- Exclude `vendor/composer/installed.php` from `set-stable-tag` diff comparison — it contains branch name and commit hash that inherently differ between `prepare-release` (`release/X.Y.Z`) and `release-plugin` (`release/pX.Y.Z/publish`) builds

## Context
The `set-stable-tag` workflow's "Compare marketplace artifacts" step was failing for the 5.0.1 release because of these differences. Already hotfixed on `release/p5.0.1/publish` — this PR brings the fixes to `main` for future releases.

## Test plan
- [ ] Re-run `set-stable-tag` on `release/p5.0.1/publish` to verify the comparison passes
- [ ] Verify future `prepare-release` builds no longer include `.phpunit.result.cache` or `report/`