### PR TITLE
Add signal pause/resume controls for Pixel + CAPI

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -6,6 +6,9 @@ on:
       - 'release/**'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -40,5 +40,5 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v7
         with:
-          name: official-facebook-pixel
-          path: artifact-contents
+          name: facebook-pixel-for-wordpress
+          path: artifact-contents/official-facebook-pixel

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -40,5 +40,5 @@ jobs:
       - name: Upload build artifact
         uses: actions/upload-artifact@v7
         with:
-          name: facebook-pixel-for-wordpress
-          path: artifact-contents/official-facebook-pixel
+          name: official-facebook-pixel
+          path: artifact-contents

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,29 +34,3 @@ jobs:
 
       - name: Run PHPCS
         run: vendor/bin/phpcs --standard=phpcs.xml --extensions=php --ignore=vendor/ .
-
-  build-and-upload:
-    if: startsWith(github.ref, 'refs/heads/release/')
-    needs: test-and-code-style
-    name: Build and Upload Artifact
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout release branch
-        uses: actions/checkout@v6
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
-        with:
-          php-version: '7.4'
-          tools: composer
-
-      - name: Install dependencies and build
-        run: |
-          composer install
-          vendor/bin/phing
-
-      - name: Upload build artifact
-        uses: actions/upload-artifact@v7
-        with:
-          name: facebook-pixel-for-wordpress
-          path: build/facebook-pixel-for-wordpress-*.zip

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,3 +34,29 @@ jobs:
 
       - name: Run PHPCS
         run: vendor/bin/phpcs --standard=phpcs.xml --extensions=php --ignore=vendor/ .
+
+  build-and-upload:
+    if: startsWith(github.ref, 'refs/heads/release/')
+    needs: test-and-code-style
+    name: Build and Upload Artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout release branch
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer
+
+      - name: Install dependencies and build
+        run: |
+          composer install
+          vendor/bin/phing
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: facebook-pixel-for-wordpress
+          path: build/facebook-pixel-for-wordpress-*.zip

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -133,10 +133,13 @@ jobs:
                 .map(l => l.name)
                 .filter(l => l.startsWith(labelPrefix))
                 .map(l => l.replace(labelPrefix, "").trim());
-              if (labels.length === 0 || labels[0].toLowerCase() === 'none') continue;
+              if (labels.length > 0 && labels[0].toLowerCase() === 'none') continue;
 
-              const category = labels[0];
-              changelog.push(`* ${category.charAt(0).toUpperCase()}${category.slice(1)} - ${pr.title} by @${pr.user.login} in #${pr.number}`);
+              const category = labels.length > 0 ? labels[0] : null;
+              const prefix = category
+                ? `${category.charAt(0).toUpperCase()}${category.slice(1)} - `
+                : '';
+              changelog.push(`* ${prefix}${pr.title} by @${pr.user.login} in #${pr.number}`);
             }
 
             const date = new Date().toISOString().slice(0, 10);

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -133,13 +133,10 @@ jobs:
                 .map(l => l.name)
                 .filter(l => l.startsWith(labelPrefix))
                 .map(l => l.replace(labelPrefix, "").trim());
-              if (labels.length > 0 && labels[0].toLowerCase() === 'none') continue;
+              if (labels.length === 0 || labels[0].toLowerCase() === 'none') continue;
 
-              const category = labels.length > 0 ? labels[0] : null;
-              const prefix = category
-                ? `${category.charAt(0).toUpperCase()}${category.slice(1)} - `
-                : '';
-              changelog.push(`* ${prefix}${pr.title} by @${pr.user.login} in #${pr.number}`);
+              const category = labels[0];
+              changelog.push(`* ${category.charAt(0).toUpperCase()}${category.slice(1)} - ${pr.title} by @${pr.user.login} in #${pr.number}`);
             }
 
             const date = new Date().toISOString().slice(0, 10);

--- a/FacebookAds/Http/Parameters.php
+++ b/FacebookAds/Http/Parameters.php
@@ -27,6 +27,24 @@ namespace FacebookPixelPlugin\FacebookAds\Http;
 class Parameters extends \ArrayObject {
 
   /**
+   * @param mixed $data
+   * @param int $flags
+   * @param string $iterator_class
+   */
+  public function __construct(
+    $data = array(),
+    $flags = 0,
+    $iterator_class = 'ArrayIterator') {
+    if ($data instanceof \ArrayObject) {
+      $data = $data->getArrayCopy();
+    } elseif (is_object($data)) {
+      $data = get_object_vars($data);
+    }
+
+    parent::__construct($data, $flags, $iterator_class);
+  }
+
+  /**
    * @param array $data
    */
   public function enhance(array $data) {

--- a/FacebookAds/Http/Parameters.php
+++ b/FacebookAds/Http/Parameters.php
@@ -35,10 +35,16 @@ class Parameters extends \ArrayObject {
     $data = array(),
     $flags = 0,
     $iterator_class = 'ArrayIterator') {
-    if ($data instanceof \ArrayObject) {
+    if ($data instanceof self) {
+      $data = $data->export();
+    } elseif ($data instanceof \ArrayObject) {
       $data = $data->getArrayCopy();
     } elseif (is_object($data)) {
       $data = get_object_vars($data);
+    }
+
+    if (!is_array($data)) {
+      $data = array();
     }
 
     parent::__construct($data, $flags, $iterator_class);

--- a/FacebookAds/Http/Parameters.php
+++ b/FacebookAds/Http/Parameters.php
@@ -35,9 +35,7 @@ class Parameters extends \ArrayObject {
     $data = array(),
     $flags = 0,
     $iterator_class = 'ArrayIterator') {
-    if ($data instanceof self) {
-      $data = $data->export();
-    } elseif ($data instanceof \ArrayObject) {
+    if ($data instanceof \ArrayObject) {
       $data = $data->getArrayCopy();
     } elseif (is_object($data)) {
       $data = get_object_vars($data);

--- a/__tests__/FacebookWordpressTestBase.php
+++ b/__tests__/FacebookWordpressTestBase.php
@@ -31,13 +31,24 @@ use PHPUnit\Framework\TestCase;
 use WP_Mock\Tools\Constraints\ExpectationsMet;
 use FacebookPixelPlugin\Core\AAMSettingsFields;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\AdsPixelSettings;
+use FacebookPixelPlugin\Core\FacebookSignalState;
 
 /**
  * FacebookWordpressTestBase class.
  */
 abstract class FacebookWordpressTestBase extends TestCase {
-
+    /**
+     * Shared alias mock handle.
+     *
+     * @var mixed
+     */
     protected $mocked_fbpixel;
+
+    /**
+     * Shared options alias mock handle.
+     *
+     * @var mixed
+     */
     protected $mocked_options;
 
     /**
@@ -63,6 +74,10 @@ abstract class FacebookWordpressTestBase extends TestCase {
         $_SERVER['HTTPS']       = 'on';
         $_SERVER['HTTP_HOST']   = 'www.pikachu.com';
         $_SERVER['REQUEST_URI'] = '/index.php';
+        $_COOKIE                = array();
+        $_POST                  = array();
+        $_SESSION               = array();
+        FacebookSignalState::resume();
     }
 
     /**

--- a/__tests__/bootstrap.php
+++ b/__tests__/bootstrap.php
@@ -21,4 +21,15 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
+if ( ! defined( 'ABSPATH' ) ) {
+    define( 'ABSPATH', dirname( __DIR__ ) . '/' );
+}
+if ( ! defined( 'YEAR_IN_SECONDS' ) ) {
+    define( 'YEAR_IN_SECONDS', 365 * 24 * 60 * 60 );
+}
+
+require_once __DIR__ . '/../core/class-facebookpixelsignals.php';
+require_once __DIR__ . '/../core/class-facebooksignalstate.php';
+require_once __DIR__ . '/../core/class-resumetrackingajax.php';
+
 WP_Mock::bootstrap();

--- a/__tests__/core/FacebookPixelSignalsTest.php
+++ b/__tests__/core/FacebookPixelSignalsTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * @package FacebookPixelPlugin
+ */
+
+namespace FacebookPixelPlugin\Tests\Core;
+
+use FacebookPixelPlugin\Core\FacebookPixelSignals;
+use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
+
+/**
+ * FacebookPixelSignalsTest class.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class FacebookPixelSignalsTest extends FacebookWordpressTestBase {
+  /**
+   * Test tri-state cookie reads.
+   *
+   * @return void
+   */
+  public function testGetSignalsStateReadsCookieValues() {
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'return' => function ( $value ) {
+          return $value;
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_unslash',
+      array(
+        'return' => function ( $value ) {
+          return $value;
+        },
+      )
+    );
+
+    $this->assertNull( FacebookPixelSignals::get_signals_state() );
+    $this->assertFalse( FacebookPixelSignals::should_pause_tracking() );
+
+    $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ] = '0';
+    $this->assertFalse( FacebookPixelSignals::get_signals_state() );
+    $this->assertTrue( FacebookPixelSignals::should_pause_tracking() );
+
+    $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ] = '1';
+    $this->assertTrue( FacebookPixelSignals::get_signals_state() );
+    $this->assertFalse( FacebookPixelSignals::should_pause_tracking() );
+  }
+
+  /**
+   * Test that the AJAX handler updates request cookie state.
+   *
+   * @return void
+   */
+  public function testHandleSetSignalsUpdatesCookieState() {
+    $_POST['granted'] = '1';
+
+    \WP_Mock::userFunction(
+      'check_ajax_referer',
+      array(
+        'args' => array( FacebookPixelSignals::NONCE_ACTION, 'security' ),
+      )
+    );
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'return' => function ( $value ) {
+          return $value;
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_unslash',
+      array(
+        'return' => function ( $value ) {
+          return $value;
+        },
+      )
+    );
+    \WP_Mock::userFunction( 'is_ssl', array( 'return' => false ) );
+
+    $captured_payload = null;
+    \WP_Mock::userFunction(
+      'wp_send_json_success',
+      array(
+        'return' => function ( $payload ) use ( &$captured_payload ) {
+          $captured_payload = $payload;
+          return $payload;
+        },
+      )
+    );
+
+    $handler = new FacebookPixelSignals();
+    $handler->handle_set_signals();
+
+    $this->assertEquals( '1', $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ] );
+    $this->assertEquals( array( 'granted' => true ), $captured_payload );
+  }
+}

--- a/__tests__/core/FacebookServerSideEventTest.php
+++ b/__tests__/core/FacebookServerSideEventTest.php
@@ -28,6 +28,7 @@
 namespace FacebookPixelPlugin\Tests\Core;
 
 use FacebookPixelPlugin\Core\ServerEventFactory;
+use FacebookPixelPlugin\Core\FacebookSignalState;
 use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 
@@ -178,5 +179,37 @@ final class FacebookServerSideEventTest extends FacebookWordpressTestBase {
       'Lead',
       $pending_pixel_event->getEventName()
     );
+  }
+
+  /**
+   * Tests that frontend sends are suppressed while tracking is paused.
+   *
+   * @return void
+   */
+  public function testSendSuppressedWhenPausedOnFrontend() {
+    self::mockFacebookWordpressOptions();
+
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+
+    \WP_Mock::userFunction( 'is_admin', array( 'return' => false ) );
+    \WP_Mock::userFunction( 'wp_doing_cron', array( 'return' => false ) );
+
+    FacebookSignalState::pause();
+
+    $api = \Mockery::mock( 'alias:FacebookPixelPlugin\FacebookAds\Api' );
+    $api->shouldReceive( 'init' )->never();
+
+    $event = ServerEventFactory::new_event( 'Lead' );
+    FacebookServerSideEvent::send( array( $event ) );
+
+    $this->assertTrue( true );
   }
 }

--- a/__tests__/core/FacebookWordpressPixelInjectionTest.php
+++ b/__tests__/core/FacebookWordpressPixelInjectionTest.php
@@ -28,6 +28,8 @@
 namespace FacebookPixelPlugin\Tests\Core;
 
 use FacebookPixelPlugin\Core\AAMSettingsFields;
+use FacebookPixelPlugin\Core\FacebookPixel;
+use FacebookPixelPlugin\Core\FacebookSignalState;
 use FacebookPixelPlugin\Core\FacebookWordpressPixelInjection;
 use FacebookPixelPlugin\Core\FacebookPluginConfig;
 use FacebookPixelPlugin\Core\FacebookWordpressOptions;
@@ -72,7 +74,7 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
    * @return void
    */
   public function testPixelInjection() {
-    self::mockGetOption( 1234 );
+    self::mockGetOption( '1234' );
     $injection_obj = new FacebookWordpressPixelInjection();
     \WP_Mock::expectActionAdded(
       'wp_head',
@@ -117,7 +119,7 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
    * @return void
    */
   public function testServerEventSendingInjection() {
-    self::mockGetOption( 1234, 'abc' );
+    self::mockGetOption( '1234', 'abc' );
     self::mockGetTransientAAMSettings(
       '1234',
       false,
@@ -187,5 +189,72 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
         ),
       )
     );
+  }
+
+  /**
+   * Tests that paused injection includes the gating bootstrap and paused init.
+   *
+   * @return void
+   */
+  public function testInjectPixelCodeIncludesPausedBootstrap() {
+    FacebookSignalState::pause();
+    FacebookWordpressPixelInjection::$render_cache = array();
+    FacebookPixel::set_pixel_id( '1234' );
+
+    $mocked_options = \Mockery::mock(
+      'alias:FacebookPixelPlugin\Core\FacebookWordpressOptions'
+    );
+    $mocked_options->shouldReceive( 'get_capi_integration_status' )
+      ->andReturn( '1' );
+    $mocked_options->shouldReceive( 'get_agent_string' )
+      ->andReturn( 'WordPress' );
+    $mocked_options->shouldReceive( 'get_user_info' )
+      ->andReturn( array() );
+
+    $mocked_utils = \Mockery::mock(
+      'alias:FacebookPixelPlugin\Core\FacebookPluginUtils'
+    );
+    $mocked_utils->shouldReceive( 'is_internal_user' )
+      ->andReturn( false );
+
+    \WP_Mock::userFunction(
+      'wp_json_encode',
+      array(
+        'return' => function ( $data ) {
+          return json_encode( $data );
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_create_nonce',
+      array(
+        'return' => 'nonce',
+      )
+    );
+    \WP_Mock::userFunction(
+      'admin_url',
+      array(
+        'return' => 'https://www.pikachu.com/wp-admin/admin-ajax.php',
+      )
+    );
+    \WP_Mock::userFunction(
+      'esc_js',
+      array(
+        'return' => function ( $value ) {
+          return $value;
+        },
+      )
+    );
+
+    $injection_obj = new FacebookWordpressPixelInjection();
+
+    ob_start();
+    $injection_obj->inject_pixel_code();
+    $output = ob_get_clean();
+
+    $this->assertStringContainsString( 'window.FacebookSignal', $output );
+    $this->assertStringContainsString( 'window.fbpix', $output );
+    $this->assertStringContainsString( "fbq('consent', 'revoke');", $output );
+    $this->assertStringContainsString( '"paused":true', $output );
   }
 }

--- a/__tests__/core/FacebookWordpressPixelInjectionTest.php
+++ b/__tests__/core/FacebookWordpressPixelInjectionTest.php
@@ -252,8 +252,8 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
     $injection_obj->inject_pixel_code();
     $output = ob_get_clean();
 
-    $this->assertStringContainsString( 'window.FacebookSignal', $output );
-    $this->assertStringContainsString( 'window.fbpix', $output );
+    $this->assertStringContainsString( 'FacebookSignal.init', $output );
+    $this->assertStringContainsString( 'FacebookSignal.queueEvent', $output );
     $this->assertStringContainsString( "fbq('consent', 'revoke');", $output );
     $this->assertStringContainsString( '"paused":true', $output );
   }

--- a/__tests__/core/PixelRendererTest.php
+++ b/__tests__/core/PixelRendererTest.php
@@ -255,6 +255,11 @@ final class PixelRendererTest extends FacebookWordpressTestBase {
    */
   public function testPixelRenderQueuesEventsWhenPaused() {
     \WP_Mock::userFunction(
+      'get_option',
+      array( 'return' => array() )
+    );
+
+    \WP_Mock::userFunction(
       'wp_json_encode',
       array(
         'args'   => array(
@@ -293,6 +298,11 @@ final class PixelRendererTest extends FacebookWordpressTestBase {
    * @covers \FacebookPixelPlugin\Core\PixelRenderer::render
    */
   public function testPixelRenderQueuesEventsWhenPausedWithoutScriptTag() {
+    \WP_Mock::userFunction(
+      'get_option',
+      array( 'return' => array() )
+    );
+
     \WP_Mock::userFunction(
       'wp_json_encode',
       array(

--- a/__tests__/core/PixelRendererTest.php
+++ b/__tests__/core/PixelRendererTest.php
@@ -28,6 +28,7 @@
 namespace FacebookPixelPlugin\Tests\Core;
 
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
+use FacebookPixelPlugin\Core\FacebookSignalState;
 use FacebookPixelPlugin\Core\PixelRenderer;
 use FacebookPixelPlugin\Core\FacebookWordpressOptions;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
@@ -245,5 +246,79 @@ final class PixelRendererTest extends FacebookWordpressTestBase {
     );
 
     $this->assertEquals( $expected, $code );
+  }
+
+  /**
+   * Test that paused rendering queues events instead of firing fbq directly.
+   *
+   * @covers \FacebookPixelPlugin\Core\PixelRenderer::render
+   */
+  public function testPixelRenderQueuesEventsWhenPaused() {
+    \WP_Mock::userFunction(
+      'wp_json_encode',
+      array(
+        'args'   => array(
+          \Mockery::type( 'array' ),
+          \Mockery::type( 'int' ),
+        ),
+        'return' => function ( $data, $options ) {
+          return json_encode( $data );
+        },
+      )
+    );
+
+    FacebookSignalState::pause();
+    FacebookWordpressOptions::set_version_info();
+
+    $event = ( new Event() )
+      ->setEventName( 'Lead' )
+      ->setEventId( 'TestEventId' )
+      ->setEventTime( 1234 );
+
+    $code = PixelRenderer::render( array( $event ), 'Test' );
+
+    $this->assertStringContainsString( 'FacebookSignal.queueEvent(', $code );
+    $this->assertStringContainsString( '"event_name":"Lead"', $code );
+    $this->assertStringContainsString( '"event_id":"TestEventId"', $code );
+    $this->assertStringContainsString(
+      '"fb_integration_tracking":"Test"',
+      $code
+    );
+    $this->assertStringNotContainsString( "fbq('track'", $code );
+  }
+
+  /**
+   * Test that paused raw rendering still returns queue-aware JS.
+   *
+   * @covers \FacebookPixelPlugin\Core\PixelRenderer::render
+   */
+  public function testPixelRenderQueuesEventsWhenPausedWithoutScriptTag() {
+    \WP_Mock::userFunction(
+      'wp_json_encode',
+      array(
+        'args'   => array(
+          \Mockery::type( 'array' ),
+          \Mockery::type( 'int' ),
+        ),
+        'return' => function ( $data, $options ) {
+          return json_encode( $data );
+        },
+      )
+    );
+
+    FacebookSignalState::pause();
+    FacebookWordpressOptions::set_version_info();
+
+    $event = ( new Event() )
+      ->setEventName( 'Purchase' )
+      ->setEventId( 'TestEventId' )
+      ->setEventTime( 1234 )
+      ->setCustomData( ( new CustomData() )->setValue( '10.00' ) );
+
+    $code = PixelRenderer::render( array( $event ), 'Test', false );
+
+    $this->assertStringContainsString( 'FacebookSignal.queueEvent(', $code );
+    $this->assertStringContainsString( '"event_name":"Purchase"', $code );
+    $this->assertStringNotContainsString( '<script', $code );
   }
 }

--- a/__tests__/core/ResumeTrackingAjaxTest.php
+++ b/__tests__/core/ResumeTrackingAjaxTest.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * @package FacebookPixelPlugin
+ */
+
+namespace FacebookPixelPlugin\Tests\Core;
+
+use FacebookPixelPlugin\Core\ResumeTrackingAjax;
+use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
+
+/**
+ * ResumeTrackingAjaxTest class.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class ResumeTrackingAjaxTest extends FacebookWordpressTestBase {
+  /**
+   * Test queued event validation rules.
+   *
+   * @return void
+   */
+  public function testValidateEventRejectsUnknownAndStaleEvents() {
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'return' => function ( $value ) {
+          return $value;
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'absint',
+      array(
+        'return' => function ( $value ) {
+          return (int) $value;
+        },
+      )
+    );
+
+    $handler = new ResumeTrackingAjax();
+    $method  = new \ReflectionMethod( ResumeTrackingAjax::class, 'validate_event' );
+    $method->setAccessible( true );
+
+    $this->assertFalse(
+      $method->invoke(
+        $handler,
+        array(
+          'event_name' => 'UnknownEvent',
+          'event_time' => time(),
+        ),
+        time()
+      )
+    );
+
+    $this->assertFalse(
+      $method->invoke(
+        $handler,
+        array(
+          'event_name' => 'Purchase',
+          'event_time' => time() - 3600,
+        ),
+        time()
+      )
+    );
+
+    $this->assertTrue(
+      $method->invoke(
+        $handler,
+        array(
+          'event_name' => 'Purchase',
+          'event_time' => time(),
+        ),
+        time()
+      )
+    );
+  }
+
+  /**
+   * Test replay event construction keeps source URL and event metadata.
+   *
+   * @return void
+   */
+  public function testBuildEventUsesQueuedPayload() {
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'return' => function ( $value ) {
+          return $value;
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'esc_url_raw',
+      array(
+        'return' => function ( $value ) {
+          return $value;
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'absint',
+      array(
+        'return' => function ( $value ) {
+          return (int) $value;
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_unslash',
+      array(
+        'return' => function ( $value ) {
+          return $value;
+        },
+      )
+    );
+
+    $handler = new ResumeTrackingAjax();
+    $method  = new \ReflectionMethod( ResumeTrackingAjax::class, 'build_event' );
+    $method->setAccessible( true );
+
+    $event = $method->invoke(
+      $handler,
+      array(
+        'event_name'       => 'Purchase',
+        'event_id'         => 'evt-1',
+        'event_time'       => 1234,
+        'event_source_url' => 'https://www.pikachu.com/product/1',
+        'custom_data'      => array(
+          'currency' => 'USD',
+          'value'    => 10,
+        ),
+      )
+    );
+
+    $this->assertEquals( 'Purchase', $event->getEventName() );
+    $this->assertEquals( 'evt-1', $event->getEventId() );
+    $this->assertEquals( 1234, $event->getEventTime() );
+    $this->assertEquals(
+      'https://www.pikachu.com/product/1',
+      $event->getEventSourceUrl()
+    );
+    $this->assertEquals(
+      'usd',
+      $event->getCustomData()->normalize()['currency']
+    );
+  }
+}

--- a/__tests__/core/ResumeTrackingAjaxTest.php
+++ b/__tests__/core/ResumeTrackingAjaxTest.php
@@ -46,7 +46,7 @@ final class ResumeTrackingAjaxTest extends FacebookWordpressTestBase {
       $method->invoke(
         $handler,
         array(
-          'event_name' => 'UnknownEvent',
+          'event_name' => 'Bad Name!',
           'event_time' => time(),
         ),
         time()

--- a/__tests__/core/ResumeTrackingAjaxTest.php
+++ b/__tests__/core/ResumeTrackingAjaxTest.php
@@ -40,7 +40,9 @@ final class ResumeTrackingAjaxTest extends FacebookWordpressTestBase {
 
     $handler = new ResumeTrackingAjax();
     $method  = new \ReflectionMethod( ResumeTrackingAjax::class, 'validate_event' );
-    $method->setAccessible( true );
+    if ( PHP_VERSION_ID < 80100 ) {
+      $method->setAccessible( true );
+    }
 
     $this->assertFalse(
       $method->invoke(
@@ -117,7 +119,9 @@ final class ResumeTrackingAjaxTest extends FacebookWordpressTestBase {
 
     $handler = new ResumeTrackingAjax();
     $method  = new \ReflectionMethod( ResumeTrackingAjax::class, 'build_event' );
-    $method->setAccessible( true );
+    if ( PHP_VERSION_ID < 80100 ) {
+      $method->setAccessible( true );
+    }
 
     $event = $method->invoke(
       $handler,

--- a/__tests_sdk__/FacebookAdsTest/Http/ParametersTest.php
+++ b/__tests_sdk__/FacebookAdsTest/Http/ParametersTest.php
@@ -38,6 +38,48 @@ class ParametersTest extends AbstractUnitTestCase {
     $this->assertTrue($parameters instanceof \Countable);
   }
 
+  public function testConstructorAcceptsArrayObject() {
+    $parameters = new Parameters(new \ArrayObject(array(
+      'scalar' => 'value',
+      'non_scalar' => array('nested'),
+    )));
+
+    $this->assertSame(array(
+      'scalar' => 'value',
+      'non_scalar' => array('nested'),
+    ), $parameters->getArrayCopy());
+  }
+
+  public function testConstructorAcceptsObject() {
+    $object = new \stdClass();
+    $object->scalar = 'value';
+    $object->non_scalar = array('nested');
+
+    $parameters = new Parameters($object);
+
+    $this->assertSame(array(
+      'scalar' => 'value',
+      'non_scalar' => array('nested'),
+    ), $parameters->getArrayCopy());
+  }
+
+  public function testConstructorIgnoresScalarAndNullInput() {
+    $this->assertSame(array(), (new Parameters('value'))->getArrayCopy());
+    $this->assertSame(array(), (new Parameters(null))->getArrayCopy());
+  }
+
+  public function testConstructorCopiesParametersWithoutExporting() {
+    $parameters = new Parameters(new Parameters(array(
+      'scalar' => 'value',
+      'non_scalar' => array('nested'),
+    )));
+
+    $this->assertSame(array(
+      'scalar' => 'value',
+      'non_scalar' => array('nested'),
+    ), $parameters->getArrayCopy());
+  }
+
   public function testEnhance() {
     $parameters = new Parameters();
     $copy = $parameters->getArrayCopy();

--- a/__tests_sdk__/FacebookAdsTest/Logger/CurlLogger/JsonAwareParametersTest.php
+++ b/__tests_sdk__/FacebookAdsTest/Logger/CurlLogger/JsonAwareParametersTest.php
@@ -24,7 +24,9 @@
 
 namespace FacebookPixelPlugin\FacebookAdsTest\Logger\CurlLogger;
 
+use FacebookPixelPlugin\FacebookAds\Http\Parameters;
 use FacebookPixelPlugin\FacebookAds\Logger\CurlLogger\JsonAwareParameters;
+use FacebookPixelPlugin\FacebookAds\Logger\CurlLogger\JsonNode;
 use FacebookPixelPlugin\FacebookAdsTest\AbstractUnitTestCase;
 
 class JsonAwareParametersTest extends AbstractUnitTestCase {
@@ -41,5 +43,20 @@ class JsonAwareParametersTest extends AbstractUnitTestCase {
     foreach ($params as $param) {
       $this->assertTrue(is_scalar($param) || is_null($param));
     }
+  }
+
+  public function testConstructorPreservesJsonAwareExportForParameters() {
+    $params = new Parameters(array(
+      'json_field' => array(
+        'query_field' => str_repeat('x', JsonNode::EXPLOSION_THRESHOLD + 1),
+      ),
+    ));
+
+    $this->assertSame(
+      "{\n  \"query_field\": \""
+        . str_repeat('x', JsonNode::EXPLOSION_THRESHOLD + 1)
+        . "\"\n}",
+      (new JsonAwareParameters($params))->export()['json_field']
+    );
   }
 }

--- a/__tests_sdk__/FacebookAdsTest/Logger/CurlLoggerTest.php
+++ b/__tests_sdk__/FacebookAdsTest/Logger/CurlLoggerTest.php
@@ -161,6 +161,9 @@ class CurlLoggerTest extends AbstractLoggerTest {
 
     $logger->logRequest(static::VALUE_LOG_LEVEL, $request);
 
+    $this->assertStringContainsString("--data-urlencode 'json_field=[", $this->getBuffer());
+    $this->assertStringContainsString("  \"json_value\"", $this->getBuffer());
+
     $logger->setJsonPrettyPrint(false);
     $this->assertFalse($logger->isJsonPrettyPrint());
   }

--- a/core/class-facebookpixel.php
+++ b/core/class-facebookpixel.php
@@ -269,10 +269,37 @@ src="https://www.facebook.com/tr?id=%s&ev=%s%s&noscript=1" />
         $tracking_name,
         $with_script_tag
     ) {
-        $payload = self::build_queue_payload( $event, $param, $tracking_name );
-        $code    = 'FacebookSignal.queueEvent(' .
-            wp_json_encode( $payload, JSON_PRETTY_PRINT ) .
-            ');';
+        $is_custom = ( new ReflectionClass( __CLASS__ ) )
+            ->getConstant( strtoupper( $event ) ) === false;
+
+        if ( is_array( $param ) ) {
+            $payload = self::build_queue_payload(
+                $event,
+                $param,
+                $tracking_name,
+                $is_custom
+            );
+            $code    = 'FacebookSignal.queueEvent(' .
+                wp_json_encode(
+                    $payload,
+                    JSON_PRETTY_PRINT | JSON_HEX_TAG | JSON_HEX_AMP |
+                        JSON_HEX_APOS | JSON_HEX_QUOT
+                ) .
+                ');';
+        } else {
+            $code = sprintf(
+                'FacebookSignal.queueEvent({"event_name":%s,'
+                . '"custom_data":%s,"event_id":null,"event_time":%d,'
+                . '"is_custom":%s});',
+                wp_json_encode(
+                    $event,
+                    JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+                ),
+                (string) $param,
+                time(),
+                $is_custom ? 'true' : 'false'
+            );
+        }
 
         if ( ! $with_script_tag ) {
             return $code;
@@ -287,13 +314,16 @@ src="https://www.facebook.com/tr?id=%s&ev=%s%s&noscript=1" />
      * @param string       $event         Event name.
      * @param array|string $param         Event params.
      * @param string       $tracking_name Integration tracking name.
+     * @param bool|null    $is_custom     Whether the event is a custom event;
+     *                                    null = auto-detect.
      *
      * @return array
      */
     public static function build_queue_payload(
         $event,
         $param = array(),
-        $tracking_name = ''
+        $tracking_name = '',
+        $is_custom = null
     ) {
         $custom_data = is_array( $param ) ? $param : array();
         $event_id    = null;
@@ -307,11 +337,17 @@ src="https://www.facebook.com/tr?id=%s&ev=%s%s&noscript=1" />
             $custom_data[ self::FB_INTEGRATION_TRACKING_KEY ] = $tracking_name;
         }
 
+        if ( null === $is_custom ) {
+            $is_custom = ( new ReflectionClass( __CLASS__ ) )
+                ->getConstant( strtoupper( $event ) ) === false;
+        }
+
         return array(
             'event_name'  => $event,
             'custom_data' => $custom_data,
             'event_id'    => $event_id,
             'event_time'  => time(),
+            'is_custom'   => (bool) $is_custom,
         );
     }
 

--- a/core/class-facebookpixel.php
+++ b/core/class-facebookpixel.php
@@ -223,6 +223,15 @@ src="https://www.facebook.com/tr?id=%s&ev=%s%s&noscript=1" />
             return;
         }
 
+        if ( self::is_tracking_paused() ) {
+            return self::get_pixel_queue_code(
+                $event,
+                $param,
+                $tracking_name,
+                $with_script_tag
+            );
+        }
+
         $code      = $with_script_tag ? "<script type='text/javascript'>" .
         self::$pixel_fbq_code_without_script .
         '</script>' : self::$pixel_fbq_code_without_script;
@@ -242,6 +251,78 @@ src="https://www.facebook.com/tr?id=%s&ev=%s%s&noscript=1" />
             ', ' . $param_str,
             ''
         );
+    }
+
+    /**
+     * Gets queueing code for a paused event.
+     *
+     * @param string $event           Event name.
+     * @param array  $param           Event parameters.
+     * @param string $tracking_name   Integration tracking name.
+     * @param bool   $with_script_tag Whether to include a script wrapper.
+     *
+     * @return string
+     */
+    private static function get_pixel_queue_code(
+        $event,
+        $param,
+        $tracking_name,
+        $with_script_tag
+    ) {
+        $payload = self::build_queue_payload( $event, $param, $tracking_name );
+        $code    = 'FacebookSignal.queueEvent(' .
+            wp_json_encode( $payload, JSON_PRETTY_PRINT ) .
+            ');';
+
+        if ( ! $with_script_tag ) {
+            return $code;
+        }
+
+        return "<script type='text/javascript'>{$code}</script>";
+    }
+
+    /**
+     * Build queue payload for a paused event.
+     *
+     * @param string       $event         Event name.
+     * @param array|string $param         Event params.
+     * @param string       $tracking_name Integration tracking name.
+     *
+     * @return array
+     */
+    public static function build_queue_payload(
+        $event,
+        $param = array(),
+        $tracking_name = ''
+    ) {
+        $custom_data = is_array( $param ) ? $param : array();
+        $event_id    = null;
+
+        if ( isset( $custom_data['eventID'] ) ) {
+            $event_id = $custom_data['eventID'];
+            unset( $custom_data['eventID'] );
+        }
+
+        if ( ! empty( $tracking_name ) ) {
+            $custom_data[ self::FB_INTEGRATION_TRACKING_KEY ] = $tracking_name;
+        }
+
+        return array(
+            'event_name'  => $event,
+            'custom_data' => $custom_data,
+            'event_id'    => $event_id,
+            'event_time'  => time(),
+        );
+    }
+
+    /**
+     * Whether the current request is paused.
+     *
+     * @return bool
+     */
+    private static function is_tracking_paused() {
+        return class_exists( '\FacebookPixelPlugin\Core\FacebookSignalState' ) &&
+            FacebookSignalState::is_paused();
     }
 
     /**

--- a/core/class-facebookpixel.php
+++ b/core/class-facebookpixel.php
@@ -342,13 +342,22 @@ src="https://www.facebook.com/tr?id=%s&ev=%s%s&noscript=1" />
                 ->getConstant( strtoupper( $event ) ) === false;
         }
 
-        return array(
+        $payload = array(
             'event_name'  => $event,
             'custom_data' => $custom_data,
             'event_id'    => $event_id,
             'event_time'  => time(),
             'is_custom'   => (bool) $is_custom,
         );
+
+        if ( ! empty( $event_id ) ) {
+            $queued_user_data = FacebookSignalState::get_queued_user_data( $event_id );
+            if ( null !== $queued_user_data ) {
+                $payload['user_data'] = $queued_user_data;
+            }
+        }
+
+        return $payload;
     }
 
     /**

--- a/core/class-facebookpixelsignals.php
+++ b/core/class-facebookpixelsignals.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Copyright (C) 2017-present, Meta, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * @package FacebookPixelPlugin
+ */
+
+namespace FacebookPixelPlugin\Core;
+
+defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
+
+/**
+ * Cookie-backed signals state for frontend event gating.
+ */
+class FacebookPixelSignals {
+    const COOKIE_NAME  = 'fbpix_pixel_signals';
+    const AJAX_ACTION  = 'fbpix_set_pixel_signals';
+    const NONCE_ACTION = 'fbpix_pixel_signals_nonce';
+
+    /**
+     * Register AJAX handlers.
+     */
+    public function __construct() {
+        add_action(
+            'wp_ajax_' . self::AJAX_ACTION,
+            array( $this, 'handle_set_signals' )
+        );
+        add_action(
+            'wp_ajax_nopriv_' . self::AJAX_ACTION,
+            array( $this, 'handle_set_signals' )
+        );
+    }
+
+    /**
+     * Get current signals state.
+     *
+     * @return bool|null
+     */
+    public static function get_signals_state() {
+        if ( ! isset( $_COOKIE[ self::COOKIE_NAME ] ) ) {
+            return null;
+        }
+
+        return '1' === sanitize_text_field(
+            wp_unslash( $_COOKIE[ self::COOKIE_NAME ] )
+        );
+    }
+
+    /**
+     * Whether tracking should be paused.
+     *
+     * @return bool
+     */
+    public static function should_pause_tracking() {
+        return false === self::get_signals_state();
+    }
+
+    /**
+     * Persist signals via AJAX.
+     *
+     * @return void
+     */
+    public function handle_set_signals() {
+        check_ajax_referer( self::NONCE_ACTION, 'security' );
+
+        $granted = isset( $_POST['granted'] ) &&
+            '1' === sanitize_text_field( wp_unslash( $_POST['granted'] ) );
+
+        $this->set_cookie( $granted );
+        $_COOKIE[ self::COOKIE_NAME ] = $granted ? '1' : '0';
+
+        wp_send_json_success(
+            array(
+                'granted' => $granted,
+            )
+        );
+    }
+
+    /**
+     * Set signals cookie.
+     *
+     * @param bool $granted Whether signals is granted.
+     *
+     * @return void
+     */
+    private function set_cookie( $granted ) {
+        setcookie(
+            self::COOKIE_NAME,
+            $granted ? '1' : '0',
+            time() + YEAR_IN_SECONDS,
+            defined( 'COOKIEPATH' ) ? COOKIEPATH : '/',
+            defined( 'COOKIE_DOMAIN' ) ? COOKIE_DOMAIN : '',
+            is_ssl(),
+            false
+        );
+    }
+}

--- a/core/class-facebookserversideevent.php
+++ b/core/class-facebookserversideevent.php
@@ -94,6 +94,7 @@ class FacebookServerSideEvent {
         $this->tracked_events[] = $event;
         if ( $send_now ) {
             if ( self::should_suppress_frontend_send() ) {
+                FacebookSignalState::queue_event( $event );
                 return;
             }
             do_action(
@@ -177,6 +178,9 @@ class FacebookServerSideEvent {
         }
 
         if ( self::should_suppress_frontend_send() ) {
+            foreach ( $events as $queued_event ) {
+                FacebookSignalState::queue_event( $queued_event );
+            }
             return;
         }
 

--- a/core/class-facebookserversideevent.php
+++ b/core/class-facebookserversideevent.php
@@ -93,6 +93,9 @@ class FacebookServerSideEvent {
     public function track( $event, $send_now = true ) {
         $this->tracked_events[] = $event;
         if ( $send_now ) {
+            if ( self::should_suppress_frontend_send() ) {
+                return;
+            }
             do_action(
                 'send_server_events',
                 array( $event ),
@@ -173,6 +176,10 @@ class FacebookServerSideEvent {
             return;
         }
 
+        if ( self::should_suppress_frontend_send() ) {
+            return;
+        }
+
         $pixel_id     = FacebookWordpressOptions::get_active_pixel_id();
         $access_token = FacebookWordpressOptions::get_active_access_token();
         $agent        = FacebookWordpressOptions::get_agent_string();
@@ -230,5 +237,21 @@ class FacebookServerSideEvent {
 
         return 'wp-cloudbridge-plugin' ===
         $custom_properties['fb_integration_tracking'];
+    }
+
+    /**
+     * Whether the current request should suppress frontend sends.
+     *
+     * @return bool
+     */
+    private static function should_suppress_frontend_send() {
+        $is_admin_request = function_exists( 'is_admin' ) ? is_admin() : false;
+        $is_cron_request  = function_exists( 'wp_doing_cron' ) ?
+            wp_doing_cron() :
+            false;
+
+        return FacebookSignalState::is_paused() &&
+            ! $is_admin_request &&
+            ! $is_cron_request;
     }
 }

--- a/core/class-facebooksignalstate.php
+++ b/core/class-facebooksignalstate.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Copyright (C) 2017-present, Meta, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * @package FacebookPixelPlugin
+ */
+
+namespace FacebookPixelPlugin\Core;
+
+defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
+
+/**
+ * Static per-request paused state.
+ */
+class FacebookSignalState {
+    /**
+     * Whether tracking is paused for the current request.
+     *
+     * @var bool
+     */
+    private static $paused = false;
+
+    /**
+     * Pause tracking for this request.
+     *
+     * @return void
+     */
+    public static function pause() {
+        self::$paused = true;
+    }
+
+    /**
+     * Resume tracking for this request.
+     *
+     * @return void
+     */
+    public static function resume() {
+        self::$paused = false;
+    }
+
+    /**
+     * Check whether tracking is paused.
+     *
+     * @return bool
+     */
+    public static function is_paused() {
+        return (bool) apply_filters(
+            'facebook_tracking_paused',
+            self::$paused
+        );
+    }
+}

--- a/core/class-facebooksignalstate.php
+++ b/core/class-facebooksignalstate.php
@@ -94,6 +94,38 @@ class FacebookSignalState {
     }
 
     /**
+     * Get the safe-to-forward normalized user_data for a queued event.
+     *
+     * Strips fields that the resume request will derive from its own context
+     * (client_ip_address, client_user_agent, fbp, fbc) so the resume can build
+     * those from cookies/headers it actually sees.
+     *
+     * @param string $event_id Event identifier.
+     * @return array|null
+     */
+    public static function get_queued_user_data( $event_id ) {
+        $event = self::get_queued_event( $event_id );
+        if ( null === $event ) {
+            return null;
+        }
+
+        $user_data = $event->getUserData();
+        if ( null === $user_data ) {
+            return null;
+        }
+
+        $normalized = $user_data->normalize();
+        unset(
+            $normalized['client_ip_address'],
+            $normalized['client_user_agent'],
+            $normalized['fbp'],
+            $normalized['fbc']
+        );
+
+        return ! empty( $normalized ) ? $normalized : null;
+    }
+
+    /**
      * Reset the queued events store. Intended for tests.
      *
      * @return void

--- a/core/class-facebooksignalstate.php
+++ b/core/class-facebooksignalstate.php
@@ -15,6 +15,8 @@
 
 namespace FacebookPixelPlugin\Core;
 
+use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
+
 defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 
 /**
@@ -27,6 +29,13 @@ class FacebookSignalState {
      * @var bool
      */
     private static $paused = false;
+
+    /**
+     * CAPI events queued while paused, keyed by event_id.
+     *
+     * @var array<string, Event>
+     */
+    private static $queued_events = array();
 
     /**
      * Pause tracking for this request.
@@ -56,5 +65,40 @@ class FacebookSignalState {
             'facebook_tracking_paused',
             self::$paused
         );
+    }
+
+    /**
+     * Queue a CAPI event so it can be enriched on resume.
+     *
+     * @param Event $event Event to queue.
+     * @return void
+     */
+    public static function queue_event( Event $event ) {
+        $event_id = $event->getEventId();
+        if ( empty( $event_id ) ) {
+            return;
+        }
+        self::$queued_events[ $event_id ] = $event;
+    }
+
+    /**
+     * Get a queued CAPI event by event_id.
+     *
+     * @param string $event_id Event identifier.
+     * @return Event|null
+     */
+    public static function get_queued_event( $event_id ) {
+        return isset( self::$queued_events[ $event_id ] )
+            ? self::$queued_events[ $event_id ]
+            : null;
+    }
+
+    /**
+     * Reset the queued events store. Intended for tests.
+     *
+     * @return void
+     */
+    public static function reset_queue() {
+        self::$queued_events = array();
     }
 }

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -188,6 +188,19 @@ window.FacebookSignal = window.FacebookSignal || {
         }
     })(),
 
+    _readCookie: function(name) {
+        try {
+            var pairs = (document.cookie || '').split(';');
+            for (var i = 0; i < pairs.length; i++) {
+                var pair = pairs[i].replace(/^\s+/, '');
+                if (pair.indexOf(name + '=') === 0) {
+                    return decodeURIComponent(pair.substring(name.length + 1));
+                }
+            }
+        } catch (e) {}
+        return null;
+    },
+
     init: function(config) {
         this._config = config || {};
         this._paused = !!this._config.paused;
@@ -291,7 +304,9 @@ window.FacebookSignal = window.FacebookSignal || {
             xhr.send(JSON.stringify({
                 security: self._config.resumeNonce,
                 events: self._queue,
-                fbclid: self._fbclid
+                fbclid: self._fbclid,
+                fbp: self._readCookie('_fbp'),
+                fbc: self._readCookie('_fbc')
             }));
         });
     },

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -310,10 +310,11 @@ window.FacebookSignal = window.FacebookSignal || {
         for (var i = 0; i < this._queue.length; i++) {
             var queuedEvent = this._queue[i];
             var customData = queuedEvent.custom_data || {};
+            var trackMethod = queuedEvent.is_custom ? 'trackCustom' : 'track';
             if (queuedEvent.event_id) {
-                fbq('track', queuedEvent.event_name, customData, { eventID: queuedEvent.event_id });
+                fbq(trackMethod, queuedEvent.event_name, customData, { eventID: queuedEvent.event_id });
             } else {
-                fbq('track', queuedEvent.event_name, customData);
+                fbq(trackMethod, queuedEvent.event_name, customData);
             }
         }
 
@@ -424,7 +425,10 @@ JS;
         );
 
         return "<script type='text/javascript'>FacebookSignal.init(" .
-            wp_json_encode( $config ) .
+            wp_json_encode(
+                $config,
+                JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT
+            ) .
             ');</script>';
     }
 }

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -89,6 +89,10 @@ class FacebookWordpressPixelInjection {
      * @return void
      */
     public function send_pending_events() {
+        if ( FacebookSignalState::is_paused() ) {
+            return;
+        }
+
         $pending_events =
         FacebookServerSideEvent::get_instance()->get_pending_events();
         if ( count( $pending_events ) > 0 ) {
@@ -127,16 +131,21 @@ class FacebookWordpressPixelInjection {
 
         self::$render_cache[ FacebookPluginConfig::IS_PIXEL_RENDERED ] = true;
         echo FacebookPixel::get_pixel_base_code(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        echo $this->get_facebook_signal_bootstrap_code(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         $capi_integration_status =
         FacebookWordpressOptions::get_capi_integration_status();
         // Only include user info for frontend users, not internal/admin users.
         $user_info = FacebookPluginUtils::is_internal_user() ?
             array() : FacebookWordpressOptions::get_user_info();
+        if ( FacebookSignalState::is_paused() ) {
+            echo "<script type='text/javascript'>fbq('consent', 'revoke');</script>"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        }
         echo FacebookPixel::get_pixel_init_code( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
             FacebookWordpressOptions::get_agent_string(),
             $user_info, // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
             '1' === $capi_integration_status // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         );
+        echo $this->get_facebook_signal_init_code(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         echo FacebookPixel::get_pixel_page_view_code(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
     }
 
@@ -151,5 +160,248 @@ class FacebookWordpressPixelInjection {
      */
     public function inject_pixel_noscript_code() {
         echo FacebookPixel::get_pixel_noscript_code(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+    }
+
+    /**
+     * Inline FacebookSignal and signals helper.
+     *
+     * @return string
+     */
+    private function get_facebook_signal_bootstrap_code() {
+        $cookie_name    = FacebookPixelSignals::COOKIE_NAME;
+        $signals_nonce  = wp_create_nonce( FacebookPixelSignals::NONCE_ACTION );
+        $ajax_url       = admin_url( 'admin-ajax.php' );
+        $signals_action = FacebookPixelSignals::AJAX_ACTION;
+
+        $javascript = <<<'JS'
+window.FacebookSignal = window.FacebookSignal || {
+    _paused: false,
+    _queue: [],
+    _config: {},
+    _fbclid: (function() {
+        try {
+            var match = window.location.search.match(/[?&]fbclid=([^&]*)/);
+            return match ? decodeURIComponent(match[1]) : null;
+        } catch (e) {
+            return null;
+        }
+    })(),
+
+    init: function(config) {
+        this._config = config || {};
+        this._paused = !!this._config.paused;
+    },
+
+    queueEvent: function(eventData) {
+        if (!eventData || !eventData.event_name) {
+            return;
+        }
+        eventData.event_time = eventData.event_time || Math.floor(Date.now() / 1000);
+        eventData.event_source_url = eventData.event_source_url || window.location.href;
+        this._queue.push(eventData);
+    },
+
+    trackEvent: function(name, params, userData) {
+        var eventParams = params ? Object.assign({}, params) : {};
+        var eventId = eventParams.eventID || null;
+
+        if (eventId) {
+            delete eventParams.eventID;
+        }
+
+        if (this._paused) {
+            this.queueEvent({
+                event_name: name,
+                custom_data: eventParams,
+                user_data: userData || null,
+                event_id: eventId
+            });
+            return;
+        }
+
+        if (eventId) {
+            fbq('track', name, eventParams, { eventID: eventId });
+        } else {
+            fbq('track', name, eventParams);
+        }
+    },
+
+    setPaused: function(paused) {
+        this._paused = !!paused;
+        if (this._paused) {
+            fbq('consent', 'revoke');
+        }
+    },
+
+    resume: function() {
+        var self = this;
+
+        if (!self._paused || !self._config.ajaxUrl) {
+            return Promise.resolve({ success: true, data: { sent_count: 0 } });
+        }
+
+        return new Promise(function(resolve, reject) {
+            var xhr = new XMLHttpRequest();
+            var url = self._config.ajaxUrl +
+                (self._config.ajaxUrl.indexOf('?') === -1 ? '?' : '&') +
+                'action=' + encodeURIComponent(self._config.resumeAction);
+
+            xhr.open('POST', url, true);
+            xhr.setRequestHeader('Content-Type', 'application/json');
+            xhr.onload = function() {
+                if (xhr.status < 200 || xhr.status >= 300) {
+                    reject(new Error('Resume AJAX failed: ' + xhr.status));
+                    return;
+                }
+
+                try {
+                    var response = JSON.parse(xhr.responseText);
+                    self._handleResumeResponse(response.data || {});
+                    resolve(response);
+                } catch (error) {
+                    reject(error);
+                }
+            };
+            xhr.onerror = function() {
+                reject(new Error('Network error'));
+            };
+            xhr.send(JSON.stringify({
+                security: self._config.resumeNonce,
+                events: self._queue,
+                fbclid: self._fbclid
+            }));
+        });
+    },
+
+    _handleResumeResponse: function(data) {
+        if (data.fbp) {
+            document.cookie = '_fbp=' + encodeURIComponent(data.fbp) + ';path=/;max-age=7776000;SameSite=Lax';
+        }
+
+        if (data.fbc) {
+            document.cookie = '_fbc=' + encodeURIComponent(data.fbc) + ';path=/;max-age=7776000;SameSite=Lax';
+        }
+
+        fbq('consent', 'grant');
+
+        for (var i = 0; i < this._queue.length; i++) {
+            var queuedEvent = this._queue[i];
+            var customData = queuedEvent.custom_data || {};
+            if (queuedEvent.event_id) {
+                fbq('track', queuedEvent.event_name, customData, { eventID: queuedEvent.event_id });
+            } else {
+                fbq('track', queuedEvent.event_name, customData);
+            }
+        }
+
+        this._queue = [];
+        this._paused = false;
+    }
+};
+
+window.fbpix = window.fbpix || {};
+(function(api) {
+    var cookieName = '__COOKIE_NAME__';
+    var ajaxUrl = '__AJAX_URL__';
+    var signalsAction = '__SIGNALS_ACTION__';
+    var signalsNonce = '__SIGNALS_NONCE__';
+
+    function setCookie(value) {
+        var expires = new Date();
+        expires.setTime(expires.getTime() + (365 * 24 * 60 * 60 * 1000));
+        document.cookie = cookieName + '=' + encodeURIComponent(value) + ';expires=' + expires.toUTCString() + ';path=/;SameSite=Lax';
+    }
+
+    function getCookie() {
+        var match = document.cookie.match(new RegExp('(?:^|;\\s*)' + cookieName + '=([^;]*)'));
+        return match ? decodeURIComponent(match[1]) : null;
+    }
+
+    api.setSignals = function(granted) {
+        var value = granted ? '1' : '0';
+        setCookie(value);
+
+        return new Promise(function(resolve, reject) {
+            var xhr = new XMLHttpRequest();
+            xhr.open('POST', ajaxUrl, true);
+            xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
+            xhr.onload = function() {
+                if (xhr.status < 200 || xhr.status >= 300) {
+                    reject(new Error('Signals AJAX failed: ' + xhr.status));
+                    return;
+                }
+
+                try {
+                    var response = JSON.parse(xhr.responseText);
+                    if (!granted) {
+                        window.FacebookSignal.setPaused(true);
+                        resolve(response);
+                        return;
+                    }
+
+                    if (window.FacebookSignal && window.FacebookSignal._paused) {
+                        window.FacebookSignal.resume().then(function() {
+                            resolve(response);
+                        }, function(error) {
+                            reject(error);
+                        });
+                        return;
+                    }
+
+                    resolve(response);
+                } catch (error) {
+                    reject(error);
+                }
+            };
+            xhr.onerror = function() {
+                reject(new Error('Network error'));
+            };
+            xhr.send(
+                'action=' + encodeURIComponent(signalsAction) +
+                '&security=' + encodeURIComponent(signalsNonce) +
+                '&granted=' + encodeURIComponent(value)
+            );
+        });
+    };
+
+    api.getSignals = function() {
+        var value = getCookie();
+        if (value === null) {
+            return null;
+        }
+        return value === '1';
+    };
+})(window.fbpix);
+JS;
+
+        $replacements = array(
+            '__COOKIE_NAME__'    => esc_js( $cookie_name ),
+            '__AJAX_URL__'       => esc_js( $ajax_url ),
+            '__SIGNALS_ACTION__' => esc_js( $signals_action ),
+            '__SIGNALS_NONCE__'  => esc_js( $signals_nonce ),
+        );
+
+        return "<script type='text/javascript'>" .
+            strtr( $javascript, $replacements ) .
+            '</script>';
+    }
+
+    /**
+     * Initialize FacebookSignal with current config.
+     *
+     * @return string
+     */
+    private function get_facebook_signal_init_code() {
+        $config = array(
+            'paused'       => FacebookSignalState::is_paused(),
+            'ajaxUrl'      => admin_url( 'admin-ajax.php' ),
+            'resumeAction' => ResumeTrackingAjax::ACTION,
+            'resumeNonce'  => wp_create_nonce( ResumeTrackingAjax::NONCE_ACTION ),
+            'pixelId'      => FacebookPixel::get_pixel_id(),
+        );
+
+        return "<script type='text/javascript'>FacebookSignal.init(" .
+            wp_json_encode( $config ) .
+            ');</script>';
     }
 }

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -178,6 +178,7 @@ window.FacebookSignal = window.FacebookSignal || {
     _paused: false,
     _queue: [],
     _config: {},
+    _seenEventIds: {},
     _fbclid: (function() {
         try {
             var match = window.location.search.match(/[?&]fbclid=([^&]*)/);
@@ -190,15 +191,37 @@ window.FacebookSignal = window.FacebookSignal || {
     init: function(config) {
         this._config = config || {};
         this._paused = !!this._config.paused;
+
+        try {
+            var raw = window.sessionStorage.getItem('fbpix_seen_event_ids');
+            this._seenEventIds = raw ? JSON.parse(raw) : {};
+        } catch (e) {
+            this._seenEventIds = this._seenEventIds || {};
+        }
     },
 
     queueEvent: function(eventData) {
         if (!eventData || !eventData.event_name) {
             return;
         }
+
+        if (eventData.event_id && this._seenEventIds[eventData.event_id]) {
+            return;
+        }
+
         eventData.event_time = eventData.event_time || Math.floor(Date.now() / 1000);
         eventData.event_source_url = eventData.event_source_url || window.location.href;
         this._queue.push(eventData);
+
+        if (eventData.event_id) {
+            this._seenEventIds[eventData.event_id] = 1;
+            try {
+                window.sessionStorage.setItem(
+                    'fbpix_seen_event_ids',
+                    JSON.stringify(this._seenEventIds)
+                );
+            } catch (e) {}
+        }
     },
 
     trackEvent: function(name, params, userData) {

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -60,6 +60,10 @@ class FacebookWordpressPixelInjection {
         $pixel_id = FacebookWordpressOptions::get_active_pixel_id();
         if ( FacebookPluginUtils::is_positive_integer( $pixel_id ) ) {
             add_action(
+                'wp_enqueue_scripts',
+                array( $this, 'enqueue_signal_script' )
+            );
+            add_action(
                 'wp_head',
                 array( $this, 'inject_pixel_code' )
             );
@@ -131,7 +135,6 @@ class FacebookWordpressPixelInjection {
 
         self::$render_cache[ FacebookPluginConfig::IS_PIXEL_RENDERED ] = true;
         echo FacebookPixel::get_pixel_base_code(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-        echo $this->get_facebook_signal_bootstrap_code(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         $capi_integration_status =
         FacebookWordpressOptions::get_capi_integration_status();
         // Only include user info for frontend users, not internal/admin users.
@@ -163,266 +166,29 @@ class FacebookWordpressPixelInjection {
     }
 
     /**
-     * Inline FacebookSignal and signals helper.
+     * Enqueue FacebookSignal helper script.
      *
-     * @return string
+     * @return void
      */
-    private function get_facebook_signal_bootstrap_code() {
-        $cookie_name    = FacebookPixelSignals::COOKIE_NAME;
-        $signals_nonce  = wp_create_nonce( FacebookPixelSignals::NONCE_ACTION );
-        $ajax_url       = admin_url( 'admin-ajax.php' );
-        $signals_action = FacebookPixelSignals::AJAX_ACTION;
-
-        $javascript = <<<'JS'
-window.FacebookSignal = window.FacebookSignal || {
-    _paused: false,
-    _queue: [],
-    _config: {},
-    _seenEventIds: {},
-    _fbclid: (function() {
-        try {
-            var match = window.location.search.match(/[?&]fbclid=([^&]*)/);
-            return match ? decodeURIComponent(match[1]) : null;
-        } catch (e) {
-            return null;
-        }
-    })(),
-
-    _readCookie: function(name) {
-        try {
-            var pairs = (document.cookie || '').split(';');
-            for (var i = 0; i < pairs.length; i++) {
-                var pair = pairs[i].replace(/^\s+/, '');
-                if (pair.indexOf(name + '=') === 0) {
-                    return decodeURIComponent(pair.substring(name.length + 1));
-                }
-            }
-        } catch (e) {}
-        return null;
-    },
-
-    init: function(config) {
-        this._config = config || {};
-        this._paused = !!this._config.paused;
-
-        try {
-            var raw = window.sessionStorage.getItem('fbpix_seen_event_ids');
-            this._seenEventIds = raw ? JSON.parse(raw) : {};
-        } catch (e) {
-            this._seenEventIds = this._seenEventIds || {};
-        }
-    },
-
-    queueEvent: function(eventData) {
-        if (!eventData || !eventData.event_name) {
-            return;
-        }
-
-        if (eventData.event_id && this._seenEventIds[eventData.event_id]) {
-            return;
-        }
-
-        eventData.event_time = eventData.event_time || Math.floor(Date.now() / 1000);
-        eventData.event_source_url = eventData.event_source_url || window.location.href;
-        this._queue.push(eventData);
-
-        if (eventData.event_id) {
-            this._seenEventIds[eventData.event_id] = 1;
-            try {
-                window.sessionStorage.setItem(
-                    'fbpix_seen_event_ids',
-                    JSON.stringify(this._seenEventIds)
-                );
-            } catch (e) {}
-        }
-    },
-
-    trackEvent: function(name, params, userData) {
-        var eventParams = params ? Object.assign({}, params) : {};
-        var eventId = eventParams.eventID || null;
-
-        if (eventId) {
-            delete eventParams.eventID;
-        }
-
-        if (this._paused) {
-            this.queueEvent({
-                event_name: name,
-                custom_data: eventParams,
-                user_data: userData || null,
-                event_id: eventId
-            });
-            return;
-        }
-
-        if (eventId) {
-            fbq('track', name, eventParams, { eventID: eventId });
-        } else {
-            fbq('track', name, eventParams);
-        }
-    },
-
-    setPaused: function(paused) {
-        this._paused = !!paused;
-        if (this._paused) {
-            fbq('consent', 'revoke');
-        }
-    },
-
-    resume: function() {
-        var self = this;
-
-        if (!self._paused || !self._config.ajaxUrl) {
-            return Promise.resolve({ success: true, data: { sent_count: 0 } });
-        }
-
-        return new Promise(function(resolve, reject) {
-            var xhr = new XMLHttpRequest();
-            var url = self._config.ajaxUrl +
-                (self._config.ajaxUrl.indexOf('?') === -1 ? '?' : '&') +
-                'action=' + encodeURIComponent(self._config.resumeAction);
-
-            xhr.open('POST', url, true);
-            xhr.setRequestHeader('Content-Type', 'application/json');
-            xhr.onload = function() {
-                if (xhr.status < 200 || xhr.status >= 300) {
-                    reject(new Error('Resume AJAX failed: ' + xhr.status));
-                    return;
-                }
-
-                try {
-                    var response = JSON.parse(xhr.responseText);
-                    self._handleResumeResponse(response.data || {});
-                    resolve(response);
-                } catch (error) {
-                    reject(error);
-                }
-            };
-            xhr.onerror = function() {
-                reject(new Error('Network error'));
-            };
-            xhr.send(JSON.stringify({
-                security: self._config.resumeNonce,
-                events: self._queue,
-                fbclid: self._fbclid,
-                fbp: self._readCookie('_fbp'),
-                fbc: self._readCookie('_fbc')
-            }));
-        });
-    },
-
-    _handleResumeResponse: function(data) {
-        if (data.fbp) {
-            document.cookie = '_fbp=' + encodeURIComponent(data.fbp) + ';path=/;max-age=7776000;SameSite=Lax';
-        }
-
-        if (data.fbc) {
-            document.cookie = '_fbc=' + encodeURIComponent(data.fbc) + ';path=/;max-age=7776000;SameSite=Lax';
-        }
-
-        fbq('consent', 'grant');
-
-        for (var i = 0; i < this._queue.length; i++) {
-            var queuedEvent = this._queue[i];
-            var customData = queuedEvent.custom_data || {};
-            var trackMethod = queuedEvent.is_custom ? 'trackCustom' : 'track';
-            if (queuedEvent.event_id) {
-                fbq(trackMethod, queuedEvent.event_name, customData, { eventID: queuedEvent.event_id });
-            } else {
-                fbq(trackMethod, queuedEvent.event_name, customData);
-            }
-        }
-
-        this._queue = [];
-        this._paused = false;
-    }
-};
-
-window.fbpix = window.fbpix || {};
-(function(api) {
-    var cookieName = '__COOKIE_NAME__';
-    var ajaxUrl = '__AJAX_URL__';
-    var signalsAction = '__SIGNALS_ACTION__';
-    var signalsNonce = '__SIGNALS_NONCE__';
-
-    function setCookie(value) {
-        var expires = new Date();
-        expires.setTime(expires.getTime() + (365 * 24 * 60 * 60 * 1000));
-        document.cookie = cookieName + '=' + encodeURIComponent(value) + ';expires=' + expires.toUTCString() + ';path=/;SameSite=Lax';
-    }
-
-    function getCookie() {
-        var match = document.cookie.match(new RegExp('(?:^|;\\s*)' + cookieName + '=([^;]*)'));
-        return match ? decodeURIComponent(match[1]) : null;
-    }
-
-    api.setSignals = function(granted) {
-        var value = granted ? '1' : '0';
-        setCookie(value);
-
-        return new Promise(function(resolve, reject) {
-            var xhr = new XMLHttpRequest();
-            xhr.open('POST', ajaxUrl, true);
-            xhr.setRequestHeader('Content-Type', 'application/x-www-form-urlencoded; charset=UTF-8');
-            xhr.onload = function() {
-                if (xhr.status < 200 || xhr.status >= 300) {
-                    reject(new Error('Signals AJAX failed: ' + xhr.status));
-                    return;
-                }
-
-                try {
-                    var response = JSON.parse(xhr.responseText);
-                    if (!granted) {
-                        window.FacebookSignal.setPaused(true);
-                        resolve(response);
-                        return;
-                    }
-
-                    if (window.FacebookSignal && window.FacebookSignal._paused) {
-                        window.FacebookSignal.resume().then(function() {
-                            resolve(response);
-                        }, function(error) {
-                            reject(error);
-                        });
-                        return;
-                    }
-
-                    resolve(response);
-                } catch (error) {
-                    reject(error);
-                }
-            };
-            xhr.onerror = function() {
-                reject(new Error('Network error'));
-            };
-            xhr.send(
-                'action=' + encodeURIComponent(signalsAction) +
-                '&security=' + encodeURIComponent(signalsNonce) +
-                '&granted=' + encodeURIComponent(value)
-            );
-        });
-    };
-
-    api.getSignals = function() {
-        var value = getCookie();
-        if (value === null) {
-            return null;
-        }
-        return value === '1';
-    };
-})(window.fbpix);
-JS;
-
-        $replacements = array(
-            '__COOKIE_NAME__'    => esc_js( $cookie_name ),
-            '__AJAX_URL__'       => esc_js( $ajax_url ),
-            '__SIGNALS_ACTION__' => esc_js( $signals_action ),
-            '__SIGNALS_NONCE__'  => esc_js( $signals_nonce ),
+    public function enqueue_signal_script() {
+        wp_enqueue_script(
+            'facebook-signal',
+            plugins_url( '../js/facebook_signal.js', __FILE__ ),
+            array(),
+            FacebookPluginConfig::PLUGIN_VERSION,
+            false
         );
 
-        return "<script type='text/javascript'>" .
-            strtr( $javascript, $replacements ) .
-            '</script>';
+        wp_localize_script(
+            'facebook-signal',
+            'facebookSignalConfig',
+            array(
+                'cookieName'    => FacebookPixelSignals::COOKIE_NAME,
+                'ajaxUrl'       => admin_url( 'admin-ajax.php' ),
+                'signalsAction' => FacebookPixelSignals::AJAX_ACTION,
+                'signalsNonce'  => wp_create_nonce( FacebookPixelSignals::NONCE_ACTION ),
+            )
+        );
     }
 
     /**

--- a/core/class-pixelrenderer.php
+++ b/core/class-pixelrenderer.php
@@ -148,15 +148,24 @@ class PixelRenderer {
                 $fb_integration_tracking;
         }
 
+        $is_custom = ( new ReflectionClass(
+            'FacebookPixelPlugin\Core\FacebookPixel'
+        ) )->getConstant( strtoupper( $event->getEventName() ) ) === false;
+
         $payload = array(
             'event_name'  => $event->getEventName(),
             'custom_data' => $normalized_custom_data,
             'event_id'    => $event->getEventId(),
             'event_time'  => $event->getEventTime(),
+            'is_custom'   => $is_custom,
         );
 
         return 'FacebookSignal.queueEvent(' .
-            wp_json_encode( $payload, JSON_PRETTY_PRINT ) .
+            wp_json_encode(
+                $payload,
+                JSON_PRETTY_PRINT | JSON_HEX_TAG | JSON_HEX_AMP |
+                    JSON_HEX_APOS | JSON_HEX_QUOT
+            ) .
             ');';
     }
 }

--- a/core/class-pixelrenderer.php
+++ b/core/class-pixelrenderer.php
@@ -160,6 +160,13 @@ class PixelRenderer {
             'is_custom'   => $is_custom,
         );
 
+        $queued_user_data = FacebookSignalState::get_queued_user_data(
+            $event->getEventId()
+        );
+        if ( null !== $queued_user_data ) {
+            $payload['user_data'] = $queued_user_data;
+        }
+
         return 'FacebookSignal.queueEvent(' .
             wp_json_encode(
                 $payload,

--- a/core/class-pixelrenderer.php
+++ b/core/class-pixelrenderer.php
@@ -95,6 +95,13 @@ class PixelRenderer {
         $event,
         $fb_integration_tracking
     ) {
+        if ( FacebookSignalState::is_paused() ) {
+            return self::get_queue_track_code(
+                $event,
+                $fb_integration_tracking
+            );
+        }
+
         $event_data[ self::EVENT_ID ] = $event->getEventId();
 
         $custom_data = $event->getCustomData() !== null ?
@@ -118,5 +125,38 @@ class PixelRenderer {
             wp_json_encode( $normalized_custom_data, JSON_PRETTY_PRINT ),
             wp_json_encode( $event_data, JSON_PRETTY_PRINT )
         );
+    }
+
+    /**
+     * Generate queueing code for a paused event.
+     *
+     * @param \FacebookPixelPlugin\Core\Event $event Event object.
+     * @param bool                            $fb_integration_tracking Tracking label.
+     *
+     * @return string
+     */
+    private static function get_queue_track_code(
+        $event,
+        $fb_integration_tracking
+    ) {
+        $custom_data            = $event->getCustomData() !== null ?
+            $event->getCustomData() : new CustomData();
+        $normalized_custom_data = $custom_data->normalize();
+
+        if ( ! is_null( $fb_integration_tracking ) ) {
+            $normalized_custom_data[ self::FB_INTEGRATION_TRACKING ] =
+                $fb_integration_tracking;
+        }
+
+        $payload = array(
+            'event_name'  => $event->getEventName(),
+            'custom_data' => $normalized_custom_data,
+            'event_id'    => $event->getEventId(),
+            'event_time'  => $event->getEventTime(),
+        );
+
+        return 'FacebookSignal.queueEvent(' .
+            wp_json_encode( $payload, JSON_PRETTY_PRINT ) .
+            ');';
     }
 }

--- a/core/class-pixelrenderer.php
+++ b/core/class-pixelrenderer.php
@@ -148,24 +148,17 @@ class PixelRenderer {
                 $fb_integration_tracking;
         }
 
-        $is_custom = ( new ReflectionClass(
-            'FacebookPixelPlugin\Core\FacebookPixel'
-        ) )->getConstant( strtoupper( $event->getEventName() ) ) === false;
-
-        $payload = array(
-            'event_name'  => $event->getEventName(),
-            'custom_data' => $normalized_custom_data,
-            'event_id'    => $event->getEventId(),
-            'event_time'  => $event->getEventTime(),
-            'is_custom'   => $is_custom,
-        );
-
-        $queued_user_data = FacebookSignalState::get_queued_user_data(
-            $event->getEventId()
-        );
-        if ( null !== $queued_user_data ) {
-            $payload['user_data'] = $queued_user_data;
+        if ( ! empty( $event->getEventId() ) ) {
+            $normalized_custom_data[ self::EVENT_ID ] = $event->getEventId();
         }
+
+        $payload               = FacebookPixel::build_queue_payload(
+            $event->getEventName(),
+            $normalized_custom_data,
+            '',
+            null
+        );
+        $payload['event_time'] = $event->getEventTime();
 
         return 'FacebookSignal.queueEvent(' .
             wp_json_encode(

--- a/core/class-resumetrackingajax.php
+++ b/core/class-resumetrackingajax.php
@@ -127,7 +127,8 @@ class ResumeTrackingAjax {
         }
 
         $event_name = sanitize_text_field( $event_data['event_name'] );
-        if ( ! in_array( $event_name, self::$allowed_events, true ) ) {
+        if ( ! in_array( $event_name, self::$allowed_events, true )
+            && ! preg_match( '/^[A-Za-z][A-Za-z0-9_]{0,49}$/', $event_name ) ) {
             return false;
         }
 

--- a/core/class-resumetrackingajax.php
+++ b/core/class-resumetrackingajax.php
@@ -45,6 +45,13 @@ class ResumeTrackingAjax {
     const RATE_LIMIT_MAX_EVENTS = 80;
 
     /**
+     * Object-cache group used by atomic rate-limit counters.
+     *
+     * @var string
+     */
+    const RATE_LIMIT_GROUP = 'fbpix_resume_tracking_rl';
+
+    /**
      * Allowed replayed event names.
      *
      * @var string[]
@@ -367,14 +374,15 @@ class ResumeTrackingAjax {
             return false;
         }
 
-        $key   = $this->get_rate_limit_key();
-        $count = (int) get_transient( $key );
-
-        return $count >= $max;
+        return $this->get_rate_limit_count() >= $max;
     }
 
     /**
      * Records that the current client just had N events accepted.
+     *
+     * Uses wp_cache_incr when a persistent object cache is available so the
+     * counter increments atomically; falls back to a transient read+write for
+     * single-process / no-object-cache installs.
      *
      * @param int $accepted_event_count Number of events accepted in this request.
      *
@@ -394,9 +402,47 @@ class ResumeTrackingAjax {
         }
 
         $key   = $this->get_rate_limit_key();
-        $count = (int) get_transient( $key );
+        $delta = (int) $accepted_event_count;
 
-        set_transient( $key, $count + (int) $accepted_event_count, $window );
+        if ( $this->using_atomic_cache() ) {
+            wp_cache_add( $key, 0, self::RATE_LIMIT_GROUP, $window );
+            if ( false === wp_cache_incr( $key, $delta, self::RATE_LIMIT_GROUP ) ) {
+                wp_cache_set( $key, $delta, self::RATE_LIMIT_GROUP, $window );
+            }
+            return;
+        }
+
+        $current = (int) get_transient( $key );
+        set_transient( $key, $current + $delta, $window );
+    }
+
+    /**
+     * Reads the current rate-limit counter for this client.
+     *
+     * @return int
+     */
+    private function get_rate_limit_count() {
+        $key = $this->get_rate_limit_key();
+
+        if ( $this->using_atomic_cache() ) {
+            $count = wp_cache_get( $key, self::RATE_LIMIT_GROUP );
+            if ( false !== $count ) {
+                return (int) $count;
+            }
+        }
+
+        return (int) get_transient( $key );
+    }
+
+    /**
+     * Whether wp_cache_incr-backed atomic increments are available.
+     *
+     * @return bool
+     */
+    private function using_atomic_cache() {
+        return function_exists( 'wp_cache_incr' )
+            && function_exists( 'wp_using_ext_object_cache' )
+            && wp_using_ext_object_cache();
     }
 
     /**

--- a/core/class-resumetrackingajax.php
+++ b/core/class-resumetrackingajax.php
@@ -18,6 +18,7 @@ namespace FacebookPixelPlugin\Core;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Content;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\CustomData;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
+use FacebookPixelPlugin\FacebookAds\Object\ServerSide\UserData;
 
 defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 
@@ -216,6 +217,24 @@ class ResumeTrackingAjax {
         $event->setCustomData( $custom_data );
         $event->setActionSource( 'website' );
 
+        if ( ! empty( $event_data['user_data'] ) && is_array( $event_data['user_data'] ) ) {
+            $forwarded = $this->build_user_data_from_payload( $event_data['user_data'] );
+            if ( null !== $forwarded ) {
+                $existing = $event->getUserData();
+                if ( null !== $existing ) {
+                    $forwarded->setFbp( $existing->getFbp() );
+                    $forwarded->setFbc( $existing->getFbc() );
+                    $forwarded->setClientIpAddress(
+                        $existing->getClientIpAddress()
+                    );
+                    $forwarded->setClientUserAgent(
+                        $existing->getClientUserAgent()
+                    );
+                }
+                $event->setUserData( $forwarded );
+            }
+        }
+
         return $event;
     }
 
@@ -292,6 +311,90 @@ class ResumeTrackingAjax {
         }
 
         return $event_custom_data;
+    }
+
+    /**
+     * Build a UserData object from a forwarded resume payload.
+     *
+     * Accepts the normalized short-key shape produced by UserData::normalize()
+     * (em, ph, ln, fn, ct, st, zp, country, external_id, etc.). Hashable PII
+     * keys are expected to already be SHA256 hashes; the SDK's normalize() at
+     * send time skips hashing for already-hashed values.
+     *
+     * @param array $user_data Forwarded user_data payload.
+     *
+     * @return UserData|null
+     */
+    private function build_user_data_from_payload( array $user_data ) {
+        $array_setters = array(
+            'em'          => 'setEmails',
+            'ph'          => 'setPhones',
+            'ge'          => 'setGenders',
+            'db'          => 'setDatesOfBirth',
+            'ln'          => 'setLastNames',
+            'fn'          => 'setFirstNames',
+            'ct'          => 'setCities',
+            'st'          => 'setStates',
+            'zp'          => 'setZipCodes',
+            'country'     => 'setCountryCodes',
+            'external_id' => 'setExternalIds',
+        );
+
+        $scalar_setters = array(
+            'subscription_id' => 'setSubscriptionId',
+            'fb_login_id'     => 'setFbLoginId',
+            'lead_id'         => 'setLeadId',
+            'f5first'         => 'setF5first',
+            'f5last'          => 'setF5last',
+            'fi'              => 'setFi',
+            'dobd'            => 'setDobd',
+            'dobm'            => 'setDobm',
+            'doby'            => 'setDoby',
+            'madid'           => 'setMadid',
+            'anon_id'         => 'setAnonId',
+            'ctwa_clid'       => 'setCtwaClid',
+            'page_id'         => 'setPageId',
+        );
+
+        $ud      = new UserData();
+        $applied = false;
+
+        foreach ( $array_setters as $key => $setter ) {
+            if ( empty( $user_data[ $key ] ) || ! is_array( $user_data[ $key ] ) ) {
+                continue;
+            }
+            $values = array();
+            foreach ( $user_data[ $key ] as $value ) {
+                if ( is_array( $value ) || is_object( $value ) ) {
+                    continue;
+                }
+                $clean = sanitize_text_field( (string) $value );
+                if ( '' !== $clean ) {
+                    $values[] = $clean;
+                }
+            }
+            if ( ! empty( $values ) ) {
+                $ud->{$setter}( $values );
+                $applied = true;
+            }
+        }
+
+        foreach ( $scalar_setters as $key => $setter ) {
+            if ( ! isset( $user_data[ $key ] ) ) {
+                continue;
+            }
+            if ( is_array( $user_data[ $key ] ) || is_object( $user_data[ $key ] ) ) {
+                continue;
+            }
+            $clean = sanitize_text_field( (string) $user_data[ $key ] );
+            if ( '' === $clean ) {
+                continue;
+            }
+            $ud->{$setter}( $clean );
+            $applied = true;
+        }
+
+        return $applied ? $ud : null;
     }
 
     /**

--- a/core/class-resumetrackingajax.php
+++ b/core/class-resumetrackingajax.php
@@ -82,6 +82,10 @@ class ResumeTrackingAjax {
             wp_send_json_error( array( 'message' => 'Invalid nonce.' ), 403 );
         }
 
+        if ( ! empty( $body['fbclid'] ) && empty( $_GET['fbclid'] ) ) {
+            $_GET['fbclid'] = sanitize_text_field( $body['fbclid'] );
+        }
+
         $events = isset( $body['events'] ) && is_array( $body['events'] ) ?
             array_slice( $body['events'], 0, self::MAX_EVENTS ) :
             array();

--- a/core/class-resumetrackingajax.php
+++ b/core/class-resumetrackingajax.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * Copyright (C) 2017-present, Meta, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * @package FacebookPixelPlugin
+ */
+
+namespace FacebookPixelPlugin\Core;
+
+use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Content;
+use FacebookPixelPlugin\FacebookAds\Object\ServerSide\CustomData;
+use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
+
+defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
+
+/**
+ * AJAX endpoint for replaying queued events after signals grant.
+ */
+class ResumeTrackingAjax {
+    const ACTION        = 'fbpix_resume_tracking';
+    const NONCE_ACTION  = 'fbpix_resume_tracking';
+    const MAX_EVENTS    = 20;
+    const MAX_EVENT_AGE = 1800;
+
+    /**
+     * Allowed replayed event names.
+     *
+     * @var string[]
+     */
+    private static $allowed_events = array(
+        'PageView',
+        'ViewContent',
+        'Search',
+        'AddToCart',
+        'AddToWishlist',
+        'InitiateCheckout',
+        'AddPaymentInfo',
+        'Purchase',
+        'Lead',
+        'CompleteRegistration',
+        'Contact',
+        'CustomizeProduct',
+        'Donate',
+        'FindLocation',
+        'Schedule',
+        'StartTrial',
+        'SubmitApplication',
+        'Subscribe',
+    );
+
+    /**
+     * Register AJAX handlers.
+     */
+    public function __construct() {
+        add_action( 'wp_ajax_' . self::ACTION, array( $this, 'handle' ) );
+        add_action( 'wp_ajax_nopriv_' . self::ACTION, array( $this, 'handle' ) );
+    }
+
+    /**
+     * Process queued event replay.
+     *
+     * @return void
+     */
+    public function handle() {
+        $body = json_decode( file_get_contents( 'php://input' ), true );
+
+        if ( ! is_array( $body ) ) {
+            wp_send_json_error( array( 'message' => 'Invalid request body.' ), 400 );
+        }
+
+        $nonce = isset( $body['security'] ) ?
+            sanitize_text_field( $body['security'] ) : '';
+        if ( ! wp_verify_nonce( $nonce, self::NONCE_ACTION ) ) {
+            wp_send_json_error( array( 'message' => 'Invalid nonce.' ), 403 );
+        }
+
+        $events = isset( $body['events'] ) && is_array( $body['events'] ) ?
+            array_slice( $body['events'], 0, self::MAX_EVENTS ) :
+            array();
+        $now    = time();
+
+        $events_to_send = array();
+        foreach ( $events as $event_data ) {
+            if ( ! $this->validate_event( $event_data, $now ) ) {
+                continue;
+            }
+
+            $events_to_send[] = $this->build_event( $event_data );
+        }
+
+        if ( ! empty( $events_to_send ) ) {
+            FacebookServerSideEvent::send( $events_to_send );
+        }
+
+        wp_send_json_success(
+            array(
+                'fbp'        => ServerEventFactory::get_fbp_value(),
+                'fbc'        => ServerEventFactory::get_fbc_value(),
+                'sent_count' => count( $events_to_send ),
+            )
+        );
+    }
+
+    /**
+     * Validate incoming queued event.
+     *
+     * @param mixed $event_data Event payload.
+     * @param int   $now        Current timestamp.
+     *
+     * @return bool
+     */
+    private function validate_event( $event_data, $now ) {
+        if ( ! is_array( $event_data ) || empty( $event_data['event_name'] ) ) {
+            return false;
+        }
+
+        $event_name = sanitize_text_field( $event_data['event_name'] );
+        if ( ! in_array( $event_name, self::$allowed_events, true ) ) {
+            return false;
+        }
+
+        if ( ! empty( $event_data['event_time'] ) ) {
+            $event_time = absint( $event_data['event_time'] );
+            if ( $event_time > $now || ( $now - $event_time ) > self::MAX_EVENT_AGE ) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Build replay event from queue payload.
+     *
+     * @param array $event_data Event payload.
+     *
+     * @return Event
+     */
+    private function build_event( $event_data ) {
+        $event_name = sanitize_text_field( $event_data['event_name'] );
+        $event      = ServerEventFactory::new_event( $event_name );
+
+        if ( ! empty( $event_data['event_time'] ) ) {
+            $event->setEventTime( absint( $event_data['event_time'] ) );
+        }
+
+        if ( ! empty( $event_data['event_id'] ) ) {
+            $event->setEventId(
+                sanitize_text_field( $event_data['event_id'] )
+            );
+        }
+
+        if ( ! empty( $event_data['event_source_url'] ) ) {
+            $event->setEventSourceUrl(
+                esc_url_raw( $event_data['event_source_url'] )
+            );
+        }
+
+        $custom_data = isset( $event_data['custom_data'] ) &&
+            is_array( $event_data['custom_data'] ) ?
+            $this->build_custom_data( $event_data['custom_data'] ) :
+            new CustomData();
+
+        $event->setCustomData( $custom_data );
+        $event->setActionSource( 'website' );
+
+        return $event;
+    }
+
+    /**
+     * Build custom data object from queue payload.
+     *
+     * @param array $custom_data Event custom data.
+     *
+     * @return CustomData
+     */
+    private function build_custom_data( $custom_data ) {
+        $sanitized  = array();
+        $extra_data = array();
+        $valid_keys = array(
+            'value',
+            'net_revenue',
+            'currency',
+            'content_name',
+            'content_category',
+            'content_ids',
+            'contents',
+            'content_type',
+            'order_id',
+            'predicted_ltv',
+            'num_items',
+            'status',
+            'search_string',
+            'item_number',
+            'delivery_category',
+        );
+
+        foreach ( $custom_data as $key => $value ) {
+            $key = sanitize_text_field( $key );
+            if ( 'contents' === $key && is_array( $value ) ) {
+                $sanitized[ $key ] = $value;
+                continue;
+            }
+
+            if ( is_array( $value ) ) {
+                $value = array_map(
+                    array( $this, 'sanitize_scalar_or_array_value' ),
+                    $value
+                );
+            } else {
+                $value = $this->sanitize_scalar_or_array_value( $value );
+            }
+
+            if ( in_array( $key, $valid_keys, true ) ) {
+                $sanitized[ $key ] = $value;
+            } else {
+                $extra_data[ $key ] = $value;
+            }
+        }
+
+        $event_custom_data = new CustomData( $sanitized );
+
+        if ( isset( $sanitized['contents'] ) ) {
+            $contents = array();
+            foreach ( $sanitized['contents'] as $content_as_array ) {
+                if ( ! is_array( $content_as_array ) ) {
+                    continue;
+                }
+                if ( isset( $content_as_array['id'] ) &&
+                    ! isset( $content_as_array['product_id'] ) ) {
+                    $content_as_array['product_id'] = $content_as_array['id'];
+                }
+                $contents[] = new Content( $content_as_array );
+            }
+            $event_custom_data->setContents( $contents );
+        }
+
+        foreach ( $extra_data as $key => $value ) {
+            $event_custom_data->addCustomProperty( $key, $value );
+        }
+
+        return $event_custom_data;
+    }
+
+    /**
+     * Sanitize scalar value recursively.
+     *
+     * @param mixed $value Value to sanitize.
+     *
+     * @return mixed
+     */
+    private function sanitize_scalar_or_array_value( $value ) {
+        if ( is_array( $value ) ) {
+            return array_map(
+                array( $this, 'sanitize_scalar_or_array_value' ),
+                $value
+            );
+        }
+
+        if ( is_numeric( $value ) ) {
+            return $value + 0;
+        }
+
+        return sanitize_text_field( (string) $value );
+    }
+}

--- a/core/class-resumetrackingajax.php
+++ b/core/class-resumetrackingajax.php
@@ -31,6 +31,20 @@ class ResumeTrackingAjax {
     const MAX_EVENT_AGE = 1800;
 
     /**
+     * Default rate-limit window in seconds (5 minutes).
+     *
+     * @var int
+     */
+    const RATE_LIMIT_WINDOW = 300;
+
+    /**
+     * Default maximum accepted events per IP per window.
+     *
+     * @var int
+     */
+    const RATE_LIMIT_MAX_EVENTS = 80;
+
+    /**
      * Allowed replayed event names.
      *
      * @var string[]
@@ -82,6 +96,10 @@ class ResumeTrackingAjax {
             wp_send_json_error( array( 'message' => 'Invalid nonce.' ), 403 );
         }
 
+        if ( $this->is_rate_limited() ) {
+            wp_send_json_error( array( 'message' => 'Rate limit exceeded.' ), 429 );
+        }
+
         if ( ! empty( $body['fbclid'] ) && empty( $_GET['fbclid'] ) ) {
             $_GET['fbclid'] = sanitize_text_field( $body['fbclid'] );
         }
@@ -101,6 +119,7 @@ class ResumeTrackingAjax {
         }
 
         if ( ! empty( $events_to_send ) ) {
+            $this->record_rate_limit_usage( count( $events_to_send ) );
             FacebookServerSideEvent::send( $events_to_send );
         }
 
@@ -275,5 +294,67 @@ class ResumeTrackingAjax {
         }
 
         return sanitize_text_field( (string) $value );
+    }
+
+    /**
+     * Whether the current client is over its resume-tracking rate limit.
+     *
+     * Counts accepted events (not requests) per IP per window. Both the
+     * window length and the cap are filterable.
+     *
+     * @return bool
+     */
+    private function is_rate_limited() {
+        $max = (int) apply_filters(
+            'fbpix_resume_tracking_rate_limit_max',
+            self::RATE_LIMIT_MAX_EVENTS
+        );
+
+        if ( $max <= 0 ) {
+            return false;
+        }
+
+        $key   = $this->get_rate_limit_key();
+        $count = (int) get_transient( $key );
+
+        return $count >= $max;
+    }
+
+    /**
+     * Records that the current client just had N events accepted.
+     *
+     * @param int $accepted_event_count Number of events accepted in this request.
+     *
+     * @return void
+     */
+    private function record_rate_limit_usage( $accepted_event_count ) {
+        if ( $accepted_event_count <= 0 ) {
+            return;
+        }
+
+        $window = (int) apply_filters(
+            'fbpix_resume_tracking_rate_limit_window',
+            self::RATE_LIMIT_WINDOW
+        );
+        if ( $window <= 0 ) {
+            return;
+        }
+
+        $key   = $this->get_rate_limit_key();
+        $count = (int) get_transient( $key );
+
+        set_transient( $key, $count + (int) $accepted_event_count, $window );
+    }
+
+    /**
+     * Builds a transient key scoped to the requesting client IP.
+     *
+     * @return string
+     */
+    private function get_rate_limit_key() {
+        $ip = isset( $_SERVER['REMOTE_ADDR'] ) ?
+            sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) :
+            '';
+        return 'fbpix_resume_tracking_rl_' . md5( $ip );
     }
 }

--- a/core/class-resumetrackingajax.php
+++ b/core/class-resumetrackingajax.php
@@ -100,9 +100,18 @@ class ResumeTrackingAjax {
             wp_send_json_error( array( 'message' => 'Rate limit exceeded.' ), 429 );
         }
 
-        if ( ! empty( $body['fbclid'] ) && empty( $_GET['fbclid'] ) ) {
-            $_GET['fbclid'] = sanitize_text_field( $body['fbclid'] );
-        }
+        $fbclid = ! empty( $body['fbclid'] ) ?
+            sanitize_text_field( $body['fbclid'] ) : '';
+        $fbp    = ! empty( $body['fbp'] ) ?
+            sanitize_text_field( $body['fbp'] ) : '';
+        $fbc    = ! empty( $body['fbc'] ) ?
+            sanitize_text_field( $body['fbc'] ) : '';
+
+        // Expose queued attribution to ServerEventFactory so resumed events
+        // share the same attribution path as normal CAPI events.
+        $restore_get_fbclid = $this->temporarily_set_superglobal_value( '_GET', 'fbclid', $fbclid );
+        $restore_cookie_fbp = $this->temporarily_set_superglobal_value( '_COOKIE', '_fbp', $fbp );
+        $restore_cookie_fbc = $this->temporarily_set_superglobal_value( '_COOKIE', '_fbc', $fbc );
 
         $events = isset( $body['events'] ) && is_array( $body['events'] ) ?
             array_slice( $body['events'], 0, self::MAX_EVENTS ) :
@@ -117,6 +126,10 @@ class ResumeTrackingAjax {
 
             $events_to_send[] = $this->build_event( $event_data );
         }
+
+        $this->restore_superglobal_value( '_GET', 'fbclid', $restore_get_fbclid );
+        $this->restore_superglobal_value( '_COOKIE', '_fbp', $restore_cookie_fbp );
+        $this->restore_superglobal_value( '_COOKIE', '_fbc', $restore_cookie_fbc );
 
         if ( ! empty( $events_to_send ) ) {
             $this->record_rate_limit_usage( count( $events_to_send ) );
@@ -294,6 +307,46 @@ class ResumeTrackingAjax {
         }
 
         return sanitize_text_field( (string) $value );
+    }
+
+    /**
+     * Temporarily sets a superglobal value and returns data needed to restore it.
+     *
+     * @param string $superglobal Superglobal name without dollar sign.
+     * @param string $key         Key to set.
+     * @param string $value       Value to set; empty string is a no-op.
+     *
+     * @return array
+     */
+    private function temporarily_set_superglobal_value( $superglobal, $key, $value ) {
+        $had_value = isset( $GLOBALS[ $superglobal ][ $key ] );
+        $original  = $had_value ? $GLOBALS[ $superglobal ][ $key ] : null;
+
+        if ( '' !== $value && null !== $value ) {
+            $GLOBALS[ $superglobal ][ $key ] = $value;
+        }
+
+        return array(
+            'had_value' => $had_value,
+            'original'  => $original,
+        );
+    }
+
+    /**
+     * Restores a superglobal value saved by temporarily_set_superglobal_value().
+     *
+     * @param string $superglobal Superglobal name without dollar sign.
+     * @param string $key         Key to restore.
+     * @param array  $restore     Restore data.
+     *
+     * @return void
+     */
+    private function restore_superglobal_value( $superglobal, $key, $restore ) {
+        if ( ! empty( $restore['had_value'] ) ) {
+            $GLOBALS[ $superglobal ][ $key ] = $restore['original'];
+        } else {
+            unset( $GLOBALS[ $superglobal ][ $key ] );
+        }
     }
 
     /**

--- a/core/class-resumetrackingajax.php
+++ b/core/class-resumetrackingajax.php
@@ -268,11 +268,6 @@ class ResumeTrackingAjax {
 
         foreach ( $custom_data as $key => $value ) {
             $key = sanitize_text_field( $key );
-            if ( 'contents' === $key && is_array( $value ) ) {
-                $sanitized[ $key ] = $value;
-                continue;
-            }
-
             if ( is_array( $value ) ) {
                 $value = array_map(
                     array( $this, 'sanitize_scalar_or_array_value' ),

--- a/core/class-servereventfactory.php
+++ b/core/class-servereventfactory.php
@@ -174,6 +174,15 @@ class ServerEventFactory {
   }
 
     /**
+     * Public wrapper for the current request's FBP value.
+     *
+     * @return string|null
+     */
+    public static function get_fbp_value() {
+        return self::get_fbp();
+    }
+
+    /**
      * Retrieves the Facebook Click ID (FBC) cookie or session variable.
      *
      * This function returns the value of the FBC cookie or session variable,
@@ -211,6 +220,15 @@ class ServerEventFactory {
         }
 
         return $fbc;
+    }
+
+    /**
+     * Public wrapper for the current request's FBC value.
+     *
+     * @return string|null
+     */
+    public static function get_fbc_value() {
+        return self::get_fbc();
     }
 
     /**

--- a/facebook-for-wordpress.php
+++ b/facebook-for-wordpress.php
@@ -35,15 +35,21 @@ if ( file_exists( $local_config ) ) {
 }
 
 require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
+require_once plugin_dir_path( __FILE__ ) . 'core/class-facebookpixelsignals.php';
+require_once plugin_dir_path( __FILE__ ) . 'core/class-facebooksignalstate.php';
+require_once plugin_dir_path( __FILE__ ) . 'core/class-resumetrackingajax.php';
 
 use FacebookPixelPlugin\Core\FacebookPixel;
+use FacebookPixelPlugin\Core\FacebookPixelSignals;
 use FacebookPixelPlugin\Core\FacebookPluginConfig;
 use FacebookPixelPlugin\Core\FacebookPluginUtils;
+use FacebookPixelPlugin\Core\FacebookSignalState;
 use FacebookPixelPlugin\Core\FacebookWordpressOpenBridge;
 use FacebookPixelPlugin\Core\FacebookWordpressOptions;
 use FacebookPixelPlugin\Core\FacebookWordpressPixelInjection;
 use FacebookPixelPlugin\Core\FacebookWordpressSettingsPage;
 use FacebookPixelPlugin\Core\FacebookWordpressSettingsRecorder;
+use FacebookPixelPlugin\Core\ResumeTrackingAjax;
 use FacebookPixelPlugin\Core\ServerEventAsyncTask;
 
 /**
@@ -66,6 +72,12 @@ class FacebookForWordpress {
 
     $options = FacebookWordpressOptions::get_options();
     FacebookPixel::initialize( FacebookWordpressOptions::get_active_pixel_id() );
+    new FacebookPixelSignals();
+    new ResumeTrackingAjax();
+
+    if ( FacebookPixelSignals::should_pause_tracking() ) {
+        FacebookSignalState::pause();
+    }
 
     add_action( 'init', array( $this, 'register_pixel_injection' ), 0 );
     add_action( 'parse_request', array( $this, 'handle_events_request' ), 0 );

--- a/integration/class-facebookwordpresseasydigitaldownloads.php
+++ b/integration/class-facebookwordpresseasydigitaldownloads.php
@@ -36,6 +36,7 @@ use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 use FacebookPixelPlugin\Core\PixelRenderer;
 use FacebookPixelPlugin\Core\FacebookWordpressOptions;
 use FacebookPixelPlugin\Core\EventIdGenerator;
+use FacebookPixelPlugin\Core\FacebookSignalState;
 
 /**
  * FacebookWordpressEasyDigitalDownloads class.
@@ -206,6 +207,7 @@ class FacebookWordpressEasyDigitalDownloads extends FacebookWordpressIntegration
                 'trackingName'     => self::TRACKING_NAME,
                 'agentString'      => FacebookWordpressOptions::get_agent_string(),
                 'pixelId'          => FacebookWordpressOptions::get_active_pixel_id(),
+                'paused'           => FacebookSignalState::is_paused(),
             )
         );
 

--- a/js/facebook_pixel_add_to_cart.js
+++ b/js/facebook_pixel_add_to_cart.js
@@ -1,38 +1,59 @@
 jQuery(document).ready(function ($) {
-    $('.edd-add-to-cart').click(function (e) {
-        e.preventDefault();
+  $('.edd-add-to-cart').click(function (e) {
+    e.preventDefault();
 
-        var _this = $(this), form = _this.closest('form');
-        var download = _this.data('download-id');
-        var currency = $('.edd_purchase_' + download + ' meta[itemprop="priceCurrency\']').attr('content');
-        var form = _this.parents('form').last();
-        var value = 0;
-        var variable_price = _this.data('variable-price');
-        var event_id = form.find("input[name='facebook_event_id']").val();
+    var integrationKey =
+      facebookPixelData.fbIntegrationKey ||
+      facebookPixelData.fb_integration_key;
+    var trackingName =
+      facebookPixelData.trackingName || facebookPixelData.tracking_name;
+    var agentString =
+      facebookPixelData.agentString || facebookPixelData.agent_string;
+    var pixelId = facebookPixelData.pixelId || facebookPixelData.pixel_id;
+    var _this = $(this),
+      form = _this.closest('form');
+    var download = _this.data('download-id');
+    var currency = $(
+      '.edd_purchase_' + download + ' meta[itemprop="priceCurrency\']',
+    ).attr('content');
+    var form = _this.parents('form').last();
+    var value = 0;
+    var variable_price = _this.data('variable-price');
+    var event_id = form.find("input[name='facebook_event_id']").val();
 
-        if (variable_price == 'yes') {
-            form.find('.edd_price_option_' + download + ':checked', form).each(function (index) {
-                value = $(this).data('price');
-            });
-        } else {
-            if (_this.data('price') && _this.data('price') > 0) {
-                value = _this.data('price');
-            }
-        }
+    if (variable_price == 'yes') {
+      form
+        .find('.edd_price_option_' + download + ':checked', form)
+        .each(function (index) {
+          value = $(this).data('price');
+        });
+    } else {
+      if (_this.data('price') && _this.data('price') > 0) {
+        value = _this.data('price');
+      }
+    }
 
-        var param = {
-            'content_ids': [download],
-            'content_type': 'product',
-            'currency': currency,
-            'fb_integration_key': facebookPixelData.fb_integration_key,
-            'value': value
-        };
+    var param = {
+      content_ids: [download],
+      content_type: 'product',
+      currency: currency,
+      fb_integration_tracking: trackingName || integrationKey,
+      value: value,
+    };
 
-        fbq('set', 'agent', facebookPixelData.agent_string, facebookPixelData.pixel_id);
-        if (event_id) {
-            fbq('track', 'AddToCart', param, { 'eventID': event_id });
-        } else {
-            fbq('track', 'AddToCart', param);
-        }
-    });
+    if (window.FacebookSignal && window.FacebookSignal._paused) {
+      if (event_id) {
+        param.eventID = event_id;
+      }
+      window.FacebookSignal.trackEvent('AddToCart', param);
+      return;
+    }
+
+    fbq('set', 'agent', agentString, pixelId);
+    if (event_id) {
+      fbq('track', 'AddToCart', param, { eventID: event_id });
+    } else {
+      fbq('track', 'AddToCart', param);
+    }
+  });
 });

--- a/js/facebook_signal.js
+++ b/js/facebook_signal.js
@@ -1,0 +1,269 @@
+window.FacebookSignal = window.FacebookSignal || {
+  _paused: false,
+  _queue: [],
+  _config: {},
+  _seenEventIds: {},
+  _fbclid: (function () {
+    try {
+      var match = window.location.search.match(/[?&]fbclid=([^&]*)/);
+      return match ? decodeURIComponent(match[1]) : null;
+    } catch (e) {
+      return null;
+    }
+  })(),
+
+  _readCookie: function (name) {
+    try {
+      var pairs = (document.cookie || '').split(';');
+      for (var i = 0; i < pairs.length; i++) {
+        var pair = pairs[i].replace(/^\s+/, '');
+        if (pair.indexOf(name + '=') === 0) {
+          return decodeURIComponent(pair.substring(name.length + 1));
+        }
+      }
+    } catch (e) {}
+    return null;
+  },
+
+  init: function (config) {
+    this._config = config || {};
+    this._paused = !!this._config.paused;
+
+    try {
+      var raw = window.sessionStorage.getItem('fbpix_seen_event_ids');
+      this._seenEventIds = raw ? JSON.parse(raw) : {};
+    } catch (e) {
+      this._seenEventIds = this._seenEventIds || {};
+    }
+  },
+
+  queueEvent: function (eventData) {
+    if (!eventData || !eventData.event_name) {
+      return;
+    }
+
+    if (eventData.event_id && this._seenEventIds[eventData.event_id]) {
+      return;
+    }
+
+    eventData.event_time =
+      eventData.event_time || Math.floor(Date.now() / 1000);
+    eventData.event_source_url =
+      eventData.event_source_url || window.location.href;
+    this._queue.push(eventData);
+
+    if (eventData.event_id) {
+      this._seenEventIds[eventData.event_id] = 1;
+      try {
+        window.sessionStorage.setItem(
+          'fbpix_seen_event_ids',
+          JSON.stringify(this._seenEventIds),
+        );
+      } catch (e) {}
+    }
+  },
+
+  trackEvent: function (name, params, userData) {
+    var eventParams = params ? Object.assign({}, params) : {};
+    var eventId = eventParams.eventID || null;
+
+    if (eventId) {
+      delete eventParams.eventID;
+    }
+
+    if (this._paused) {
+      this.queueEvent({
+        event_name: name,
+        custom_data: eventParams,
+        user_data: userData || null,
+        event_id: eventId,
+      });
+      return;
+    }
+
+    if (eventId) {
+      fbq('track', name, eventParams, { eventID: eventId });
+    } else {
+      fbq('track', name, eventParams);
+    }
+  },
+
+  setPaused: function (paused) {
+    this._paused = !!paused;
+    if (this._paused) {
+      fbq('consent', 'revoke');
+    }
+  },
+
+  resume: function () {
+    var self = this;
+
+    if (!self._paused || !self._config.ajaxUrl) {
+      return Promise.resolve({ success: true, data: { sent_count: 0 } });
+    }
+
+    return new Promise(function (resolve, reject) {
+      var xhr = new XMLHttpRequest();
+      var url =
+        self._config.ajaxUrl +
+        (self._config.ajaxUrl.indexOf('?') === -1 ? '?' : '&') +
+        'action=' +
+        encodeURIComponent(self._config.resumeAction);
+
+      xhr.open('POST', url, true);
+      xhr.setRequestHeader('Content-Type', 'application/json');
+      xhr.onload = function () {
+        if (xhr.status < 200 || xhr.status >= 300) {
+          reject(new Error('Resume AJAX failed: ' + xhr.status));
+          return;
+        }
+
+        try {
+          var response = JSON.parse(xhr.responseText);
+          self._handleResumeResponse(response.data || {});
+          resolve(response);
+        } catch (error) {
+          reject(error);
+        }
+      };
+      xhr.onerror = function () {
+        reject(new Error('Network error'));
+      };
+      xhr.send(
+        JSON.stringify({
+          security: self._config.resumeNonce,
+          events: self._queue,
+          fbclid: self._fbclid,
+          fbp: self._readCookie('_fbp'),
+          fbc: self._readCookie('_fbc'),
+        }),
+      );
+    });
+  },
+
+  _handleResumeResponse: function (data) {
+    if (data.fbp) {
+      document.cookie =
+        '_fbp=' +
+        encodeURIComponent(data.fbp) +
+        ';path=/;max-age=7776000;SameSite=Lax';
+    }
+
+    if (data.fbc) {
+      document.cookie =
+        '_fbc=' +
+        encodeURIComponent(data.fbc) +
+        ';path=/;max-age=7776000;SameSite=Lax';
+    }
+
+    fbq('consent', 'grant');
+
+    for (var i = 0; i < this._queue.length; i++) {
+      var queuedEvent = this._queue[i];
+      var customData = queuedEvent.custom_data || {};
+      var trackMethod = queuedEvent.is_custom ? 'trackCustom' : 'track';
+      if (queuedEvent.event_id) {
+        fbq(trackMethod, queuedEvent.event_name, customData, {
+          eventID: queuedEvent.event_id,
+        });
+      } else {
+        fbq(trackMethod, queuedEvent.event_name, customData);
+      }
+    }
+
+    this._queue = [];
+    this._paused = false;
+  },
+};
+
+window.fbpix = window.fbpix || {};
+(function (api) {
+  var signalConfig = window.facebookSignalConfig || {};
+  var cookieName = signalConfig.cookieName || '';
+  var ajaxUrl = signalConfig.ajaxUrl || '';
+  var signalsAction = signalConfig.signalsAction || '';
+  var signalsNonce = signalConfig.signalsNonce || '';
+
+  function setCookie(value) {
+    var expires = new Date();
+    expires.setTime(expires.getTime() + 365 * 24 * 60 * 60 * 1000);
+    document.cookie =
+      cookieName +
+      '=' +
+      encodeURIComponent(value) +
+      ';expires=' +
+      expires.toUTCString() +
+      ';path=/;SameSite=Lax';
+  }
+
+  function getCookie() {
+    var match = document.cookie.match(
+      new RegExp('(?:^|;\\s*)' + cookieName + '=([^;]*)'),
+    );
+    return match ? decodeURIComponent(match[1]) : null;
+  }
+
+  api.setSignals = function (granted) {
+    var value = granted ? '1' : '0';
+    setCookie(value);
+
+    return new Promise(function (resolve, reject) {
+      var xhr = new XMLHttpRequest();
+      xhr.open('POST', ajaxUrl, true);
+      xhr.setRequestHeader(
+        'Content-Type',
+        'application/x-www-form-urlencoded; charset=UTF-8',
+      );
+      xhr.onload = function () {
+        if (xhr.status < 200 || xhr.status >= 300) {
+          reject(new Error('Signals AJAX failed: ' + xhr.status));
+          return;
+        }
+
+        try {
+          var response = JSON.parse(xhr.responseText);
+          if (!granted) {
+            window.FacebookSignal.setPaused(true);
+            resolve(response);
+            return;
+          }
+
+          if (window.FacebookSignal && window.FacebookSignal._paused) {
+            window.FacebookSignal.resume().then(
+              function () {
+                resolve(response);
+              },
+              function (error) {
+                reject(error);
+              },
+            );
+            return;
+          }
+
+          resolve(response);
+        } catch (error) {
+          reject(error);
+        }
+      };
+      xhr.onerror = function () {
+        reject(new Error('Network error'));
+      };
+      xhr.send(
+        'action=' +
+          encodeURIComponent(signalsAction) +
+          '&security=' +
+          encodeURIComponent(signalsNonce) +
+          '&granted=' +
+          encodeURIComponent(value),
+      );
+    });
+  };
+
+  api.getSignals = function () {
+    var value = getCookie();
+    if (value === null) {
+      return null;
+    }
+    return value === '1';
+  };
+})(window.fbpix);


### PR DESCRIPTION
## Description

This changeset adds first-party signal hold/release controls so a plugin or theme integration can pause Pixel + CAPI delivery on the current site and replay queued events when signals are released.

- New frontend commands: `window.fbpix.setSignals()` and `window.fbpix.getSignals()`.
- While paused:
    - Pixel events are queued client-side.
    - Frontend CAPI sends are suppressed (admin/cron still send).
- On resume:
    - Queued events are replayed through Pixel and CAPI.
    - Attribution (`_fbp`, `_fbc`) is preserved.

### Type of change

- New feature (non-breaking change which adds functionality)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/b2b0midg)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary).


## Changelog entry

Add Signal state controls for Pixel and CAPI


## Test Plan

- Default/resumed state: Pixel and CAPI send events.
- Pause signals: no Pixel or CAPI sends; events added to queue.
- Resume signals: queued events replay via Pixel and CAPI.
- Verify `_fbp` and `_fbc` handling on replay.
- Verify rate limit returns HTTP 429 when exceeded.
- Verify admin/cron CAPI events still send while paused.