### PR TITLE
Harden test event code input against XSS (T257499977)

### DIFF
--- a/core/class-facebookcapievent.php
+++ b/core/class-facebookcapievent.php
@@ -135,6 +135,27 @@ class FacebookCapiEvent {
             wp_die();
         }
 
+        if ( isset( $_POST['test_event_code'] ) ) {
+            $raw_test_event_code = sanitize_text_field(
+                wp_unslash( $_POST['test_event_code'] )
+            );
+            if ( ! preg_match( '/^[A-Za-z0-9_]+$/', $raw_test_event_code ) ) {
+                wp_send_json_error(
+                    wp_json_encode(
+                        array(
+                            'error' => array(
+                                'message'        => 'Invalid test event code',
+                                'error_user_msg' =>
+                                'Test event code must contain only'
+                                . ' letters, numbers, and underscores.',
+                            ),
+                        )
+                    )
+                );
+                wp_die();
+            }
+        }
+
         $api_version  = ApiConfig::APIVersion;
         $pixel_id     = FacebookWordpressOptions::get_pixel_id();
         $access_token = FacebookWordpressOptions::get_access_token();

--- a/js/settings_page.js
+++ b/js/settings_page.js
@@ -1,7 +1,11 @@
 function escapeHtml(str) {
     var div = document.createElement("div");
-    div.appendChild(document.createTextNode(str));
+    div.appendChild(document.createTextNode(String(str)));
     return div.innerHTML;
+}
+
+function isValidTestEventCode(code) {
+    return /^[A-Za-z0-9_]+$/.test(code);
 }
 
 window.fbAsyncInit = function () {
@@ -173,6 +177,11 @@ function sendTestEvent(e) {
 
     if (!testEventCode) {
         alert("You must enter test event code.");
+        return;
+    }
+
+    if (!isValidTestEventCode(testEventCode)) {
+        alert("Test event code must contain only letters, numbers, and underscores.");
         return;
     }
 


### PR DESCRIPTION
## Summary

- Adds client-side and server-side input validation for the test event code field, restricting it to alphanumeric characters and underscores only
- Makes `escapeHtml()` more robust by coercing input to string before creating text node
- Defense-in-depth on top of the existing `escapeHtml` sanitization added in commit 6985ae1

Fixes T257499977

## Test plan

- [ ] Enter a valid test event code (e.g., `TEST4039`) — should submit normally
- [ ] Enter a malicious payload (e.g., `"><img src=x onerror=prompt(121);>`) in the Test Event Code field — should be rejected with an alert before submission
- [ ] Verify the event log still renders correctly for successful and failed events
- [ ] Verify server returns error for invalid test event codes sent via direct API calls