### PR TITLE
Update signal held-state method naming to use hold/release terminology

### DIFF
--- a/__tests__/FacebookWordpressTestBase.php
+++ b/__tests__/FacebookWordpressTestBase.php
@@ -77,7 +77,7 @@ abstract class FacebookWordpressTestBase extends TestCase {
         $_COOKIE                = array();
         $_POST                  = array();
         $_SESSION               = array();
-        FacebookSignalState::resume();
+        FacebookSignalState::release();
     }
 
     /**

--- a/__tests__/bootstrap.php
+++ b/__tests__/bootstrap.php
@@ -28,7 +28,7 @@ if ( ! defined( 'YEAR_IN_SECONDS' ) ) {
     define( 'YEAR_IN_SECONDS', 365 * 24 * 60 * 60 );
 }
 
-require_once __DIR__ . '/../core/class-facebookpixelsignals.php';
+require_once __DIR__ . '/../core/class-signals.php';
 require_once __DIR__ . '/../core/class-facebooksignalstate.php';
 require_once __DIR__ . '/../core/class-releasesignalsajax.php';
 

--- a/__tests__/bootstrap.php
+++ b/__tests__/bootstrap.php
@@ -30,6 +30,6 @@ if ( ! defined( 'YEAR_IN_SECONDS' ) ) {
 
 require_once __DIR__ . '/../core/class-facebookpixelsignals.php';
 require_once __DIR__ . '/../core/class-facebooksignalstate.php';
-require_once __DIR__ . '/../core/class-resumetrackingajax.php';
+require_once __DIR__ . '/../core/class-releasesignalsajax.php';
 
 WP_Mock::bootstrap();

--- a/__tests__/core/FacebookPixelSignalsTest.php
+++ b/__tests__/core/FacebookPixelSignalsTest.php
@@ -62,7 +62,7 @@ final class FacebookPixelSignalsTest extends FacebookWordpressTestBase {
    * @return void
    */
   public function testHandleSetSignalsUpdatesCookieState() {
-    $_POST['granted'] = '1';
+    $_POST['state'] = 'active';
 
     \WP_Mock::userFunction(
       'check_ajax_referer',
@@ -106,6 +106,6 @@ final class FacebookPixelSignalsTest extends FacebookWordpressTestBase {
       FacebookPixelSignals::STATE_ACTIVE,
       $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ]
     );
-    $this->assertEquals( array( 'granted' => true ), $captured_payload );
+    $this->assertEquals( array( 'state' => 'active' ), $captured_payload );
   }
 }

--- a/__tests__/core/FacebookPixelSignalsTest.php
+++ b/__tests__/core/FacebookPixelSignalsTest.php
@@ -38,16 +38,22 @@ final class FacebookPixelSignalsTest extends FacebookWordpressTestBase {
       )
     );
 
-    $this->assertNull( FacebookPixelSignals::get_signals_state() );
-    $this->assertFalse( FacebookPixelSignals::should_pause_tracking() );
+    $this->assertNull( FacebookPixelSignals::get_signal_state() );
+    $this->assertFalse( FacebookPixelSignals::should_hold_signals() );
 
-    $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ] = '0';
-    $this->assertFalse( FacebookPixelSignals::get_signals_state() );
-    $this->assertTrue( FacebookPixelSignals::should_pause_tracking() );
+    $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ] = FacebookPixelSignals::STATE_HELD;
+    $this->assertSame(
+      FacebookPixelSignals::STATE_HELD,
+      FacebookPixelSignals::get_signal_state()
+    );
+    $this->assertTrue( FacebookPixelSignals::should_hold_signals() );
 
-    $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ] = '1';
-    $this->assertTrue( FacebookPixelSignals::get_signals_state() );
-    $this->assertFalse( FacebookPixelSignals::should_pause_tracking() );
+    $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ] = FacebookPixelSignals::STATE_ACTIVE;
+    $this->assertSame(
+      FacebookPixelSignals::STATE_ACTIVE,
+      FacebookPixelSignals::get_signal_state()
+    );
+    $this->assertFalse( FacebookPixelSignals::should_hold_signals() );
   }
 
   /**
@@ -94,9 +100,12 @@ final class FacebookPixelSignalsTest extends FacebookWordpressTestBase {
     );
 
     $handler = new FacebookPixelSignals();
-    $handler->handle_set_signals();
+    $handler->handle_update_state();
 
-    $this->assertEquals( '1', $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ] );
+    $this->assertEquals(
+      FacebookPixelSignals::STATE_ACTIVE,
+      $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ]
+    );
     $this->assertEquals( array( 'granted' => true ), $captured_payload );
   }
 }

--- a/__tests__/core/FacebookPixelSignalsTest.php
+++ b/__tests__/core/FacebookPixelSignalsTest.php
@@ -108,4 +108,69 @@ final class FacebookPixelSignalsTest extends FacebookWordpressTestBase {
     );
     $this->assertEquals( array( 'state' => 'active' ), $captured_payload );
   }
+
+  /**
+   * Test that an unrecognised cookie value is treated as unset by all predicates.
+   *
+   * @return void
+   */
+  public function testUnrecognisedCookieValueTreatedAsUnset() {
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'return' => function ( $value ) {
+          return $value;
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_unslash',
+      array(
+        'return' => function ( $value ) {
+          return $value;
+        },
+      )
+    );
+
+    $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ] = 'garbage';
+    $this->assertNull( FacebookPixelSignals::get_signal_state() );
+    $this->assertFalse( FacebookPixelSignals::is_signals_active() );
+    $this->assertFalse( FacebookPixelSignals::should_hold_signals() );
+  }
+
+  /**
+   * Test is_signals_active() mirrors should_hold_signals() inverse.
+   *
+   * @return void
+   */
+  public function testIsSignalsActiveReturnsTrueOnlyWhenActive() {
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'return' => function ( $value ) {
+          return $value;
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_unslash',
+      array(
+        'return' => function ( $value ) {
+          return $value;
+        },
+      )
+    );
+
+    // Unset cookie — neither active nor held.
+    unset( $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ] );
+    $this->assertFalse( FacebookPixelSignals::is_signals_active() );
+
+    // Explicitly held.
+    $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ] = FacebookPixelSignals::STATE_HELD;
+    $this->assertFalse( FacebookPixelSignals::is_signals_active() );
+
+    // Explicitly active.
+    $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ] = FacebookPixelSignals::STATE_ACTIVE;
+    $this->assertTrue( FacebookPixelSignals::is_signals_active() );
+  }
 }

--- a/__tests__/core/FacebookServerSideEventTest.php
+++ b/__tests__/core/FacebookServerSideEventTest.php
@@ -182,11 +182,11 @@ final class FacebookServerSideEventTest extends FacebookWordpressTestBase {
   }
 
   /**
-   * Tests that frontend sends are suppressed while tracking is paused.
+   * Tests that frontend sends are suppressed while signals are held.
    *
    * @return void
    */
-  public function testSendSuppressedWhenPausedOnFrontend() {
+  public function testSendSuppressedWhenHeldOnFrontend() {
     self::mockFacebookWordpressOptions();
 
     \WP_Mock::userFunction(
@@ -202,7 +202,7 @@ final class FacebookServerSideEventTest extends FacebookWordpressTestBase {
     \WP_Mock::userFunction( 'is_admin', array( 'return' => false ) );
     \WP_Mock::userFunction( 'wp_doing_cron', array( 'return' => false ) );
 
-    FacebookSignalState::pause();
+    FacebookSignalState::hold();
 
     $api = \Mockery::mock( 'alias:FacebookPixelPlugin\FacebookAds\Api' );
     $api->shouldReceive( 'init' )->never();

--- a/__tests__/core/FacebookWordpressPixelInjectionTest.php
+++ b/__tests__/core/FacebookWordpressPixelInjectionTest.php
@@ -266,7 +266,8 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
    */
   public function testHeldInitCodeIncludesCapturedAttribution() {
     FacebookSignalState::hold();
-    FacebookSignalState::set_attribution_data( 'fbc', 'fb.1.123.test' );
+    $_COOKIE['_fbp'] = 'fb.1.123.browser';
+    $_COOKIE['_fbc'] = 'fb.1.123.click';
     FacebookWordpressPixelInjection::$render_cache = array();
     FacebookPixel::set_pixel_id( '1234' );
 
@@ -286,6 +287,22 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
     $mocked_utils->shouldReceive( 'is_internal_user' )
       ->andReturn( false );
 
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'return' => function ( $value ) {
+          return $value;
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_unslash',
+      array(
+        'return' => function ( $value ) {
+          return $value;
+        },
+      )
+    );
     \WP_Mock::userFunction(
       'wp_json_encode',
       array(
@@ -322,7 +339,8 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
     $output = ob_get_clean();
 
     $this->assertStringContainsString( '"attribution"', $output );
-    $this->assertStringContainsString( 'fb.1.123.test', $output );
+    $this->assertStringContainsString( 'fb.1.123.browser', $output );
+    $this->assertStringContainsString( 'fb.1.123.click', $output );
   }
 
   /**

--- a/__tests__/core/FacebookWordpressPixelInjectionTest.php
+++ b/__tests__/core/FacebookWordpressPixelInjectionTest.php
@@ -324,4 +324,73 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
     $this->assertStringContainsString( '"attribution"', $output );
     $this->assertStringContainsString( 'fb.1.123.test', $output );
   }
+
+  /**
+   * Tests that attribution is omitted from init config while not held.
+   *
+   * @return void
+   */
+  public function testActiveInitCodeOmitsAttribution() {
+    FacebookSignalState::set_attribution_data( 'fbp', 'fb.1.123.browser' );
+    FacebookSignalState::set_attribution_data( 'fbc', 'fb.1.123.click' );
+    FacebookWordpressPixelInjection::$render_cache = array();
+    FacebookPixel::set_pixel_id( '1234' );
+
+    $mocked_options = \Mockery::mock(
+      'alias:FacebookPixelPlugin\Core\FacebookWordpressOptions'
+    );
+    $mocked_options->shouldReceive( 'get_capi_integration_status' )
+      ->andReturn( '1' );
+    $mocked_options->shouldReceive( 'get_agent_string' )
+      ->andReturn( 'WordPress' );
+    $mocked_options->shouldReceive( 'get_user_info' )
+      ->andReturn( array() );
+
+    $mocked_utils = \Mockery::mock(
+      'alias:FacebookPixelPlugin\Core\FacebookPluginUtils'
+    );
+    $mocked_utils->shouldReceive( 'is_internal_user' )
+      ->andReturn( false );
+
+    \WP_Mock::userFunction(
+      'wp_json_encode',
+      array(
+        'return' => function ( $data ) {
+          return json_encode( $data );
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_create_nonce',
+      array(
+        'return' => 'nonce',
+      )
+    );
+    \WP_Mock::userFunction(
+      'admin_url',
+      array(
+        'return' => 'https://www.pikachu.com/wp-admin/admin-ajax.php',
+      )
+    );
+    \WP_Mock::userFunction(
+      'esc_js',
+      array(
+        'return' => function ( $value ) {
+          return $value;
+        },
+      )
+    );
+
+    $injection_obj = new FacebookWordpressPixelInjection();
+
+    ob_start();
+    $injection_obj->inject_pixel_code();
+    $output = ob_get_clean();
+
+    $this->assertStringContainsString( 'FacebookSignal.init', $output );
+    $this->assertStringContainsString( '"held":false', $output );
+    $this->assertStringNotContainsString( '"attribution"', $output );
+    $this->assertStringNotContainsString( 'fb.1.123.browser', $output );
+    $this->assertStringNotContainsString( 'fb.1.123.click', $output );
+  }
 }

--- a/__tests__/core/FacebookWordpressPixelInjectionTest.php
+++ b/__tests__/core/FacebookWordpressPixelInjectionTest.php
@@ -192,12 +192,12 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
   }
 
   /**
-   * Tests that paused injection includes the gating bootstrap and paused init.
+   * Tests that held injection includes the gating bootstrap and held init.
    *
    * @return void
    */
-  public function testInjectPixelCodeIncludesPausedBootstrap() {
-    FacebookSignalState::pause();
+  public function testInjectPixelCodeIncludesHeldBootstrap() {
+    FacebookSignalState::hold();
     FacebookWordpressPixelInjection::$render_cache = array();
     FacebookPixel::set_pixel_id( '1234' );
 
@@ -255,6 +255,73 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
     $this->assertStringContainsString( 'FacebookSignal.init', $output );
     $this->assertStringContainsString( 'FacebookSignal.queueEvent', $output );
     $this->assertStringContainsString( "fbq('consent', 'revoke');", $output );
-    $this->assertStringContainsString( '"paused":true', $output );
+    $this->assertStringContainsString( '"held":true', $output );
+    $this->assertStringContainsString( '"attribution"', $output );
+  }
+
+  /**
+   * Tests that attribution captured while held is forwarded via init config.
+   *
+   * @return void
+   */
+  public function testHeldInitCodeIncludesCapturedAttribution() {
+    FacebookSignalState::hold();
+    FacebookSignalState::set_attribution_data( 'fbc', 'fb.1.123.test' );
+    FacebookWordpressPixelInjection::$render_cache = array();
+    FacebookPixel::set_pixel_id( '1234' );
+
+    $mocked_options = \Mockery::mock(
+      'alias:FacebookPixelPlugin\Core\FacebookWordpressOptions'
+    );
+    $mocked_options->shouldReceive( 'get_capi_integration_status' )
+      ->andReturn( '1' );
+    $mocked_options->shouldReceive( 'get_agent_string' )
+      ->andReturn( 'WordPress' );
+    $mocked_options->shouldReceive( 'get_user_info' )
+      ->andReturn( array() );
+
+    $mocked_utils = \Mockery::mock(
+      'alias:FacebookPixelPlugin\Core\FacebookPluginUtils'
+    );
+    $mocked_utils->shouldReceive( 'is_internal_user' )
+      ->andReturn( false );
+
+    \WP_Mock::userFunction(
+      'wp_json_encode',
+      array(
+        'return' => function ( $data ) {
+          return json_encode( $data );
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_create_nonce',
+      array(
+        'return' => 'nonce',
+      )
+    );
+    \WP_Mock::userFunction(
+      'admin_url',
+      array(
+        'return' => 'https://www.pikachu.com/wp-admin/admin-ajax.php',
+      )
+    );
+    \WP_Mock::userFunction(
+      'esc_js',
+      array(
+        'return' => function ( $value ) {
+          return $value;
+        },
+      )
+    );
+
+    $injection_obj = new FacebookWordpressPixelInjection();
+
+    ob_start();
+    $injection_obj->inject_pixel_code();
+    $output = ob_get_clean();
+
+    $this->assertStringContainsString( '"attribution"', $output );
+    $this->assertStringContainsString( 'fb.1.123.test', $output );
   }
 }

--- a/__tests__/core/PixelRendererTest.php
+++ b/__tests__/core/PixelRendererTest.php
@@ -249,11 +249,11 @@ final class PixelRendererTest extends FacebookWordpressTestBase {
   }
 
   /**
-   * Test that paused rendering queues events instead of firing fbq directly.
+   * Test that held rendering queues events instead of firing fbq directly.
    *
    * @covers \FacebookPixelPlugin\Core\PixelRenderer::render
    */
-  public function testPixelRenderQueuesEventsWhenPaused() {
+  public function testPixelRenderQueuesEventsWhenHeld() {
     \WP_Mock::userFunction(
       'get_option',
       array( 'return' => array() )
@@ -272,7 +272,7 @@ final class PixelRendererTest extends FacebookWordpressTestBase {
       )
     );
 
-    FacebookSignalState::pause();
+    FacebookSignalState::hold();
     FacebookWordpressOptions::set_version_info();
 
     $event = ( new Event() )
@@ -293,11 +293,11 @@ final class PixelRendererTest extends FacebookWordpressTestBase {
   }
 
   /**
-   * Test that paused raw rendering still returns queue-aware JS.
+   * Test that held raw rendering still returns queue-aware JS.
    *
    * @covers \FacebookPixelPlugin\Core\PixelRenderer::render
    */
-  public function testPixelRenderQueuesEventsWhenPausedWithoutScriptTag() {
+  public function testPixelRenderQueuesEventsWhenHeldWithoutScriptTag() {
     \WP_Mock::userFunction(
       'get_option',
       array( 'return' => array() )
@@ -316,7 +316,7 @@ final class PixelRendererTest extends FacebookWordpressTestBase {
       )
     );
 
-    FacebookSignalState::pause();
+    FacebookSignalState::hold();
     FacebookWordpressOptions::set_version_info();
 
     $event = ( new Event() )

--- a/__tests__/core/ReleaseSignalsAjaxTest.php
+++ b/__tests__/core/ReleaseSignalsAjaxTest.php
@@ -5,16 +5,16 @@
 
 namespace FacebookPixelPlugin\Tests\Core;
 
-use FacebookPixelPlugin\Core\ResumeTrackingAjax;
+use FacebookPixelPlugin\Core\ReleaseSignalsAjax;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 
 /**
- * ResumeTrackingAjaxTest class.
+ * ReleaseSignalsAjaxTest class.
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
-final class ResumeTrackingAjaxTest extends FacebookWordpressTestBase {
+final class ReleaseSignalsAjaxTest extends FacebookWordpressTestBase {
   /**
    * Test queued event validation rules.
    *
@@ -38,8 +38,8 @@ final class ResumeTrackingAjaxTest extends FacebookWordpressTestBase {
       )
     );
 
-    $handler = new ResumeTrackingAjax();
-    $method  = new \ReflectionMethod( ResumeTrackingAjax::class, 'validate_event' );
+    $handler = new ReleaseSignalsAjax();
+    $method  = new \ReflectionMethod( ReleaseSignalsAjax::class, 'validate_event' );
     if ( PHP_VERSION_ID < 80100 ) {
       $method->setAccessible( true );
     }
@@ -79,7 +79,7 @@ final class ResumeTrackingAjaxTest extends FacebookWordpressTestBase {
   }
 
   /**
-   * Test replay event construction keeps source URL and event metadata.
+   * Test released event construction keeps source URL and event metadata.
    *
    * @return void
    */
@@ -117,8 +117,8 @@ final class ResumeTrackingAjaxTest extends FacebookWordpressTestBase {
       )
     );
 
-    $handler = new ResumeTrackingAjax();
-    $method  = new \ReflectionMethod( ResumeTrackingAjax::class, 'build_event' );
+    $handler = new ReleaseSignalsAjax();
+    $method  = new \ReflectionMethod( ReleaseSignalsAjax::class, 'build_event' );
     if ( PHP_VERSION_ID < 80100 ) {
       $method->setAccessible( true );
     }

--- a/__tests__/core/SignalsTest.php
+++ b/__tests__/core/SignalsTest.php
@@ -61,8 +61,8 @@ final class SignalsTest extends FacebookWordpressTestBase {
    *
    * @return void
    */
-  public function testHandleSetSignalsUpdatesCookieState() {
-    $_POST['state'] = 'active';
+  public function testHandleUpdateStateUpdatesCookieState() {
+    $_POST['state'] = Signals::STATE_ACTIVE;
 
     \WP_Mock::userFunction(
       'check_ajax_referer',
@@ -106,7 +106,132 @@ final class SignalsTest extends FacebookWordpressTestBase {
       Signals::STATE_ACTIVE,
       $_COOKIE[ Signals::COOKIE_NAME ]
     );
-    $this->assertEquals( array( 'state' => 'active' ), $captured_payload );
+    $this->assertEquals(
+      array( 'state' => Signals::STATE_ACTIVE ),
+      $captured_payload
+    );
+  }
+
+  /**
+   * Helper: set up WP function mocks needed by handle_update_state().
+   *
+   * @param array|null $captured_payload Reference to capture wp_send_json_success payload.
+   * @return void
+   */
+  private function mockHandleUpdateStateDeps( &$captured_payload ) {
+    \WP_Mock::userFunction(
+      'check_ajax_referer',
+      array(
+        'args' => array( Signals::NONCE_ACTION, 'security' ),
+      )
+    );
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'return' => function ( $value ) {
+          return $value;
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_unslash',
+      array(
+        'return' => function ( $value ) {
+          return $value;
+        },
+      )
+    );
+    \WP_Mock::userFunction( 'is_ssl', array( 'return' => false ) );
+    \WP_Mock::userFunction(
+      'wp_send_json_success',
+      array(
+        'return' => function ( $payload ) use ( &$captured_payload ) {
+          $captured_payload = $payload;
+          return $payload;
+        },
+      )
+    );
+  }
+
+  /**
+   * Test handle_update_state() defaults to held when state param is absent.
+   *
+   * @return void
+   */
+  public function testHandleUpdateStateDefaultsToHeldWhenParamMissing() {
+    unset( $_POST['state'] );
+    $captured_payload = null;
+    $this->mockHandleUpdateStateDeps( $captured_payload );
+
+    ( new Signals() )->handle_update_state();
+
+    $this->assertSame(
+      Signals::STATE_HELD,
+      $_COOKIE[ Signals::COOKIE_NAME ]
+    );
+    $this->assertEquals(
+      array( 'state' => Signals::STATE_HELD ),
+      $captured_payload
+    );
+  }
+
+  /**
+   * Test handle_update_state() with explicit state='held'.
+   *
+   * @return void
+   */
+  public function testHandleUpdateStateExplicitHeld() {
+    $_POST['state'] = Signals::STATE_HELD;
+    $captured_payload = null;
+    $this->mockHandleUpdateStateDeps( $captured_payload );
+
+    ( new Signals() )->handle_update_state();
+
+    $this->assertSame(
+      Signals::STATE_HELD,
+      $_COOKIE[ Signals::COOKIE_NAME ]
+    );
+    $this->assertEquals(
+      array( 'state' => Signals::STATE_HELD ),
+      $captured_payload
+    );
+  }
+
+  /**
+   * Test handle_update_state() normalises invalid values to held.
+   *
+   * @dataProvider provideInvalidStateValues
+   *
+   * @param string $invalid_value
+   * @return void
+   */
+  public function testHandleUpdateStateInvalidValueBecomesHeld( $invalid_value ) {
+    $_POST['state'] = $invalid_value;
+    $captured_payload = null;
+    $this->mockHandleUpdateStateDeps( $captured_payload );
+
+    ( new Signals() )->handle_update_state();
+
+    $this->assertSame(
+      Signals::STATE_HELD,
+      $_COOKIE[ Signals::COOKIE_NAME ]
+    );
+    $this->assertEquals(
+      array( 'state' => Signals::STATE_HELD ),
+      $captured_payload
+    );
+  }
+
+  /**
+   * @return array<array<string>>
+   */
+  public static function provideInvalidStateValues() {
+    return array(
+      'garbage string' => array( 'garbage' ),
+      'empty string'   => array( '' ),
+      'numeric one'    => array( '1' ),
+      'granted legacy' => array( 'granted' ),
+    );
   }
 
   /**

--- a/__tests__/core/SignalsTest.php
+++ b/__tests__/core/SignalsTest.php
@@ -5,16 +5,16 @@
 
 namespace FacebookPixelPlugin\Tests\Core;
 
-use FacebookPixelPlugin\Core\FacebookPixelSignals;
+use FacebookPixelPlugin\Core\Signals;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 
 /**
- * FacebookPixelSignalsTest class.
+ * SignalsTest class.
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
-final class FacebookPixelSignalsTest extends FacebookWordpressTestBase {
+final class SignalsTest extends FacebookWordpressTestBase {
   /**
    * Test tri-state cookie reads.
    *
@@ -38,22 +38,22 @@ final class FacebookPixelSignalsTest extends FacebookWordpressTestBase {
       )
     );
 
-    $this->assertNull( FacebookPixelSignals::get_signal_state() );
-    $this->assertFalse( FacebookPixelSignals::should_hold_signals() );
+    $this->assertNull( Signals::get_signal_state() );
+    $this->assertFalse( Signals::should_hold_signals() );
 
-    $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ] = FacebookPixelSignals::STATE_HELD;
+    $_COOKIE[ Signals::COOKIE_NAME ] = Signals::STATE_HELD;
     $this->assertSame(
-      FacebookPixelSignals::STATE_HELD,
-      FacebookPixelSignals::get_signal_state()
+      Signals::STATE_HELD,
+      Signals::get_signal_state()
     );
-    $this->assertTrue( FacebookPixelSignals::should_hold_signals() );
+    $this->assertTrue( Signals::should_hold_signals() );
 
-    $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ] = FacebookPixelSignals::STATE_ACTIVE;
+    $_COOKIE[ Signals::COOKIE_NAME ] = Signals::STATE_ACTIVE;
     $this->assertSame(
-      FacebookPixelSignals::STATE_ACTIVE,
-      FacebookPixelSignals::get_signal_state()
+      Signals::STATE_ACTIVE,
+      Signals::get_signal_state()
     );
-    $this->assertFalse( FacebookPixelSignals::should_hold_signals() );
+    $this->assertFalse( Signals::should_hold_signals() );
   }
 
   /**
@@ -67,7 +67,7 @@ final class FacebookPixelSignalsTest extends FacebookWordpressTestBase {
     \WP_Mock::userFunction(
       'check_ajax_referer',
       array(
-        'args' => array( FacebookPixelSignals::NONCE_ACTION, 'security' ),
+        'args' => array( Signals::NONCE_ACTION, 'security' ),
       )
     );
     \WP_Mock::userFunction(
@@ -99,12 +99,12 @@ final class FacebookPixelSignalsTest extends FacebookWordpressTestBase {
       )
     );
 
-    $handler = new FacebookPixelSignals();
+    $handler = new Signals();
     $handler->handle_update_state();
 
     $this->assertEquals(
-      FacebookPixelSignals::STATE_ACTIVE,
-      $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ]
+      Signals::STATE_ACTIVE,
+      $_COOKIE[ Signals::COOKIE_NAME ]
     );
     $this->assertEquals( array( 'state' => 'active' ), $captured_payload );
   }
@@ -132,10 +132,10 @@ final class FacebookPixelSignalsTest extends FacebookWordpressTestBase {
       )
     );
 
-    $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ] = 'garbage';
-    $this->assertNull( FacebookPixelSignals::get_signal_state() );
-    $this->assertFalse( FacebookPixelSignals::is_signals_active() );
-    $this->assertFalse( FacebookPixelSignals::should_hold_signals() );
+    $_COOKIE[ Signals::COOKIE_NAME ] = 'garbage';
+    $this->assertNull( Signals::get_signal_state() );
+    $this->assertFalse( Signals::is_signals_active() );
+    $this->assertFalse( Signals::should_hold_signals() );
   }
 
   /**
@@ -162,15 +162,15 @@ final class FacebookPixelSignalsTest extends FacebookWordpressTestBase {
     );
 
     // Unset cookie — neither active nor held.
-    unset( $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ] );
-    $this->assertFalse( FacebookPixelSignals::is_signals_active() );
+    unset( $_COOKIE[ Signals::COOKIE_NAME ] );
+    $this->assertFalse( Signals::is_signals_active() );
 
     // Explicitly held.
-    $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ] = FacebookPixelSignals::STATE_HELD;
-    $this->assertFalse( FacebookPixelSignals::is_signals_active() );
+    $_COOKIE[ Signals::COOKIE_NAME ] = Signals::STATE_HELD;
+    $this->assertFalse( Signals::is_signals_active() );
 
     // Explicitly active.
-    $_COOKIE[ FacebookPixelSignals::COOKIE_NAME ] = FacebookPixelSignals::STATE_ACTIVE;
-    $this->assertTrue( FacebookPixelSignals::is_signals_active() );
+    $_COOKIE[ Signals::COOKIE_NAME ] = Signals::STATE_ACTIVE;
+    $this->assertTrue( Signals::is_signals_active() );
   }
 }

--- a/core/class-facebookpixel.php
+++ b/core/class-facebookpixel.php
@@ -223,7 +223,7 @@ src="https://www.facebook.com/tr?id=%s&ev=%s%s&noscript=1" />
             return;
         }
 
-        if ( self::is_tracking_paused() ) {
+        if ( self::are_signals_held() ) {
             return self::get_pixel_queue_code(
                 $event,
                 $param,
@@ -254,7 +254,7 @@ src="https://www.facebook.com/tr?id=%s&ev=%s%s&noscript=1" />
     }
 
     /**
-     * Gets queueing code for a paused event.
+     * Gets queueing code for a held event.
      *
      * @param string $event           Event name.
      * @param array  $param           Event parameters.
@@ -309,7 +309,7 @@ src="https://www.facebook.com/tr?id=%s&ev=%s%s&noscript=1" />
     }
 
     /**
-     * Build queue payload for a paused event.
+     * Build queue payload for a held event.
      *
      * @param string       $event         Event name.
      * @param array|string $param         Event params.
@@ -361,13 +361,13 @@ src="https://www.facebook.com/tr?id=%s&ev=%s%s&noscript=1" />
     }
 
     /**
-     * Whether the current request is paused.
+     * Whether signals are held for the current request.
      *
      * @return bool
      */
-    private static function is_tracking_paused() {
+    private static function are_signals_held() {
         return class_exists( '\FacebookPixelPlugin\Core\FacebookSignalState' ) &&
-            FacebookSignalState::is_paused();
+            FacebookSignalState::is_held();
     }
 
     /**

--- a/core/class-facebookpixelsignals.php
+++ b/core/class-facebookpixelsignals.php
@@ -21,9 +21,11 @@ defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
  * Cookie-backed signals state for frontend event gating.
  */
 class FacebookPixelSignals {
-    const COOKIE_NAME  = 'fbpix_pixel_signals';
+    const COOKIE_NAME  = 'wc_facebook_signals_state';
     const AJAX_ACTION  = 'fbpix_set_pixel_signals';
     const NONCE_ACTION = 'fbpix_pixel_signals_nonce';
+    const STATE_ACTIVE = 'active';
+    const STATE_HELD   = 'held';
 
     /**
      * Register AJAX handlers.
@@ -31,51 +33,59 @@ class FacebookPixelSignals {
     public function __construct() {
         add_action(
             'wp_ajax_' . self::AJAX_ACTION,
-            array( $this, 'handle_set_signals' )
+            array( $this, 'handle_update_state' )
         );
         add_action(
             'wp_ajax_nopriv_' . self::AJAX_ACTION,
-            array( $this, 'handle_set_signals' )
+            array( $this, 'handle_update_state' )
         );
     }
 
     /**
      * Get current signals state.
      *
-     * @return bool|null
+     * @return string|null 'active', 'held', or null when unset.
      */
-    public static function get_signals_state() {
+    public static function get_signal_state() {
         if ( ! isset( $_COOKIE[ self::COOKIE_NAME ] ) ) {
             return null;
         }
 
-        return '1' === sanitize_text_field(
+        $state = sanitize_text_field(
             wp_unslash( $_COOKIE[ self::COOKIE_NAME ] )
         );
+
+        if ( in_array( $state, array( self::STATE_ACTIVE, self::STATE_HELD ), true ) ) {
+            return $state;
+        }
+
+        return null;
     }
 
     /**
-     * Whether tracking should be paused.
+     * Whether signals should be held.
      *
      * @return bool
      */
-    public static function should_pause_tracking() {
-        return false === self::get_signals_state();
+    public static function should_hold_signals() {
+        return self::STATE_HELD === self::get_signal_state();
     }
 
     /**
-     * Persist signals via AJAX.
+     * Persist the signal grant state via AJAX.
      *
      * @return void
      */
-    public function handle_set_signals() {
+    public function handle_update_state() {
         check_ajax_referer( self::NONCE_ACTION, 'security' );
 
         $granted = isset( $_POST['granted'] ) &&
             '1' === sanitize_text_field( wp_unslash( $_POST['granted'] ) );
 
-        $this->set_cookie( $granted );
-        $_COOKIE[ self::COOKIE_NAME ] = $granted ? '1' : '0';
+        $state = $granted ? self::STATE_ACTIVE : self::STATE_HELD;
+
+        $this->set_cookie( $state );
+        $_COOKIE[ self::COOKIE_NAME ] = $state;
 
         wp_send_json_success(
             array(
@@ -85,16 +95,16 @@ class FacebookPixelSignals {
     }
 
     /**
-     * Set signals cookie.
+     * Set the signal state cookie.
      *
-     * @param bool $granted Whether signals is granted.
+     * @param string $state Signal state ('active' or 'held').
      *
      * @return void
      */
-    private function set_cookie( $granted ) {
+    private function set_cookie( $state ) {
         setcookie(
             self::COOKIE_NAME,
-            $granted ? '1' : '0',
+            $state,
             time() + YEAR_IN_SECONDS,
             defined( 'COOKIEPATH' ) ? COOKIEPATH : '/',
             defined( 'COOKIE_DOMAIN' ) ? COOKIE_DOMAIN : '',

--- a/core/class-facebookpixelsignals.php
+++ b/core/class-facebookpixelsignals.php
@@ -63,6 +63,15 @@ class FacebookPixelSignals {
     }
 
     /**
+     * Whether signals are currently active.
+     *
+     * @return bool
+     */
+    public static function is_signals_active() {
+        return self::STATE_ACTIVE === self::get_signal_state();
+    }
+
+    /**
      * Whether signals should be held.
      *
      * @return bool

--- a/core/class-facebookpixelsignals.php
+++ b/core/class-facebookpixelsignals.php
@@ -72,24 +72,29 @@ class FacebookPixelSignals {
     }
 
     /**
-     * Persist the signal grant state via AJAX.
+     * Persist the signal state via AJAX.
+     *
+     * Expected POST params:
+     *  - security : nonce
+     *  - state    : 'active' or 'held'
      *
      * @return void
      */
     public function handle_update_state() {
         check_ajax_referer( self::NONCE_ACTION, 'security' );
 
-        $granted = isset( $_POST['granted'] ) &&
-            '1' === sanitize_text_field( wp_unslash( $_POST['granted'] ) );
+        $raw_state = isset( $_POST['state'] )
+            ? strtolower( sanitize_text_field( wp_unslash( $_POST['state'] ) ) )
+            : self::STATE_HELD;
 
-        $state = $granted ? self::STATE_ACTIVE : self::STATE_HELD;
+        $state = self::STATE_ACTIVE === $raw_state ? self::STATE_ACTIVE : self::STATE_HELD;
 
         $this->set_cookie( $state );
         $_COOKIE[ self::COOKIE_NAME ] = $state;
 
         wp_send_json_success(
             array(
-                'granted' => $granted,
+                'state' => $state,
             )
         );
     }

--- a/core/class-facebookpixelsignals.php
+++ b/core/class-facebookpixelsignals.php
@@ -83,11 +83,11 @@ class FacebookPixelSignals {
     public function handle_update_state() {
         check_ajax_referer( self::NONCE_ACTION, 'security' );
 
-        $raw_state = isset( $_POST['state'] )
-            ? strtolower( sanitize_text_field( wp_unslash( $_POST['state'] ) ) )
-            : self::STATE_HELD;
-
-        $state = self::STATE_ACTIVE === $raw_state ? self::STATE_ACTIVE : self::STATE_HELD;
+        $state = self::normalize_state(
+            isset( $_POST['state'] )
+                ? sanitize_text_field( wp_unslash( $_POST['state'] ) )
+                : null
+        );
 
         $this->set_cookie( $state );
         $_COOKIE[ self::COOKIE_NAME ] = $state;
@@ -97,6 +97,25 @@ class FacebookPixelSignals {
                 'state' => $state,
             )
         );
+    }
+
+    /**
+     * Normalize an incoming state value to a canonical STATE_ACTIVE / STATE_HELD.
+     *
+     * Anything that is not exactly 'active' (case-insensitive) becomes 'held'.
+     *
+     * @param string|null $raw Raw input value.
+     *
+     * @return string
+     */
+    private static function normalize_state( $raw ) {
+        if ( null === $raw ) {
+            return self::STATE_HELD;
+        }
+
+        $candidate = strtolower( $raw );
+
+        return self::STATE_ACTIVE === $candidate ? self::STATE_ACTIVE : self::STATE_HELD;
     }
 
     /**

--- a/core/class-facebookserversideevent.php
+++ b/core/class-facebookserversideevent.php
@@ -254,7 +254,7 @@ class FacebookServerSideEvent {
             wp_doing_cron() :
             false;
 
-        return FacebookSignalState::is_paused() &&
+        return FacebookSignalState::is_held() &&
             ! $is_admin_request &&
             ! $is_cron_request;
     }

--- a/core/class-facebooksignalstate.php
+++ b/core/class-facebooksignalstate.php
@@ -20,55 +20,62 @@ use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
 defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 
 /**
- * Static per-request paused state.
+ * Static per-request state for held signal delivery.
  */
 class FacebookSignalState {
     /**
-     * Whether tracking is paused for the current request.
+     * Whether signals are currently held for this request.
      *
      * @var bool
      */
-    private static $paused = false;
+    private static $held = false;
 
     /**
-     * CAPI events queued while paused, keyed by event_id.
+     * CAPI events queued while signals are held, keyed by event_id.
      *
      * @var array<string, Event>
      */
     private static $queued_events = array();
 
     /**
-     * Pause tracking for this request.
+     * Attribution data captured while signals are held (e.g. fbp, fbc).
+     *
+     * @var array<string, string>
+     */
+    private static $attribution_data = array();
+
+    /**
+     * Hold signals for the current request.
      *
      * @return void
      */
-    public static function pause() {
-        self::$paused = true;
+    public static function hold() {
+        self::$held = true;
     }
 
     /**
-     * Resume tracking for this request.
+     * Release signals for the current request.
      *
      * @return void
      */
-    public static function resume() {
-        self::$paused = false;
+    public static function release() {
+        self::$held = false;
     }
 
     /**
-     * Check whether tracking is paused.
+     * Whether signals are currently held.
      *
      * @return bool
      */
-    public static function is_paused() {
+    public static function is_held() {
         return (bool) apply_filters(
-            'facebook_tracking_paused',
-            self::$paused
+            'facebook_signals_held',
+            self::$held
         );
     }
 
     /**
-     * Queue a CAPI event so it can be enriched on resume.
+     * Queue a CAPI event so it can be enriched on release.
      *
      * @param Event $event Event to queue.
      * @return void
@@ -96,8 +103,8 @@ class FacebookSignalState {
     /**
      * Get the safe-to-forward normalized user_data for a queued event.
      *
-     * Strips fields that the resume request will derive from its own context
-     * (client_ip_address, client_user_agent, fbp, fbc) so the resume can build
+     * Strips fields that the release request will derive from its own context
+     * (client_ip_address, client_user_agent, fbp, fbc) so the release can build
      * those from cookies/headers it actually sees.
      *
      * @param string $event_id Event identifier.
@@ -126,11 +133,35 @@ class FacebookSignalState {
     }
 
     /**
-     * Reset the queued events store. Intended for tests.
+     * Store attribution data captured while signals are held.
+     *
+     * @param string $key   Data key (e.g. 'fbp', 'fbc').
+     * @param string $value Data value.
+     * @return void
+     */
+    public static function set_attribution_data( $key, $value ) {
+        self::$attribution_data[ $key ] = $value;
+    }
+
+    /**
+     * Retrieve stored attribution data.
+     *
+     * @param string $key Data key.
+     * @return string|null
+     */
+    public static function get_attribution_data( $key ) {
+        return isset( self::$attribution_data[ $key ] )
+            ? self::$attribution_data[ $key ]
+            : null;
+    }
+
+    /**
+     * Reset the queued events and attribution stores. Intended for tests.
      *
      * @return void
      */
     public static function reset_queue() {
-        self::$queued_events = array();
+        self::$queued_events    = array();
+        self::$attribution_data = array();
     }
 }

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -222,11 +222,14 @@ class FacebookWordpressPixelInjection {
             'releaseAction' => ReleaseSignalsAjax::ACTION,
             'releaseNonce'  => wp_create_nonce( ReleaseSignalsAjax::NONCE_ACTION ),
             'pixelId'       => FacebookPixel::get_pixel_id(),
-            'attribution'   => array(
+        );
+
+        if ( FacebookSignalState::is_held() ) {
+            $config['attribution'] = array(
                 'fbp' => FacebookSignalState::get_attribution_data( 'fbp' ),
                 'fbc' => FacebookSignalState::get_attribution_data( 'fbc' ),
-            ),
-        );
+            );
+        }
 
         return "<script type='text/javascript'>FacebookSignal.init(" .
             wp_json_encode(

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -93,7 +93,7 @@ class FacebookWordpressPixelInjection {
      * @return void
      */
     public function send_pending_events() {
-        if ( FacebookSignalState::is_paused() ) {
+        if ( FacebookSignalState::is_held() ) {
             return;
         }
 
@@ -140,7 +140,8 @@ class FacebookWordpressPixelInjection {
         // Only include user info for frontend users, not internal/admin users.
         $user_info = FacebookPluginUtils::is_internal_user() ?
             array() : FacebookWordpressOptions::get_user_info();
-        if ( FacebookSignalState::is_paused() ) {
+        if ( FacebookSignalState::is_held() ) {
+            $this->capture_held_attribution();
             echo "<script type='text/javascript'>fbq('consent', 'revoke');</script>"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
         }
         echo FacebookPixel::get_pixel_init_code( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
@@ -192,17 +193,39 @@ class FacebookWordpressPixelInjection {
     }
 
     /**
+     * Capture fbp/fbc attribution while signals are held so the release
+     * flow can forward it once tracking resumes.
+     *
+     * @return void
+     */
+    private function capture_held_attribution() {
+        $fbp = ServerEventFactory::get_fbp_value();
+        if ( ! empty( $fbp ) ) {
+            FacebookSignalState::set_attribution_data( 'fbp', $fbp );
+        }
+
+        $fbc = ServerEventFactory::get_fbc_value();
+        if ( ! empty( $fbc ) ) {
+            FacebookSignalState::set_attribution_data( 'fbc', $fbc );
+        }
+    }
+
+    /**
      * Initialize FacebookSignal with current config.
      *
      * @return string
      */
     private function get_facebook_signal_init_code() {
         $config = array(
-            'paused'       => FacebookSignalState::is_paused(),
-            'ajaxUrl'      => admin_url( 'admin-ajax.php' ),
-            'resumeAction' => ResumeTrackingAjax::ACTION,
-            'resumeNonce'  => wp_create_nonce( ResumeTrackingAjax::NONCE_ACTION ),
-            'pixelId'      => FacebookPixel::get_pixel_id(),
+            'held'          => FacebookSignalState::is_held(),
+            'ajaxUrl'       => admin_url( 'admin-ajax.php' ),
+            'releaseAction' => ReleaseSignalsAjax::ACTION,
+            'releaseNonce'  => wp_create_nonce( ReleaseSignalsAjax::NONCE_ACTION ),
+            'pixelId'       => FacebookPixel::get_pixel_id(),
+            'attribution'   => array(
+                'fbp' => FacebookSignalState::get_attribution_data( 'fbp' ),
+                'fbc' => FacebookSignalState::get_attribution_data( 'fbc' ),
+            ),
         );
 
         return "<script type='text/javascript'>FacebookSignal.init(" .

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -184,17 +184,17 @@ class FacebookWordpressPixelInjection {
             'facebook-signal',
             'facebookSignalConfig',
             array(
-                'cookieName'    => FacebookPixelSignals::COOKIE_NAME,
+                'cookieName'    => Signals::COOKIE_NAME,
                 'ajaxUrl'       => admin_url( 'admin-ajax.php' ),
-                'signalsAction' => FacebookPixelSignals::AJAX_ACTION,
-                'signalsNonce'  => wp_create_nonce( FacebookPixelSignals::NONCE_ACTION ),
+                'signalsAction' => Signals::AJAX_ACTION,
+                'signalsNonce'  => wp_create_nonce( Signals::NONCE_ACTION ),
             )
         );
     }
 
     /**
      * Capture fbp/fbc attribution while signals are held so the release
-     * flow can forward it once tracking resumes.
+     * flow can forward it once signals are released.
      *
      * @return void
      */

--- a/core/class-pixelrenderer.php
+++ b/core/class-pixelrenderer.php
@@ -95,7 +95,7 @@ class PixelRenderer {
         $event,
         $fb_integration_tracking
     ) {
-        if ( FacebookSignalState::is_paused() ) {
+        if ( FacebookSignalState::is_held() ) {
             return self::get_queue_track_code(
                 $event,
                 $fb_integration_tracking
@@ -128,7 +128,7 @@ class PixelRenderer {
     }
 
     /**
-     * Generate queueing code for a paused event.
+     * Generate queueing code for a held event.
      *
      * @param \FacebookPixelPlugin\Core\Event $event Event object.
      * @param bool                            $fb_integration_tracking Tracking label.

--- a/core/class-releasesignalsajax.php
+++ b/core/class-releasesignalsajax.php
@@ -53,13 +53,18 @@ class ReleaseSignalsAjax {
     const RATE_LIMIT_GROUP = 'fbpix_release_signals_rl';
 
     /**
-     * Allowed released event names.
+     * Well-known event names accepted on release.
+     *
+     * Advisory list — the validate_event() regex also passes any camelCase
+     * custom event name. Keep this list in sync with facebook-for-woocommerce
+     * ReleaseSignalsAjax::ALLOWED_EVENTS.
      *
      * @var string[]
      */
     private static $allowed_events = array(
         'PageView',
         'ViewContent',
+        'ViewCategory',
         'Search',
         'AddToCart',
         'AddToWishlist',

--- a/core/class-releasesignalsajax.php
+++ b/core/class-releasesignalsajax.php
@@ -23,11 +23,11 @@ use FacebookPixelPlugin\FacebookAds\Object\ServerSide\UserData;
 defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 
 /**
- * AJAX endpoint for replaying queued events after signals grant.
+ * AJAX endpoint for releasing held signals.
  */
-class ResumeTrackingAjax {
-    const ACTION        = 'fbpix_resume_tracking';
-    const NONCE_ACTION  = 'fbpix_resume_tracking';
+class ReleaseSignalsAjax {
+    const ACTION        = 'fbpix_release_signals';
+    const NONCE_ACTION  = 'fbpix_release_signals';
     const MAX_EVENTS    = 20;
     const MAX_EVENT_AGE = 1800;
 
@@ -50,10 +50,10 @@ class ResumeTrackingAjax {
      *
      * @var string
      */
-    const RATE_LIMIT_GROUP = 'fbpix_resume_tracking_rl';
+    const RATE_LIMIT_GROUP = 'fbpix_release_signals_rl';
 
     /**
-     * Allowed replayed event names.
+     * Allowed released event names.
      *
      * @var string[]
      */
@@ -87,7 +87,7 @@ class ResumeTrackingAjax {
     }
 
     /**
-     * Process queued event replay.
+     * Process queued event release.
      *
      * @return void
      */
@@ -115,7 +115,7 @@ class ResumeTrackingAjax {
         $fbc    = ! empty( $body['fbc'] ) ?
             sanitize_text_field( $body['fbc'] ) : '';
 
-        // Expose queued attribution to ServerEventFactory so resumed events
+        // Expose queued attribution to ServerEventFactory so released events
         // share the same attribution path as normal CAPI events.
         $restore_get_fbclid = $this->temporarily_set_superglobal_value( '_GET', 'fbclid', $fbclid );
         $restore_cookie_fbp = $this->temporarily_set_superglobal_value( '_COOKIE', '_fbp', $fbp );
@@ -183,7 +183,7 @@ class ResumeTrackingAjax {
     }
 
     /**
-     * Build replay event from queue payload.
+     * Build released event from queue payload.
      *
      * @param array $event_data Event payload.
      *
@@ -309,7 +309,7 @@ class ResumeTrackingAjax {
     }
 
     /**
-     * Build a UserData object from a forwarded resume payload.
+     * Build a UserData object from a forwarded release payload.
      *
      * Accepts the normalized short-key shape produced by UserData::normalize()
      * (em, ph, ln, fn, ct, st, zp, country, external_id, etc.). Hashable PII
@@ -455,7 +455,7 @@ class ResumeTrackingAjax {
     }
 
     /**
-     * Whether the current client is over its resume-tracking rate limit.
+     * Whether the current client is over its release-tracking rate limit.
      *
      * Counts accepted events (not requests) per IP per window. Both the
      * window length and the cap are filterable.
@@ -464,7 +464,7 @@ class ResumeTrackingAjax {
      */
     private function is_rate_limited() {
         $max = (int) apply_filters(
-            'fbpix_resume_tracking_rate_limit_max',
+            'fbpix_release_signals_rate_limit_max',
             self::RATE_LIMIT_MAX_EVENTS
         );
 
@@ -492,7 +492,7 @@ class ResumeTrackingAjax {
         }
 
         $window = (int) apply_filters(
-            'fbpix_resume_tracking_rate_limit_window',
+            'fbpix_release_signals_rate_limit_window',
             self::RATE_LIMIT_WINDOW
         );
         if ( $window <= 0 ) {
@@ -552,6 +552,6 @@ class ResumeTrackingAjax {
         $ip = isset( $_SERVER['REMOTE_ADDR'] ) ?
             sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ) :
             '';
-        return 'fbpix_resume_tracking_rl_' . md5( $ip );
+        return 'fbpix_release_signals_rl_' . md5( $ip );
     }
 }

--- a/core/class-signals.php
+++ b/core/class-signals.php
@@ -31,7 +31,7 @@ defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 class Signals {
     const COOKIE_NAME  = 'wc_facebook_signals_state';
     const AJAX_ACTION  = 'fbpix_set_pixel_signals';
-    const NONCE_ACTION = 'fbpix_pixel_signals_nonce';
+    const NONCE_ACTION = 'fbpix_signals_state_nonce';
     const STATE_ACTIVE = 'active';
     const STATE_HELD   = 'held';
 

--- a/core/class-signals.php
+++ b/core/class-signals.php
@@ -19,8 +19,16 @@ defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 
 /**
  * Cookie-backed signals state for frontend event gating.
+ *
+ * Mirrors WooCommerce\Facebook\Signals in the facebook-for-woocommerce plugin
+ * and the frontend FacebookSignal JS API. These implementations share the
+ * cookie name, state values, AJAX payload, and hold/release semantics; keep
+ * them behaviorally in sync when making changes here.
+ *
+ * @see https://github.com/woocommerce/facebook-for-woocommerce/blob/trunk/includes/Signals.php
+ * @see ../../js/facebook_signal.js
  */
-class FacebookPixelSignals {
+class Signals {
     const COOKIE_NAME  = 'wc_facebook_signals_state';
     const AJAX_ACTION  = 'fbpix_set_pixel_signals';
     const NONCE_ACTION = 'fbpix_pixel_signals_nonce';

--- a/facebook-for-wordpress.php
+++ b/facebook-for-wordpress.php
@@ -37,7 +37,7 @@ if ( file_exists( $local_config ) ) {
 require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 require_once plugin_dir_path( __FILE__ ) . 'core/class-facebookpixelsignals.php';
 require_once plugin_dir_path( __FILE__ ) . 'core/class-facebooksignalstate.php';
-require_once plugin_dir_path( __FILE__ ) . 'core/class-resumetrackingajax.php';
+require_once plugin_dir_path( __FILE__ ) . 'core/class-releasesignalsajax.php';
 
 use FacebookPixelPlugin\Core\FacebookPixel;
 use FacebookPixelPlugin\Core\FacebookPixelSignals;
@@ -49,7 +49,7 @@ use FacebookPixelPlugin\Core\FacebookWordpressOptions;
 use FacebookPixelPlugin\Core\FacebookWordpressPixelInjection;
 use FacebookPixelPlugin\Core\FacebookWordpressSettingsPage;
 use FacebookPixelPlugin\Core\FacebookWordpressSettingsRecorder;
-use FacebookPixelPlugin\Core\ResumeTrackingAjax;
+use FacebookPixelPlugin\Core\ReleaseSignalsAjax;
 use FacebookPixelPlugin\Core\ServerEventAsyncTask;
 
 /**
@@ -73,10 +73,10 @@ class FacebookForWordpress {
     $options = FacebookWordpressOptions::get_options();
     FacebookPixel::initialize( FacebookWordpressOptions::get_active_pixel_id() );
     new FacebookPixelSignals();
-    new ResumeTrackingAjax();
+    new ReleaseSignalsAjax();
 
-    if ( FacebookPixelSignals::should_pause_tracking() ) {
-        FacebookSignalState::pause();
+    if ( FacebookPixelSignals::should_hold_signals() ) {
+        FacebookSignalState::hold();
     }
 
     add_action( 'init', array( $this, 'register_pixel_injection' ), 0 );

--- a/facebook-for-wordpress.php
+++ b/facebook-for-wordpress.php
@@ -35,12 +35,12 @@ if ( file_exists( $local_config ) ) {
 }
 
 require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
-require_once plugin_dir_path( __FILE__ ) . 'core/class-facebookpixelsignals.php';
+require_once plugin_dir_path( __FILE__ ) . 'core/class-signals.php';
 require_once plugin_dir_path( __FILE__ ) . 'core/class-facebooksignalstate.php';
 require_once plugin_dir_path( __FILE__ ) . 'core/class-releasesignalsajax.php';
 
 use FacebookPixelPlugin\Core\FacebookPixel;
-use FacebookPixelPlugin\Core\FacebookPixelSignals;
+use FacebookPixelPlugin\Core\Signals;
 use FacebookPixelPlugin\Core\FacebookPluginConfig;
 use FacebookPixelPlugin\Core\FacebookPluginUtils;
 use FacebookPixelPlugin\Core\FacebookSignalState;
@@ -72,10 +72,10 @@ class FacebookForWordpress {
 
     $options = FacebookWordpressOptions::get_options();
     FacebookPixel::initialize( FacebookWordpressOptions::get_active_pixel_id() );
-    new FacebookPixelSignals();
+    new Signals();
     new ReleaseSignalsAjax();
 
-    if ( FacebookPixelSignals::should_hold_signals() ) {
+    if ( Signals::should_hold_signals() ) {
         FacebookSignalState::hold();
     }
 

--- a/integration/class-facebookwordpresseasydigitaldownloads.php
+++ b/integration/class-facebookwordpresseasydigitaldownloads.php
@@ -207,7 +207,7 @@ class FacebookWordpressEasyDigitalDownloads extends FacebookWordpressIntegration
                 'trackingName'     => self::TRACKING_NAME,
                 'agentString'      => FacebookWordpressOptions::get_agent_string(),
                 'pixelId'          => FacebookWordpressOptions::get_active_pixel_id(),
-                'paused'           => FacebookSignalState::is_paused(),
+                'held'             => FacebookSignalState::is_held(),
             )
         );
 

--- a/js/facebook_pixel_add_to_cart.js
+++ b/js/facebook_pixel_add_to_cart.js
@@ -41,7 +41,7 @@ jQuery(document).ready(function ($) {
       value: value,
     };
 
-    if (window.FacebookSignal && window.FacebookSignal._paused) {
+    if (window.FacebookSignal && window.FacebookSignal._held) {
       if (event_id) {
         param.eventID = event_id;
       }

--- a/js/facebook_signal.js
+++ b/js/facebook_signal.js
@@ -202,10 +202,9 @@ window.fbwcsignal = window.fbwcsignal || {};
     return match ? decodeURIComponent(match[1]) : null;
   }
 
-  api.setState = function (state) {
-    var granted = state === 'active';
-    var cookieValue = granted ? 'active' : 'held';
-    setCookie(cookieValue);
+  function updateState(state) {
+    var normalizedState = state === 'active' ? 'active' : 'held';
+    setCookie(normalizedState);
 
     return new Promise(function (resolve, reject) {
       var xhr = new XMLHttpRequest();
@@ -222,7 +221,7 @@ window.fbwcsignal = window.fbwcsignal || {};
 
         try {
           var response = JSON.parse(xhr.responseText);
-          if (!granted) {
+          if (normalizedState === 'held') {
             window.FacebookSignal.hold();
             resolve(response);
             return;
@@ -254,17 +253,17 @@ window.fbwcsignal = window.fbwcsignal || {};
           '&security=' +
           encodeURIComponent(signalsNonce) +
           '&state=' +
-          encodeURIComponent(cookieValue),
+          encodeURIComponent(normalizedState),
       );
     });
-  };
+  }
 
   api.hold = function () {
-    return api.setState('held');
+    return updateState('held');
   };
 
   api.release = function () {
-    return api.setState('active');
+    return updateState('active');
   };
 
   api.getState = function () {

--- a/js/facebook_signal.js
+++ b/js/facebook_signal.js
@@ -1,5 +1,5 @@
 window.FacebookSignal = window.FacebookSignal || {
-  _paused: false,
+  _held: false,
   _queue: [],
   _config: {},
   _seenEventIds: {},
@@ -27,7 +27,7 @@ window.FacebookSignal = window.FacebookSignal || {
 
   init: function (config) {
     this._config = config || {};
-    this._paused = !!this._config.paused;
+    this._held = !!this._config.held;
 
     try {
       var raw = window.sessionStorage.getItem('fbpix_seen_event_ids');
@@ -71,7 +71,7 @@ window.FacebookSignal = window.FacebookSignal || {
       delete eventParams.eventID;
     }
 
-    if (this._paused) {
+    if (this._held) {
       this.queueEvent({
         event_name: name,
         custom_data: eventParams,
@@ -88,17 +88,15 @@ window.FacebookSignal = window.FacebookSignal || {
     }
   },
 
-  setPaused: function (paused) {
-    this._paused = !!paused;
-    if (this._paused) {
-      fbq('consent', 'revoke');
-    }
+  hold: function () {
+    this._held = true;
+    fbq('consent', 'revoke');
   },
 
-  resume: function () {
+  release: function () {
     var self = this;
 
-    if (!self._paused || !self._config.ajaxUrl) {
+    if (!self._held || !self._config.ajaxUrl) {
       return Promise.resolve({ success: true, data: { sent_count: 0 } });
     }
 
@@ -108,19 +106,19 @@ window.FacebookSignal = window.FacebookSignal || {
         self._config.ajaxUrl +
         (self._config.ajaxUrl.indexOf('?') === -1 ? '?' : '&') +
         'action=' +
-        encodeURIComponent(self._config.resumeAction);
+        encodeURIComponent(self._config.releaseAction);
 
       xhr.open('POST', url, true);
       xhr.setRequestHeader('Content-Type', 'application/json');
       xhr.onload = function () {
         if (xhr.status < 200 || xhr.status >= 300) {
-          reject(new Error('Resume AJAX failed: ' + xhr.status));
+          reject(new Error('Release AJAX failed: ' + xhr.status));
           return;
         }
 
         try {
           var response = JSON.parse(xhr.responseText);
-          self._handleResumeResponse(response.data || {});
+          self._handleReleaseResponse(response.data || {});
           resolve(response);
         } catch (error) {
           reject(error);
@@ -129,19 +127,20 @@ window.FacebookSignal = window.FacebookSignal || {
       xhr.onerror = function () {
         reject(new Error('Network error'));
       };
+      var attribution = self._config.attribution || {};
       xhr.send(
         JSON.stringify({
-          security: self._config.resumeNonce,
+          security: self._config.releaseNonce,
           events: self._queue,
           fbclid: self._fbclid,
-          fbp: self._readCookie('_fbp'),
-          fbc: self._readCookie('_fbc'),
+          fbp: self._readCookie('_fbp') || attribution.fbp || null,
+          fbc: self._readCookie('_fbc') || attribution.fbc || null,
         }),
       );
     });
   },
 
-  _handleResumeResponse: function (data) {
+  _handleReleaseResponse: function (data) {
     if (data.fbp) {
       document.cookie =
         '_fbp=' +
@@ -172,11 +171,11 @@ window.FacebookSignal = window.FacebookSignal || {
     }
 
     this._queue = [];
-    this._paused = false;
+    this._held = false;
   },
 };
 
-window.fbpix = window.fbpix || {};
+window.fbwcsignal = window.fbwcsignal || {};
 (function (api) {
   var signalConfig = window.facebookSignalConfig || {};
   var cookieName = signalConfig.cookieName || '';
@@ -203,9 +202,10 @@ window.fbpix = window.fbpix || {};
     return match ? decodeURIComponent(match[1]) : null;
   }
 
-  api.setSignals = function (granted) {
-    var value = granted ? '1' : '0';
-    setCookie(value);
+  api.setState = function (state) {
+    var granted = state === 'active';
+    var cookieValue = granted ? 'active' : 'held';
+    setCookie(cookieValue);
 
     return new Promise(function (resolve, reject) {
       var xhr = new XMLHttpRequest();
@@ -223,13 +223,13 @@ window.fbpix = window.fbpix || {};
         try {
           var response = JSON.parse(xhr.responseText);
           if (!granted) {
-            window.FacebookSignal.setPaused(true);
+            window.FacebookSignal.hold();
             resolve(response);
             return;
           }
 
-          if (window.FacebookSignal && window.FacebookSignal._paused) {
-            window.FacebookSignal.resume().then(
+          if (window.FacebookSignal && window.FacebookSignal._held) {
+            window.FacebookSignal.release().then(
               function () {
                 resolve(response);
               },
@@ -254,16 +254,24 @@ window.fbpix = window.fbpix || {};
           '&security=' +
           encodeURIComponent(signalsNonce) +
           '&granted=' +
-          encodeURIComponent(value),
+          encodeURIComponent(granted ? '1' : '0'),
       );
     });
   };
 
-  api.getSignals = function () {
+  api.hold = function () {
+    return api.setState('held');
+  };
+
+  api.release = function () {
+    return api.setState('active');
+  };
+
+  api.getState = function () {
     var value = getCookie();
     if (value === null) {
       return null;
     }
-    return value === '1';
+    return value === 'active' ? 'active' : 'held';
   };
-})(window.fbpix);
+})(window.fbwcsignal);

--- a/js/facebook_signal.js
+++ b/js/facebook_signal.js
@@ -269,9 +269,9 @@ window.fbwcsignal = window.fbwcsignal || {};
 
   api.getState = function () {
     var value = getCookie();
-    if (value === null) {
-      return null;
+    if (value === 'active' || value === 'held') {
+      return value;
     }
-    return value === 'active' ? 'active' : 'held';
+    return null;
   };
 })(window.fbwcsignal);

--- a/js/facebook_signal.js
+++ b/js/facebook_signal.js
@@ -253,8 +253,8 @@ window.fbwcsignal = window.fbwcsignal || {};
           encodeURIComponent(signalsAction) +
           '&security=' +
           encodeURIComponent(signalsNonce) +
-          '&granted=' +
-          encodeURIComponent(granted ? '1' : '0'),
+          '&state=' +
+          encodeURIComponent(cookieValue),
       );
     });
   };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
   "name": "facebook-pixel-for-wordpress",
-  "version": "1.0.0",
+  "version": "5.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "facebook-pixel-for-wordpress",
-      "version": "1.0.0",
-      "license": "ISC",
+      "version": "5.1.0",
+      "license": "GPL-2.0",
       "devDependencies": {
         "prettier": "^3.3.3"
       }


### PR DESCRIPTION
## Description

This changeset continues/complements the work in https://github.com/facebookincubator/Facebook-Pixel-for-Wordpress/pull/141.

The changes refactor the method names for consistency with documentation and other implementations.

It also updates `package-lock.json` metadata to match the `package.json` version & license.

### Type of change

- Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/b2b0midg)).
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary).


## Changelog entry

Update signal held-state method naming to use hold/release terminology.


## Test Plan

- Default/resumed state: Pixel and CAPI send events.
- Pause signals: no Pixel or CAPI sends; events added to queue.
- Resume signals: queued events replay via Pixel and CAPI.
- Verify _fbp and _fbc handling on replay.
- Verify rate limit returns HTTP 429 when exceeded.
- Verify admin/cron CAPI events still send while paused.

## Screenshots

N/A