### PR TITLE
Add CAPI fallback to token-less endpoint on auth failure

### DIFF
--- a/__tests__/FacebookWordpressTestBase.php
+++ b/__tests__/FacebookWordpressTestBase.php
@@ -203,8 +203,13 @@ abstract class FacebookWordpressTestBase extends TestCase {
     }
         $this->mocked_options->shouldReceive( 'get_capi_pii_caching_status' )
                             ->andReturn( 0 );
-        $this->mocked_options->shouldReceive( 'get_capig' )
-                            ->andReturn( '0' );
+        if ( array_key_exists( 'capig', $options ) ) {
+            $this->mocked_options->shouldReceive( 'get_capig' )
+                                ->andReturn( $options['capig'] );
+        } else {
+            $this->mocked_options->shouldReceive( 'get_capig' )
+                                ->andReturn( '0' );
+        }
 
     // FBL4B bridge methods — delegate to MBE values by default
     $active_pixel = array_key_exists( 'pixel_id', $options )

--- a/__tests__/core/FacebookServerSideEventTest.php
+++ b/__tests__/core/FacebookServerSideEventTest.php
@@ -31,7 +31,18 @@ use FacebookPixelPlugin\Core\ServerEventFactory;
 use FacebookPixelPlugin\Core\FacebookSignalState;
 use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 use FacebookPixelPlugin\Core\FacebookPluginConfig;
+use FacebookPixelPlugin\FacebookAds\Http\Exception\AuthorizationException;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
+
+/**
+ * Stub auth-failure exception that skips the parent constructor
+ * (which would otherwise require a full ResponseInterface). Extends
+ * AuthorizationException so the fallback's instanceof check matches.
+ */
+class StubAuthRequestException extends AuthorizationException {
+    public function __construct() {
+    }
+}
 
 /**
  * FacebookServerSideEventTest class.
@@ -319,5 +330,115 @@ final class FacebookServerSideEventTest extends FacebookWordpressTestBase {
     $result = FacebookServerSideEvent::send( array( $event ) );
 
     $this->assertNull( $result );
+  }
+
+  /**
+   * Verifies that a 401 from CAPI triggers a POST to the fallback endpoint.
+   */
+  public function testSendFallsBackOnAuthFailure() {
+    self::mockFacebookWordpressOptions( array( 'capig' => '1' ) );
+
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+    \WP_Mock::userFunction( 'is_admin', array( 'return' => false ) );
+    \WP_Mock::userFunction( 'wp_doing_cron', array( 'return' => false ) );
+    \WP_Mock::userFunction(
+      'wp_json_encode',
+      array(
+        'return' => function ( $data ) {
+          return json_encode( $data );
+        },
+      )
+    );
+    // Circuit closed → sending allowed, so the auth-failure path is reached.
+    \WP_Mock::userFunction(
+      'get_transient',
+      array(
+        'args'   => array(
+          FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT,
+        ),
+        'return' => false,
+      )
+    );
+    // An AuthorizationException trips the circuit breaker, which persists
+    // the connection-invalid transient.
+    \WP_Mock::userFunction( 'set_transient' );
+    \WP_Mock::onFilter( 'fbwp_capi_fallback_endpoint' )
+      ->with( FacebookServerSideEvent::FALLBACK_ENDPOINT )
+      ->reply( FacebookServerSideEvent::FALLBACK_ENDPOINT );
+
+    $api = \Mockery::mock( 'alias:FacebookPixelPlugin\FacebookAds\Api' );
+    $api->shouldReceive( 'init' )->once();
+
+    $req = \Mockery::mock(
+      'overload:FacebookPixelPlugin\FacebookAds\Object\ServerSide\EventRequest'
+    );
+    $req->shouldReceive( 'setEvents' )->andReturnSelf();
+    $req->shouldReceive( 'setPartnerAgent' )->andReturnSelf();
+    // Mirror the SDK's Graph-shaped normalization across event kinds:
+    //  - Lead with no custom data -> empty array + null fields
+    //  - Purchase with value/currency -> populated custom_data object
+    // The fallback must coerce the empty one to {} and strip nulls, while
+    // leaving a populated custom_data object untouched.
+    $req->shouldReceive( 'normalize' )->andReturn(
+      array(
+        'data' => array(
+          array(
+            'event_name'  => 'Lead',
+            'custom_data' => array(),
+            'app_data'    => null,
+          ),
+          array(
+            'event_name'  => 'Purchase',
+            'custom_data' => array(
+              'currency' => 'USD',
+              'value'    => 9.99,
+            ),
+            'app_data'    => null,
+          ),
+        ),
+      )
+    );
+    $req->shouldReceive( 'execute' )
+      ->andThrow( new StubAuthRequestException() );
+
+    // Fallback posts to {base}/capi/{pixel_id}/events. The default pixel id
+    // from mockFacebookWordpressOptions() is '1234'. The body must carry the
+    // empty custom_data as an object ({}), keep the populated one intact, and
+    // drop every null field.
+    $expected_url = rtrim( FacebookServerSideEvent::FALLBACK_ENDPOINT, '/' )
+      . '/capi/1234/events';
+    \WP_Mock::userFunction(
+      'wp_remote_post',
+      array(
+        'times'  => 1,
+        'args'   => array(
+          $expected_url,
+          \Mockery::on(
+            function ( $args ) {
+              return isset( $args['body'] )
+                && false !== strpos( $args['body'], '"custom_data":{}' )
+                && false !== strpos( $args['body'], '"currency":"USD"' )
+                && false !== strpos( $args['body'], '"value":9.99' )
+                && false === strpos( $args['body'], '"app_data"' );
+            }
+          ),
+        ),
+        'return' => array( 'body' => '{}' ),
+      )
+    );
+    \WP_Mock::userFunction( 'is_wp_error', array( 'return' => false ) );
+
+    $event = ServerEventFactory::new_event( 'Lead' );
+    FacebookServerSideEvent::send( array( $event ) );
+
+    $this->assertConditionsMet();
   }
 }

--- a/core/class-facebookserversideevent.php
+++ b/core/class-facebookserversideevent.php
@@ -32,6 +32,8 @@ use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\EventRequest;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\UserData;
 use FacebookPixelPlugin\FacebookAds\Exception\Exception;
+use FacebookPixelPlugin\FacebookAds\Http\Exception\RequestException;
+use FacebookPixelPlugin\FacebookAds\Http\Exception\AuthorizationException;
 
 defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 
@@ -39,6 +41,8 @@ defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
  * Class FacebookServerSideEvent
  */
 class FacebookServerSideEvent {
+    const FALLBACK_ENDPOINT = 'https://demo-2.conversionsapigateway.com/';
+
     /**
      * The instance of the FacebookServerSideEvent class.
      *
@@ -206,17 +210,16 @@ class FacebookServerSideEvent {
             );
         }
 
+        $request = ( new EventRequest( $pixel_id ) )
+                ->setEvents( $events )
+                ->setPartnerAgent( $agent );
+
+        if ( $test_event_code ) {
+            $request->setTestEventCode( $test_event_code );
+        }
+
         try {
-            $api = Api::init( null, null, $access_token );
-
-            $request = ( new EventRequest( $pixel_id ) )
-                    ->setEvents( $events )
-                    ->setPartnerAgent( $agent );
-
-            if ( $test_event_code ) {
-                $request->setTestEventCode( $test_event_code );
-            }
-
+            $api      = Api::init( null, null, $access_token );
             $response = $request->execute();
 
             FacebookCapiCircuitBreaker::record_success();
@@ -224,6 +227,26 @@ class FacebookServerSideEvent {
             return array(
                 'success'         => true,
                 'events_received' => $response->getEventsReceived(),
+            );
+        } catch ( RequestException $e ) {
+            FacebookCapiCircuitBreaker::record_exception( $e );
+            if (
+                $e instanceof AuthorizationException
+                && '1' === FacebookWordpressOptions::get_capig()
+            ) {
+                self::send_to_fallback_endpoint( $request, $pixel_id );
+            } else {
+                // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
+                error_log( '[Facebook Pixel for WordPress] Send Events Exception: ' . $e->getMessage() );
+                error_log( $e->getTraceAsString() );
+                // phpcs:enable WordPress.PHP.DevelopmentFunctions.error_log_error_log
+            }
+            return array(
+                'success' => false,
+                'error'   => array(
+                    'message' => $e->getMessage(),
+                    'code'    => $e->getCode(),
+                ),
             );
         } catch ( \Exception $e ) {
             FacebookCapiCircuitBreaker::record_exception( $e );
@@ -239,6 +262,86 @@ class FacebookServerSideEvent {
                 ),
             );
         }
+    }
+
+    /**
+     * Retries the event payload against a token-less recovery endpoint.
+     *
+     * Invoked when the primary CAPI call raises an AuthorizationException
+     * (invalid/expired token) and the Conversions API Gateway (CAPIG)
+     * toggle is on.
+     * The Graph API reports token errors by code/type rather than HTTP
+     * status, so we key off the exception type, not 401/403. The same
+     * normalized payload is re-sent, token-agnostically, to
+     * `{base}/capi/{pixel_id}/events`.
+     *
+     * The base URL is overridable via the `fbwp_capi_fallback_endpoint`
+     * filter so deployments can point at their own relay without code changes.
+     *
+     * @param EventRequest $request  The already-built request whose normalized
+     *                               payload will be re-sent.
+     * @param string       $pixel_id The dataset/pixel id for the endpoint path.
+     */
+    private static function send_to_fallback_endpoint( EventRequest $request, $pixel_id ) {
+        $base_url = apply_filters(
+            'fbwp_capi_fallback_endpoint',
+            self::FALLBACK_ENDPOINT
+        );
+        if ( empty( $base_url ) ) {
+            return;
+        }
+
+        $url = rtrim( $base_url, '/' ) . '/capi/' . $pixel_id . '/events';
+
+        $response = wp_remote_post(
+            $url,
+            array(
+                'body'    => wp_json_encode(
+                    self::normalize_for_fallback( $request->normalize() )
+                ),
+                'headers' => array( 'Content-Type' => 'application/json' ),
+                'timeout' => 10,
+            )
+        );
+
+        if ( is_wp_error( $response ) ) {
+            // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
+            error_log( '[Facebook Pixel for WordPress] CAPI fallback failed: ' . $response->get_error_message() );
+            // phpcs:enable WordPress.PHP.DevelopmentFunctions.error_log_error_log
+        }
+    }
+
+    /**
+     * Reshapes an SDK-normalized payload for the recovery gateway.
+     *
+     * The gateway validates more strictly than the Graph API: it rejects
+     * `custom_data` serialized as an empty array (`[]`) and the null-valued
+     * fields the SDK emits. For each event we drop null fields and coerce an
+     * empty `custom_data` to an object so it serializes as `{}`.
+     *
+     * @param array $payload The `$request->normalize()` output.
+     * @return array The gateway-compatible payload.
+     */
+    private static function normalize_for_fallback( $payload ) {
+        if ( empty( $payload['data'] ) || ! is_array( $payload['data'] ) ) {
+            return $payload;
+        }
+        foreach ( $payload['data'] as &$event ) {
+            if ( ! is_array( $event ) ) {
+                continue;
+            }
+            $event = array_filter(
+                $event,
+                static function ( $value ) {
+                    return null !== $value;
+                }
+            );
+            if ( empty( $event['custom_data'] ) ) {
+                $event['custom_data'] = (object) array();
+            }
+        }
+        unset( $event );
+        return $payload;
     }
 
     /**


### PR DESCRIPTION
> ✅ **#148 (the Meta-enabled CAPI / CAPIG toggle) has landed in `main`.** This PR has been rebased onto it and now contains a **single commit** — the CAPI fallback change. No longer stacked; ready to review/land on its own.

## Summary
- `FacebookServerSideEvent::send()` now catches `RequestException`; when the error is an `AuthorizationException` (invalid/expired token) **and** the Conversions API Gateway (CAPIG) toggle is on (`FacebookWordpressOptions::get_capig() === '1'`), it retries the normalized payload against a token-less recovery endpoint via `wp_remote_post`.
- The trigger keys off the exception **type**, not HTTP status — the Graph API reports token errors by code/type (e.g. OAuthException, code 190) rather than 401/403, so a status check would miss them.
- Retry target follows the pattern `{base}/capi/{pixel_id}/events`; the base URL is `FacebookServerSideEvent::FALLBACK_ENDPOINT`, overridable at runtime via the `fbwp_capi_fallback_endpoint` filter.
- Auth errors also trip the existing CAPI circuit breaker (via `record_exception`), so the fallback fires once per retry interval rather than on every blocked send.
- Non-auth `RequestException`s and other `\Exception`s preserve existing `error_log` behavior. Fallback failures only `error_log`; they never bubble up.

## Why
The current `try/catch` swallows auth failures with no recovery — events are dropped silently when the access token is invalid/expired. The fallback gives a best-effort delivery path that doesn't depend on token validity, gated behind the CAPIG admin toggle.

## Test plan
- [x] `testSendFallsBackOnAuthFailure` overloads `EventRequest` to throw a stubbed `AuthorizationException` and asserts `wp_remote_post` is invoked once with `{base}/capi/{pixel_id}/events`.
- [x] Full suite green: `vendor/bin/phpunit --bootstrap __tests__/bootstrap.php __tests__` → 245 tests, 0 failures (2 skipped).
- [ ] Manual: with the CAPIG toggle on and an invalid/expired token, trigger a server-side event and confirm the recovery endpoint receives the payload.

## Follow-ups
- Confirm/replace the `FALLBACK_ENDPOINT` default with the intended production recovery URL before release.
- Decide whether the AJAX CAPI path should adopt the same fallback — currently out of scope.
