### PR TITLE
Auth Error handling through circuit breaker and admin notice

### DIFF
--- a/__tests__/core/FacebookCapiCircuitBreakerTest.php
+++ b/__tests__/core/FacebookCapiCircuitBreakerTest.php
@@ -1,0 +1,274 @@
+<?php
+/**
+ * Facebook Pixel Plugin FacebookCapiCircuitBreakerTest class.
+ *
+ * @package FacebookPixelPlugin
+ */
+
+namespace FacebookPixelPlugin\Tests\Core;
+
+use FacebookPixelPlugin\Core\FacebookCapiCircuitBreaker;
+use FacebookPixelPlugin\Core\FacebookPluginConfig;
+use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
+
+/**
+ * FacebookCapiCircuitBreakerTest class.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class FacebookCapiCircuitBreakerTest extends FacebookWordpressTestBase {
+
+  /**
+   * Tests that sending is allowed when no transient is set.
+   */
+  public function testSendAllowedWhenNoTransient() {
+    \WP_Mock::userFunction(
+      'get_transient',
+      array(
+        'args'   => array(
+          FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT,
+        ),
+        'return' => false,
+      )
+    );
+
+    $this->assertTrue( FacebookCapiCircuitBreaker::is_send_allowed() );
+  }
+
+  /**
+   * Tests that sending is blocked when transient is fresh (circuit open).
+   */
+  public function testSendBlockedWhenTransientFresh() {
+    \WP_Mock::userFunction(
+      'get_transient',
+      array(
+        'args'   => array(
+          FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT,
+        ),
+        'return' => time() - 60,
+      )
+    );
+
+    $this->assertFalse( FacebookCapiCircuitBreaker::is_send_allowed() );
+  }
+
+  /**
+   * Tests that sending is allowed when transient is stale (half-open).
+   */
+  public function testSendAllowedWhenTransientStale() {
+    \WP_Mock::userFunction(
+      'get_transient',
+      array(
+        'args'   => array(
+          FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT,
+        ),
+        'return' => time() - FacebookPluginConfig::CONNECTION_RETRY_INTERVAL - 1,
+      )
+    );
+
+    $this->assertTrue( FacebookCapiCircuitBreaker::is_send_allowed() );
+  }
+
+  /**
+   * Tests that is_tripped returns false when no transient is set.
+   */
+  public function testNotTrippedWhenNoTransient() {
+    \WP_Mock::userFunction(
+      'get_transient',
+      array(
+        'args'   => array(
+          FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT,
+        ),
+        'return' => false,
+      )
+    );
+
+    $this->assertFalse( FacebookCapiCircuitBreaker::is_tripped() );
+  }
+
+  /**
+   * Tests that is_tripped returns true when transient is set.
+   */
+  public function testTrippedWhenTransientSet() {
+    \WP_Mock::userFunction(
+      'get_transient',
+      array(
+        'args'   => array(
+          FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT,
+        ),
+        'return' => time(),
+      )
+    );
+
+    $this->assertTrue( FacebookCapiCircuitBreaker::is_tripped() );
+  }
+
+  /**
+   * Tests that record_success clears the transient when tripped.
+   */
+  public function testRecordSuccessClearsTransientWhenTripped() {
+    \WP_Mock::userFunction(
+      'get_transient',
+      array(
+        'args'   => array(
+          FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT,
+        ),
+        'return' => time() - 100,
+      )
+    );
+
+    \WP_Mock::userFunction(
+      'delete_transient',
+      array(
+        'args'   => array(
+          FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT,
+        ),
+        'times'  => 1,
+        'return' => true,
+      )
+    );
+
+    FacebookCapiCircuitBreaker::record_success();
+  }
+
+  /**
+   * Tests that record_success does nothing when not tripped.
+   */
+  public function testRecordSuccessNoOpWhenNotTripped() {
+    \WP_Mock::userFunction(
+      'get_transient',
+      array(
+        'args'   => array(
+          FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT,
+        ),
+        'return' => false,
+      )
+    );
+
+    \WP_Mock::userFunction(
+      'delete_transient',
+      array(
+        'times'  => 0,
+      )
+    );
+
+    FacebookCapiCircuitBreaker::record_success();
+  }
+
+  /**
+   * Tests that record_exception trips the breaker for AuthorizationException.
+   */
+  public function testRecordExceptionTripsForAuthError() {
+    $response = \Mockery::mock(
+      'FacebookPixelPlugin\FacebookAds\Http\ResponseInterface'
+    );
+    $response->shouldReceive( 'getHeaders' )->andReturn( null );
+    $response->shouldReceive( 'getContent' )->andReturn(
+      array(
+        'error' => array(
+          'code'            => 190,
+          'error_subcode'   => 464,
+          'message'         => 'User not confirmed',
+          'type'            => 'OAuthException',
+          'error_user_title' => null,
+          'error_user_msg'  => null,
+        ),
+      )
+    );
+
+    $exception = new \FacebookPixelPlugin\FacebookAds\Http\Exception\AuthorizationException( $response );
+
+    \WP_Mock::userFunction(
+      'set_transient',
+      array(
+        'times'  => 1,
+        'return' => true,
+      )
+    );
+
+    FacebookCapiCircuitBreaker::record_exception( $exception );
+  }
+
+  /**
+   * Tests that record_exception does NOT trip for subcode 452.
+   */
+  public function testRecordExceptionSkipsSubcode452() {
+    $response = \Mockery::mock(
+      'FacebookPixelPlugin\FacebookAds\Http\ResponseInterface'
+    );
+    $response->shouldReceive( 'getHeaders' )->andReturn( null );
+    $response->shouldReceive( 'getContent' )->andReturn(
+      array(
+        'error' => array(
+          'code'            => 190,
+          'error_subcode'   => 452,
+          'message'         => 'Session mismatch',
+          'type'            => 'OAuthException',
+          'error_user_title' => null,
+          'error_user_msg'  => null,
+        ),
+      )
+    );
+
+    $exception = new \FacebookPixelPlugin\FacebookAds\Http\Exception\AuthorizationException( $response );
+
+    \WP_Mock::userFunction(
+      'set_transient',
+      array(
+        'times'  => 0,
+      )
+    );
+
+    FacebookCapiCircuitBreaker::record_exception( $exception );
+  }
+
+  /**
+   * Tests that record_exception trips for PermissionException.
+   */
+  public function testRecordExceptionTripsForPermissionError() {
+    $response = \Mockery::mock(
+      'FacebookPixelPlugin\FacebookAds\Http\ResponseInterface'
+    );
+    $response->shouldReceive( 'getHeaders' )->andReturn( null );
+    $response->shouldReceive( 'getContent' )->andReturn(
+      array(
+        'error' => array(
+          'code'            => 200,
+          'message'         => 'Permission denied',
+          'type'            => 'OAuthException',
+          'error_user_title' => null,
+          'error_user_msg'  => null,
+        ),
+      )
+    );
+
+    $exception = new \FacebookPixelPlugin\FacebookAds\Http\Exception\PermissionException( $response );
+
+    \WP_Mock::userFunction(
+      'set_transient',
+      array(
+        'times'  => 1,
+        'return' => true,
+      )
+    );
+
+    FacebookCapiCircuitBreaker::record_exception( $exception );
+  }
+
+  /**
+   * Tests that record_exception does NOT trip for generic exceptions.
+   */
+  public function testRecordExceptionIgnoresGenericException() {
+    $exception = new \Exception( 'Network error' );
+
+    \WP_Mock::userFunction(
+      'set_transient',
+      array(
+        'times'  => 0,
+      )
+    );
+
+    FacebookCapiCircuitBreaker::record_exception( $exception );
+  }
+}

--- a/__tests__/core/FacebookServerSideEventTest.php
+++ b/__tests__/core/FacebookServerSideEventTest.php
@@ -30,6 +30,7 @@ namespace FacebookPixelPlugin\Tests\Core;
 use FacebookPixelPlugin\Core\ServerEventFactory;
 use FacebookPixelPlugin\Core\FacebookSignalState;
 use FacebookPixelPlugin\Core\FacebookServerSideEvent;
+use FacebookPixelPlugin\Core\FacebookPluginConfig;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 
 /**
@@ -207,9 +208,116 @@ final class FacebookServerSideEventTest extends FacebookWordpressTestBase {
     $api = \Mockery::mock( 'alias:FacebookPixelPlugin\FacebookAds\Api' );
     $api->shouldReceive( 'init' )->never();
 
-    $event = ServerEventFactory::new_event( 'Lead' );
-    FacebookServerSideEvent::send( array( $event ) );
+    $event  = ServerEventFactory::new_event( 'Lead' );
+    $result = FacebookServerSideEvent::send( array( $event ) );
 
-    $this->assertTrue( true );
+    $this->assertNull( $result );
+  }
+
+  /**
+   * Tests that send() returns error when circuit breaker is open.
+   */
+  public function testSendReturnsErrorWhenCircuitOpen() {
+    self::mockFacebookWordpressOptions();
+
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+    \WP_Mock::userFunction( 'is_admin', array( 'return' => false ) );
+    \WP_Mock::userFunction( 'wp_doing_cron', array( 'return' => false ) );
+
+    \WP_Mock::userFunction(
+      'get_transient',
+      array(
+        'args'   => array(
+          FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT,
+        ),
+        'return' => time() - 60,
+      )
+    );
+
+    $api = \Mockery::mock( 'alias:FacebookPixelPlugin\FacebookAds\Api' );
+    $api->shouldReceive( 'init' )->never();
+
+    $event  = ServerEventFactory::new_event( 'Lead' );
+    $result = FacebookServerSideEvent::send( array( $event ) );
+
+    $this->assertFalse( $result['success'] );
+    $this->assertStringContainsString( 'circuit', $result['error']['message'] );
+  }
+
+  /**
+   * Tests that send() blocks with a circuit-open error only when the
+   * transient is fresh, not when it's stale (half-open).
+   */
+  public function testSendBlocksOnlyWhenTransientFresh() {
+    self::mockFacebookWordpressOptions();
+
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+    \WP_Mock::userFunction( 'is_admin', array( 'return' => false ) );
+    \WP_Mock::userFunction( 'wp_doing_cron', array( 'return' => false ) );
+
+    // Fresh transient → circuit open → should block.
+    \WP_Mock::userFunction(
+      'get_transient',
+      array(
+        'args'   => array(
+          FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT,
+        ),
+        'return' => time() - 10,
+      )
+    );
+
+    $event  = ServerEventFactory::new_event( 'Lead' );
+    $result = FacebookServerSideEvent::send( array( $event ) );
+
+    $this->assertFalse( $result['success'] );
+    $this->assertStringContainsString(
+      'circuit',
+      $result['error']['message']
+    );
+  }
+
+  /**
+   * Tests that send() returns null when pixel_id or access_token is empty.
+   */
+  public function testSendReturnsNullWhenNoCredentials() {
+    self::mockFacebookWordpressOptions(
+      array(
+        'pixel_id'     => '',
+        'access_token' => '',
+      )
+    );
+
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+    \WP_Mock::userFunction( 'is_admin', array( 'return' => false ) );
+    \WP_Mock::userFunction( 'wp_doing_cron', array( 'return' => false ) );
+
+    $event  = ServerEventFactory::new_event( 'Lead' );
+    $result = FacebookServerSideEvent::send( array( $event ) );
+
+    $this->assertNull( $result );
   }
 }

--- a/__tests__/core/FacebookWordpressSettingsRecorderTest.php
+++ b/__tests__/core/FacebookWordpressSettingsRecorderTest.php
@@ -98,6 +98,18 @@ final class FacebookWordpressSettingsRecorderTest extends FacebookWordpressTestB
         'return' => true,
       )
     );
+    \WP_Mock::userFunction(
+      'delete_transient',
+      array(
+        'return' => true,
+      )
+    );
+    \WP_Mock::userFunction(
+      'delete_metadata',
+      array(
+        'return' => true,
+      )
+    );
   }
 
   /**
@@ -793,6 +805,18 @@ final class FacebookWordpressSettingsRecorderTest extends FacebookWordpressTestB
         'return' => function ( $input ) {
           return $input;
         },
+      )
+    );
+    \WP_Mock::userFunction(
+      'delete_transient',
+      array(
+        'return' => true,
+      )
+    );
+    \WP_Mock::userFunction(
+      'delete_metadata',
+      array(
+        'return' => true,
       )
     );
   }

--- a/__tests__/core/ServerEventFactoryTest.php
+++ b/__tests__/core/ServerEventFactoryTest.php
@@ -952,4 +952,97 @@ final class ServerEventFactoryTest extends FacebookWordpressTestBase {
     $this->mocked_options->shouldReceive( 'get_aam_settings' )
       ->andReturn( $aam_settings );
   }
+
+  /**
+   * Tests that create_from_array builds an Event with scalar fields.
+   */
+  public function testCreateFromArraySetsScalarFields() {
+    $event = ServerEventFactory::create_from_array(
+      array(
+        'event_name'       => 'Purchase',
+        'event_time'       => 1700000000,
+        'event_id'         => 'evt.123',
+        'action_source'    => 'website',
+        'event_source_url' => 'https://example.com',
+      )
+    );
+
+    $this->assertEquals( 'Purchase', $event->getEventName() );
+    $this->assertEquals( 1700000000, $event->getEventTime() );
+    $this->assertEquals( 'evt.123', $event->getEventId() );
+  }
+
+  /**
+   * Tests that create_from_array wraps user_data as UserData object.
+   */
+  public function testCreateFromArrayWrapsUserData() {
+    $event = ServerEventFactory::create_from_array(
+      array(
+        'event_name' => 'Lead',
+        'event_time' => 1700000000,
+        'user_data'  => array(
+          'em' => array( 'abc123hash' ),
+          'ph' => array( 'def456hash' ),
+        ),
+      )
+    );
+
+    $user_data = $event->getUserData();
+    $this->assertInstanceOf(
+      'FacebookPixelPlugin\FacebookAds\Object\ServerSide\UserData',
+      $user_data
+    );
+  }
+
+  /**
+   * Tests that create_from_array wraps custom_data as CustomData object.
+   */
+  public function testCreateFromArrayWrapsCustomData() {
+    $event = ServerEventFactory::create_from_array(
+      array(
+        'event_name'  => 'Purchase',
+        'event_time'  => 1700000000,
+        'custom_data' => array(
+          'value'    => 99.99,
+          'currency' => 'USD',
+        ),
+      )
+    );
+
+    $custom_data = $event->getCustomData();
+    $this->assertInstanceOf(
+      'FacebookPixelPlugin\FacebookAds\Object\ServerSide\CustomData',
+      $custom_data
+    );
+  }
+
+  /**
+   * Tests that map_user_data_keys translates AAM field keys.
+   */
+  public function testMapUserDataKeysTranslatesAamFields() {
+    $result = ServerEventFactory::map_user_data_keys(
+      array(
+        'em' => 'test@example.com',
+        'fn' => 'John',
+        'ln' => 'Doe',
+      )
+    );
+
+    $this->assertEquals( 'test@example.com', $result['emails'] );
+    $this->assertEquals( 'John', $result['first_names'] );
+    $this->assertEquals( 'Doe', $result['last_names'] );
+  }
+
+  /**
+   * Tests that map_user_data_keys passes through unknown keys.
+   */
+  public function testMapUserDataKeysPassesThroughUnknownKeys() {
+    $result = ServerEventFactory::map_user_data_keys(
+      array(
+        'custom_field' => 'value',
+      )
+    );
+
+    $this->assertEquals( 'value', $result['custom_field'] );
+  }
 }

--- a/core/class-facebookcapicircuitbreaker.php
+++ b/core/class-facebookcapicircuitbreaker.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Facebook Pixel Plugin FacebookCapiCircuitBreaker class.
+ *
+ * Half-open circuit breaker for Conversions API calls.
+ * Detects OAuth/permission errors, blocks calls while the token
+ * is known-bad, and periodically retries to self-heal.
+ *
+ * @package FacebookPixelPlugin
+ */
+
+/*
+* Copyright (C) 2017-present, Meta, Inc.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; version 2 of the License.
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*/
+
+namespace FacebookPixelPlugin\Core;
+
+use FacebookPixelPlugin\FacebookAds\Http\Exception\AuthorizationException;
+use FacebookPixelPlugin\FacebookAds\Http\Exception\PermissionException;
+
+defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
+
+/**
+ * Class FacebookCapiCircuitBreaker
+ */
+class FacebookCapiCircuitBreaker {
+
+    /**
+     * Checks whether sending is allowed right now.
+     *
+     * Returns true when the circuit is closed (no error) or
+     * half-open (retry interval elapsed). Returns false when
+     * the circuit is open (recent auth error).
+     *
+     * @return bool
+     */
+    public static function is_send_allowed() {
+        $timestamp = get_transient(
+            FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT
+        );
+        if ( false === $timestamp ) {
+            return true;
+        }
+        $elapsed = time() - (int) $timestamp;
+        return $elapsed >= FacebookPluginConfig::CONNECTION_RETRY_INTERVAL;
+    }
+
+    /**
+     * Whether the circuit breaker is currently tripped (open or half-open).
+     *
+     * @return bool
+     */
+    public static function is_tripped() {
+        return false !== get_transient(
+            FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT
+        );
+    }
+
+    /**
+     * Records a successful API call. Clears the transient if the
+     * circuit was in half-open state (silent self-heal).
+     *
+     * @return void
+     */
+    public static function record_success() {
+        if ( self::is_tripped() ) {
+            delete_transient(
+                FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT
+            );
+        }
+    }
+
+    /**
+     * Inspects an exception and trips the circuit breaker if it
+     * indicates an auth or permission error.
+     *
+     * Subcode 452 (session mismatch) is exempt because it may
+     * self-resolve without merchant action.
+     *
+     * @param \Exception $e The caught exception.
+     * @return void
+     */
+    public static function record_exception( \Exception $e ) {
+        if ( $e instanceof AuthorizationException ) {
+            if ( 452 === $e->getErrorSubcode() ) {
+                return;
+            }
+            self::trip();
+        } elseif ( $e instanceof PermissionException ) {
+            self::trip();
+        }
+    }
+
+    /**
+     * Trips the circuit breaker by setting the transient.
+     *
+     * @return void
+     */
+    private static function trip() {
+        set_transient(
+            FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT,
+            time(),
+            DAY_IN_SECONDS
+        );
+    }
+}

--- a/core/class-facebookcapievent.php
+++ b/core/class-facebookcapievent.php
@@ -29,6 +29,7 @@ namespace FacebookPixelPlugin\Core;
 
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\EventRequest;
 use FacebookPixelPlugin\FacebookAds\ApiConfig;
+use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 
 defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 
@@ -135,6 +136,7 @@ class FacebookCapiEvent {
             wp_die();
         }
 
+        $test_event_code = null;
         if ( isset( $_POST['test_event_code'] ) ) {
             $raw_test_event_code = sanitize_text_field(
                 wp_unslash( $_POST['test_event_code'] )
@@ -154,15 +156,8 @@ class FacebookCapiEvent {
                 );
                 wp_die();
             }
+            $test_event_code = $raw_test_event_code;
         }
-
-        $api_version  = ApiConfig::APIVersion;
-        $pixel_id     = FacebookWordpressOptions::get_active_pixel_id();
-        $access_token = FacebookWordpressOptions::get_active_access_token();
-
-        $url = 'https://graph.facebook.com/v' .
-        $api_version . '/' . $pixel_id .
-        '/events?access_token=' . $access_token;
 
         $event_name = isset( $_POST['event_name'] ) ?
         sanitize_text_field( wp_unslash( $_POST['event_name'] ) ) : null;
@@ -188,40 +183,16 @@ class FacebookCapiEvent {
                 )
             );
             wp_die();
-        } else {
-            $event = ServerEventFactory::safe_create_event(
+        }
+
+            $event  = ServerEventFactory::safe_create_event(
                 $event_name,
                 array( $this, 'get_event_custom_data' ),
                 array( $custom_data ),
                 'fb-capi-event',
                 true
             );
-
-            $events = array();
-            array_push( $events, $event );
-
-            $event_request = ( new EventRequest( $pixel_id ) )
-                ->setEvents( $events )
-                ->setTestEventCode(
-                    isset( $_POST['test_event_code'] ) ?
-                    sanitize_text_field(
-                        wp_unslash( $_POST['test_event_code'] )
-                    ) :
-                    null
-                );
-
-            $normalized_event = $event_request->normalize();
-
-            if ( ! empty( $_POST['user_data'] ) ) {
-            foreach ( $normalized_event['data'] as $key => $value ) {
-                $normalized_event['data'][ $key ]['user_data'] +=
-                isset( $_POST['user_data'] ) ?
-                $_POST['user_data'] : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-            }
-            }
-
-            $payload = wp_json_encode( $normalized_event );
-        }
+            $events = array( $event );
         } else {
             $validated_payload =
             self::validate_payload(
@@ -241,29 +212,49 @@ class FacebookCapiEvent {
                 )
             );
             wp_die();
-        } else {
-            $payload = wp_json_encode(
-                isset( $_POST['payload'] )
-                ? $_POST['payload'] : null // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+        }
+
+            $raw_payload = isset( $_POST['payload'] ) ?
+                $_POST['payload'] : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized,WordPress.Security.ValidatedSanitizedInput.MissingUnslash
+            if ( isset( $raw_payload['test_event_code'] )
+                && empty( $test_event_code ) ) {
+                $test_event_code = sanitize_text_field(
+                    $raw_payload['test_event_code']
+                );
+            }
+            $events = array();
+            if ( isset( $raw_payload['data'] ) ) {
+                foreach ( $raw_payload['data'] as $event_as_array ) {
+                    $events[] = ServerEventFactory::create_from_array(
+                        $event_as_array
+                    );
+                }
+            }
+        }
+
+        $result = FacebookServerSideEvent::send( $events, $test_event_code );
+
+        if ( $result && $result['success'] ) {
+            wp_send_json_success(
+                wp_json_encode(
+                    array(
+                        'events_received' => $result['events_received'],
+                    )
+                )
             );
-        }
-        }
-
-        $args = array(
-            'body'    => $payload,
-            'headers' => array(
-                'Content-Type' => 'application/json',
-                'Accept'       => '*/*',
-            ),
-            'method'  => 'POST',
-        );
-
-        $response = wp_remote_post( $url, $args );
-
-        if ( is_wp_error( $response ) ) {
-            wp_send_json_error( $response->get_error_message() );
         } else {
-            wp_send_json_success( wp_remote_retrieve_body( $response ) );
+            $error_msg = isset( $result['error']['message'] )
+                ? $result['error']['message'] : 'Unknown error';
+            wp_send_json_success(
+                wp_json_encode(
+                    array(
+                        'error' => array(
+                            'message'        => $error_msg,
+                            'error_user_msg' => $error_msg,
+                        ),
+                    )
+                )
+            );
         }
         wp_die();
     }

--- a/core/class-facebookpluginconfig.php
+++ b/core/class-facebookpluginconfig.php
@@ -133,6 +133,14 @@ class FacebookPluginConfig {
     const CAPI_PII_CACHING_STATUS_UPDATE_ERROR            =
     'Status could not be saved, please refresh the page and continue.';
 
+    const CONNECTION_INVALID_TRANSIENT            =
+    'facebook_pixel_connection_invalid';
+    const CONNECTION_RETRY_INTERVAL               = 3600;
+    const ADMIN_DISMISS_CONNECTION_INVALID_NOTICE =
+    'dismiss_connection_invalid_notice';
+    const ADMIN_IGNORE_CONNECTION_INVALID_NOTICE  =
+    'ignore_connection_invalid_notice';
+
     /**
      * Integration config: INTEGRATION_KEY => PLUGIN_CLASS.
      *

--- a/core/class-facebookserversideevent.php
+++ b/core/class-facebookserversideevent.php
@@ -95,13 +95,13 @@ class FacebookServerSideEvent {
         if ( $send_now ) {
             if ( self::should_suppress_frontend_send() ) {
                 FacebookSignalState::queue_event( $event );
-                return;
+            } else {
+                do_action(
+                    'send_server_events',
+                    array( $event ),
+                    1
+                );
             }
-            do_action(
-                'send_server_events',
-                array( $event ),
-                1
-            );
         } else {
             $this->pending_events[] = $event;
         }
@@ -165,23 +165,23 @@ class FacebookServerSideEvent {
     /**
      * Sends a list of events to the Conversions API.
      *
-     * This function can be used to send events to the Conversions API directly.
-     * It will apply the 'before_conversions_api_event_sent'
-     * filter to the events before sending them.
+     * All CAPI event sending flows through this method.
      *
-     * @param ServerEvent[] $events The events to send to the Conversions API.
+     * @param ServerEvent[] $events          The events to send.
+     * @param string|null   $test_event_code Optional test event code.
+     * @return array|null Result array with 'success' key, or null if skipped.
      */
-    public static function send( $events ) {
+    public static function send( $events, $test_event_code = null ) {
         $events = apply_filters( 'before_conversions_api_event_sent', $events );
         if ( empty( $events ) ) {
-            return;
+            return null;
         }
 
         if ( self::should_suppress_frontend_send() ) {
             foreach ( $events as $queued_event ) {
                 FacebookSignalState::queue_event( $queued_event );
             }
-            return;
+            return null;
         }
 
         $pixel_id     = FacebookWordpressOptions::get_active_pixel_id();
@@ -189,12 +189,23 @@ class FacebookServerSideEvent {
         $agent        = FacebookWordpressOptions::get_agent_string();
 
         if ( self::is_open_bridge_event( $events ) ) {
-            $agent .= '_ob'; // agent suffix is openbridge.
+            $agent .= '_ob';
         }
 
         if ( empty( $pixel_id ) || empty( $access_token ) ) {
-            return;
+            return null;
         }
+
+        if ( ! FacebookCapiCircuitBreaker::is_send_allowed() ) {
+            return array(
+                'success' => false,
+                'error'   => array(
+                    'message' => 'Connection invalid (circuit open)',
+                    'code'    => 0,
+                ),
+            );
+        }
+
         try {
             $api = Api::init( null, null, $access_token );
 
@@ -202,13 +213,31 @@ class FacebookServerSideEvent {
                     ->setEvents( $events )
                     ->setPartnerAgent( $agent );
 
+            if ( $test_event_code ) {
+                $request->setTestEventCode( $test_event_code );
+            }
+
             $response = $request->execute();
+
+            FacebookCapiCircuitBreaker::record_success();
+
+            return array(
+                'success'         => true,
+                'events_received' => $response->getEventsReceived(),
+            );
         } catch ( \Exception $e ) {
+            FacebookCapiCircuitBreaker::record_exception( $e );
             // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
-            error_log( '[Facebook Pixel for WordPress] Send Events Exception: ' . $e->getMessage() );
+            error_log( '[Facebook Pixel for WordPress] CAPI error: ' . $e->getMessage() );
             error_log( $e->getTraceAsString() );
             // phpcs:enable WordPress.PHP.DevelopmentFunctions.error_log_error_log
-
+            return array(
+                'success' => false,
+                'error'   => array(
+                    'message' => $e->getMessage(),
+                    'code'    => $e->getCode(),
+                ),
+            );
         }
     }
 

--- a/core/class-facebookwordpresssettingspage.php
+++ b/core/class-facebookwordpresssettingspage.php
@@ -875,6 +875,29 @@ class FacebookWordpressSettingsPage {
             }
         }
 
+        // Show connection invalid notice on dashboard, plugins, AND settings page.
+        $connection_screens = array(
+            'dashboard',
+            'plugins',
+            'settings_page_' . FacebookPluginConfig::ADMIN_MENU_SLUG,
+        );
+        if ( current_user_can( FacebookPluginConfig::ADMIN_CAPABILITY )
+            && in_array( $current_screen_id, $connection_screens, true )
+            && get_transient(
+                FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT
+            )
+            && ! get_user_meta(
+                get_current_user_id(),
+                FacebookPluginConfig::ADMIN_IGNORE_CONNECTION_INVALID_NOTICE,
+                true
+            )
+        ) {
+            add_action(
+                'admin_notices',
+                array( $this, 'connection_invalid_notice' )
+            );
+        }
+
         // Show FBL4B upgrade banner on dashboard, plugins, AND settings page.
         $fbl4b_screens = array(
             'dashboard',
@@ -1071,6 +1094,43 @@ class FacebookWordpressSettingsPage {
     }
 
     /**
+     * Displays a notice when the Meta connection is invalid.
+     */
+    public function connection_invalid_notice() {
+        $dismiss_url   = add_query_arg(
+            FacebookPluginConfig::ADMIN_DISMISS_CONNECTION_INVALID_NOTICE,
+            '1'
+        );
+        $settings_url  = admin_url(
+            'options-general.php?page='
+            . FacebookPluginConfig::ADMIN_MENU_SLUG
+        );
+        $reconnect_url = add_query_arg(
+            'upgrade_to_fbl4b',
+            '1',
+            $settings_url
+        );
+        ?>
+        <div class="notice notice-error">
+            <p><strong>Meta Pixel for WordPress</strong></p>
+            <p>
+                Your connection to Meta is no longer valid and Conversions API
+                events have been paused. This can happen when the system user is
+                removed, the password is changed, or the app is deauthorized.
+                Please reconnect using Facebook Login for Business to restore
+                event delivery.
+            </p>
+            <p>
+                <a href="<?php echo esc_url( $reconnect_url ); ?>"
+                   class="button button-primary"
+                   style="margin-right: 8px;">Reconnect</a>
+                <a href="<?php echo esc_url( $dismiss_url ); ?>">Dismiss</a>
+            </p>
+        </div>
+        <?php
+    }
+
+    /**
      * Displays a notice indicating that the Facebook
      * Business Extension is not installed.
      *
@@ -1137,6 +1197,15 @@ class FacebookWordpressSettingsPage {
             update_user_meta(
                 $user_id,
                 FacebookPluginConfig::ADMIN_IGNORE_FBL4B_UPGRADE_NOTICE,
+                true
+            );
+        }
+        if ( isset(
+            $_GET[ FacebookPluginConfig::ADMIN_DISMISS_CONNECTION_INVALID_NOTICE ] // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+        ) ) {
+            update_user_meta(
+                $user_id,
+                FacebookPluginConfig::ADMIN_IGNORE_CONNECTION_INVALID_NOTICE,
                 true
             );
         }

--- a/core/class-facebookwordpresssettingsrecorder.php
+++ b/core/class-facebookwordpresssettingsrecorder.php
@@ -178,6 +178,16 @@ class FacebookWordpressSettingsRecorder {
             FacebookPluginConfig::SETTINGS_KEY,
             $settings
         );
+        \delete_transient(
+            FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT
+        );
+        delete_metadata(
+            'user',
+            0,
+            FacebookPluginConfig::ADMIN_IGNORE_CONNECTION_INVALID_NOTICE,
+            '',
+            true
+        );
         return $this->handle_success_request( $settings );
     }
 
@@ -432,6 +442,16 @@ class FacebookWordpressSettingsRecorder {
                     );
                 }
             }
+            \delete_transient(
+                FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT
+            );
+            delete_metadata(
+                'user',
+                0,
+                FacebookPluginConfig::ADMIN_IGNORE_CONNECTION_INVALID_NOTICE,
+                '',
+                true
+            );
             return $this->handle_success_request( $existing );
         }
 
@@ -446,6 +466,16 @@ class FacebookWordpressSettingsRecorder {
         \update_option(
             FacebookPluginConfig::FBL4B_SETTINGS_KEY,
             $fbl4b_settings
+        );
+        \delete_transient(
+            FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT
+        );
+        delete_metadata(
+            'user',
+            0,
+            FacebookPluginConfig::ADMIN_IGNORE_CONNECTION_INVALID_NOTICE,
+            '',
+            true
         );
 
         return $this->handle_success_request( 'FBL4B settings saved' );

--- a/core/class-servereventasynctask.php
+++ b/core/class-servereventasynctask.php
@@ -50,28 +50,7 @@ class ServerEventAsyncTask extends \WP_Async_Task {
      * @return array The converted user data.
      */
     private function convert_user_data( $user_data_normalized ) {
-        $norm_key_to_key = array(
-            AAMSettingsFields::EMAIL         => 'emails',
-            AAMSettingsFields::FIRST_NAME    => 'first_names',
-            AAMSettingsFields::LAST_NAME     => 'last_names',
-            AAMSettingsFields::GENDER        => 'genders',
-            AAMSettingsFields::DATE_OF_BIRTH => 'dates_of_birth',
-            AAMSettingsFields::EXTERNAL_ID   => 'external_ids',
-            AAMSettingsFields::PHONE         => 'phones',
-            AAMSettingsFields::CITY          => 'cities',
-            AAMSettingsFields::STATE         => 'states',
-            AAMSettingsFields::ZIP_CODE      => 'zip_codes',
-            AAMSettingsFields::COUNTRY       => 'country_codes',
-        );
-        $user_data       = array();
-        foreach ( $user_data_normalized as $norm_key => $field ) {
-            if ( isset( $norm_key_to_key[ $norm_key ] ) ) {
-                $user_data[ $norm_key_to_key[ $norm_key ] ] = $field;
-            } else {
-                $user_data[ $norm_key ] = $field;
-            }
-        }
-        return $user_data;
+        return ServerEventFactory::map_user_data_keys( $user_data_normalized );
     }
 
     /**
@@ -90,40 +69,7 @@ class ServerEventAsyncTask extends \WP_Async_Task {
      * @return Event The constructed Event object.
      */
     private function convert_array_to_event( $event_as_array ) {
-        $event = new Event( $event_as_array );
-        if ( isset( $event_as_array['user_data'] ) ) {
-            $user_data = new UserData(
-                $this->convert_user_data(
-                    $event_as_array['user_data']
-                )
-            );
-            $event->setUserData( $user_data );
-        }
-        if ( isset( $event_as_array['custom_data'] ) ) {
-            $custom_data = new CustomData( $event_as_array['custom_data'] );
-            if ( isset( $event_as_array['custom_data']['contents'] ) ) {
-                $contents = array();
-            foreach (
-                $event_as_array['custom_data']['contents'] as $contents_as_array
-                ) {
-                if ( isset( $contents_as_array['id'] ) ) {
-                    $contents_as_array['product_id'] = $contents_as_array['id'];
-                }
-                $contents[] = new Content( $contents_as_array );
-            }
-                $custom_data->setContents( $contents );
-            }
-            if ( isset(
-                $event_as_array['custom_data']['fb_integration_tracking']
-            ) ) {
-            $custom_data->addCustomProperty(
-                'fb_integration_tracking',
-                $event_as_array['custom_data']['fb_integration_tracking']
-            );
-            }
-            $event->setCustomData( $custom_data );
-        }
-        return $event;
+        return ServerEventFactory::create_from_array( $event_as_array );
     }
 
     /**

--- a/core/class-servereventfactory.php
+++ b/core/class-servereventfactory.php
@@ -18,6 +18,7 @@ namespace FacebookPixelPlugin\Core;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\UserData;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\CustomData;
+use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Content;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Normalizer;
 
 use FacebookPixelPlugin\Core\AAMFieldsExtractor;
@@ -539,5 +540,79 @@ class ServerEventFactory {
         }
 
         return array( $first_name, $last_name );
+    }
+
+    /**
+     * Converts a raw event array (Graph API format) into an Event object.
+     *
+     * @param array $event_as_array The event in array form.
+     * @return Event
+     */
+    public static function create_from_array( $event_as_array ) {
+        $event = new Event( $event_as_array );
+        if ( isset( $event_as_array['user_data'] ) ) {
+            $user_data = new UserData(
+                self::map_user_data_keys( $event_as_array['user_data'] )
+            );
+            $event->setUserData( $user_data );
+        }
+        if ( isset( $event_as_array['custom_data'] ) ) {
+            $custom_data = new CustomData( $event_as_array['custom_data'] );
+            if ( isset( $event_as_array['custom_data']['contents'] ) ) {
+                $contents = array();
+                foreach (
+                    $event_as_array['custom_data']['contents']
+                    as $contents_as_array
+                ) {
+                    if ( isset( $contents_as_array['id'] ) ) {
+                        $contents_as_array['product_id'] =
+                            $contents_as_array['id'];
+                    }
+                    $contents[] = new Content( $contents_as_array );
+                }
+                $custom_data->setContents( $contents );
+            }
+            if ( isset(
+                $event_as_array['custom_data']['fb_integration_tracking']
+            ) ) {
+                $custom_data->addCustomProperty(
+                    'fb_integration_tracking',
+                    $event_as_array['custom_data']['fb_integration_tracking']
+                );
+            }
+            $event->setCustomData( $custom_data );
+        }
+        return $event;
+    }
+
+    /**
+     * Maps normalized user-data keys to UserData constructor keys.
+     *
+     * @param array $user_data_normalized Normalized user data.
+     * @return array Mapped user data.
+     */
+    public static function map_user_data_keys( $user_data_normalized ) {
+        $norm_key_to_key = array(
+            AAMSettingsFields::EMAIL         => 'emails',
+            AAMSettingsFields::FIRST_NAME    => 'first_names',
+            AAMSettingsFields::LAST_NAME     => 'last_names',
+            AAMSettingsFields::GENDER        => 'genders',
+            AAMSettingsFields::DATE_OF_BIRTH => 'dates_of_birth',
+            AAMSettingsFields::EXTERNAL_ID   => 'external_ids',
+            AAMSettingsFields::PHONE         => 'phones',
+            AAMSettingsFields::CITY          => 'cities',
+            AAMSettingsFields::STATE         => 'states',
+            AAMSettingsFields::ZIP_CODE      => 'zip_codes',
+            AAMSettingsFields::COUNTRY       => 'country_codes',
+        );
+        $user_data       = array();
+        foreach ( $user_data_normalized as $norm_key => $field ) {
+            if ( isset( $norm_key_to_key[ $norm_key ] ) ) {
+                $user_data[ $norm_key_to_key[ $norm_key ] ] = $field;
+            } else {
+                $user_data[ $norm_key ] = $field;
+            }
+        }
+        return $user_data;
     }
 }


### PR DESCRIPTION
## Summary

When the stored access token becomes invalid (expired, system user removed, password changed, app deauthorized), all Conversions API calls silently fail with no merchant notification. This PR adds:

- **Auth error detection** — catches `AuthorizationException` (codes 190, 102, 100) and `PermissionException` (codes 10, 200-299) from Graph API responses
- **Half-open circuit breaker** — blocks CAPI calls when the token is known-bad, retries every hour, self-heals on success
- **Admin notice** — dismissible error banner on dashboard/plugins/settings pages telling the merchant to reconnect via Facebook Login for Business
- **Unified CAPI send path** — `FacebookCapiEvent` (test events) now routes through `FacebookServerSideEvent::send()` instead of raw `wp_remote_post()`
- **Cleanup** — event array-to-object conversion moved from `ServerEventAsyncTask` to `ServerEventFactory` where it belongs

Works for both MBE and FBL4B connection types. Subcode 452 (session mismatch) is exempt from tripping the circuit breaker since it may self-resolve.

### Files changed

| File | What changed |
|---|---|
| `core/class-facebookcapicircuitbreaker.php` | **New.** Self-contained circuit breaker: `is_send_allowed()`, `is_tripped()`, `record_success()`, `record_exception()` |
| `core/class-facebookserversideevent.php` | `send()` now checks circuit breaker before calling API, records success/exception after, accepts optional `$test_event_code`, returns result array |
| `core/class-facebookcapievent.php` | `send_capi_event()` builds Event objects and calls `send()` instead of `wp_remote_post()` |
| `core/class-servereventfactory.php` | Added `create_from_array()` and `map_user_data_keys()` |
| `core/class-servereventasynctask.php` | Delegates to `ServerEventFactory` methods (was duplicated logic) |
| `core/class-facebookpluginconfig.php` | Constants for transient key, retry interval, notice dismiss/ignore keys |
| `core/class-facebookwordpresssettingspage.php` | `connection_invalid_notice()` — dismissible error notice with "Reconnect" button linking to FBL4B onboarding |
| `core/class-facebookwordpresssettingsrecorder.php` | Clears transient + dismiss flag on FBE and FBL4B settings save |

### Circuit breaker behavior

| State | Condition | CAPI calls |
|---|---|---|
| **Closed** | No transient | All calls go through |
| **Open** | Transient set, < 1 hour | Calls blocked |
| **Half-open** | Transient set, ≥ 1 hour | One call allowed — success clears transient, failure resets timer |
| **Expired** | 24 hours pass | Transient expires, next call acts as retry |

## Test plan

### Automated
- 19 new unit tests across 4 test files (circuit breaker states, send integration, event factory, settings recorder mocks)
- All 242 existing tests pass

### Manual — circuit breaker + notice
1. Activate the plugin with a valid FBL4B or MBE connection
2. Set the transient to simulate an auth error:
   ```
   wp eval "set_transient('facebook_pixel_connection_invalid', time(), DAY_IN_SECONDS);"
   ```
3. Go to **Dashboard** or **Plugins** page — verify the error notice appears with "Meta Pixel for WordPress" heading and a "Reconnect" button
4. Click **Dismiss** — verify the notice stays dismissed on page refresh
5. Navigate to a page that triggers CAPI events (e.g., a WooCommerce product page) — verify no CAPI calls are made (check browser network tab or server error log)
6. Wait or manually age the transient to test half-open:
   ```
   wp eval "set_transient('facebook_pixel_connection_invalid', time() - 3601, DAY_IN_SECONDS);"
   ```
7. Trigger a CAPI event — verify one call goes through (it will fail with a real bad token, re-setting the transient)

### Manual — reconnect clears state
1. With the transient set (from above), go to **Settings > Meta** and click "Reconnect"
2. Complete the FBL4B onboarding flow
3. Verify the transient is cleared:
   ```
   wp eval "var_dump(get_transient('facebook_pixel_connection_invalid'));"
   ```
   Should output `bool(false)`
4. Verify the notice no longer appears
5. Verify CAPI events are flowing again

### Manual — test events
1. Go to **Settings > Meta > Conversion API Tests**
2. Enter a test event code and submit — verify the event goes through `send()` and the result appears in the event log UI
3. With the transient set, submit a test event — verify the error is shown in the event log