### PR TITLE
Rename FacebookPixelSignals refs to Signals in pixel injection

### DIFF
--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -183,10 +183,10 @@ class FacebookWordpressPixelInjection {
             'facebook-signal',
             'facebookSignalConfig',
             array(
-                'cookieName'    => FacebookPixelSignals::COOKIE_NAME,
+                'cookieName'    => Signals::COOKIE_NAME,
                 'ajaxUrl'       => admin_url( 'admin-ajax.php' ),
-                'signalsAction' => FacebookPixelSignals::AJAX_ACTION,
-                'signalsNonce'  => wp_create_nonce( FacebookPixelSignals::NONCE_ACTION ),
+                'signalsAction' => Signals::AJAX_ACTION,
+                'signalsNonce'  => wp_create_nonce( Signals::NONCE_ACTION ),
             )
         );
     }


### PR DESCRIPTION
## Summary
- Update `FacebookWordpressPixelInjection::enqueueSignalsAssets()` to reference the renamed `Signals` class (was `FacebookPixelSignals`) for `COOKIE_NAME`, `AJAX_ACTION`, and `NONCE_ACTION`.

## Test plan
- [ ] Load a page on a test WordPress install; confirm `facebookSignalConfig` is localized with the correct cookie name, AJAX URL, action, and nonce.
- [ ] Trigger a signal event and verify the AJAX request succeeds with the new nonce.