### PR TITLE
Add admin toggle for Meta-enabled Conversions API integration

### DIFF
--- a/__tests__/FacebookWordpressTestBase.php
+++ b/__tests__/FacebookWordpressTestBase.php
@@ -203,7 +203,7 @@ abstract class FacebookWordpressTestBase extends TestCase {
     }
         $this->mocked_options->shouldReceive( 'get_capi_pii_caching_status' )
                             ->andReturn( 0 );
-        $this->mocked_options->shouldReceive( 'get_add_meta_capi' )
+        $this->mocked_options->shouldReceive( 'get_capig' )
                             ->andReturn( '0' );
 
     // FBL4B bridge methods — delegate to MBE values by default

--- a/__tests__/FacebookWordpressTestBase.php
+++ b/__tests__/FacebookWordpressTestBase.php
@@ -203,6 +203,8 @@ abstract class FacebookWordpressTestBase extends TestCase {
     }
         $this->mocked_options->shouldReceive( 'get_capi_pii_caching_status' )
                             ->andReturn( 0 );
+        $this->mocked_options->shouldReceive( 'get_add_meta_capi' )
+                            ->andReturn( '0' );
 
     // FBL4B bridge methods — delegate to MBE values by default
     $active_pixel = array_key_exists( 'pixel_id', $options )

--- a/__tests__/core/FacebookWordpressPixelInjectionTest.php
+++ b/__tests__/core/FacebookWordpressPixelInjectionTest.php
@@ -210,7 +210,7 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
     );
     $mocked_options->shouldReceive( 'get_capi_integration_status' )
       ->andReturn( '1' );
-    $mocked_options->shouldReceive( 'get_add_meta_capi' )
+    $mocked_options->shouldReceive( 'get_capig' )
       ->andReturn( '0' );
     $mocked_options->shouldReceive( 'get_agent_string' )
       ->andReturn( 'WordPress' );
@@ -287,7 +287,7 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
     );
     $mocked_options->shouldReceive( 'get_capi_integration_status' )
       ->andReturn( '1' );
-    $mocked_options->shouldReceive( 'get_add_meta_capi' )
+    $mocked_options->shouldReceive( 'get_capig' )
       ->andReturn( '0' );
     $mocked_options->shouldReceive( 'get_agent_string' )
       ->andReturn( 'WordPress' );
@@ -372,7 +372,7 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
     );
     $mocked_options->shouldReceive( 'get_capi_integration_status' )
       ->andReturn( '1' );
-    $mocked_options->shouldReceive( 'get_add_meta_capi' )
+    $mocked_options->shouldReceive( 'get_capig' )
       ->andReturn( '0' );
     $mocked_options->shouldReceive( 'get_agent_string' )
       ->andReturn( 'WordPress' );
@@ -423,17 +423,17 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
     $this->assertStringContainsString( 'FacebookSignal.init', $output );
     $this->assertStringContainsString( '"held":false', $output );
     $this->assertStringContainsString( '"attribution":{}', $output );
-    $this->assertStringContainsString( '"addMetaCapi":"0"', $output );
+    $this->assertStringContainsString( '"capig":"0"', $output );
     $this->assertStringNotContainsString( 'fb.1.123.browser', $output );
     $this->assertStringNotContainsString( 'fb.1.123.click', $output );
   }
 
   /**
-   * The "Add Meta-enabled CAPI" toggle value is threaded into the
+   * The Conversions API Gateway (CAPIG) toggle value is threaded into the
    * FacebookSignal.init config so the JS init can emit
    * fbq('optinMetaEnabledCapi', ...) before fbq('init', ...).
    */
-  public function testInitConfigIncludesAddMetaCapiWhenEnabled() {
+  public function testInitConfigIncludesCapigWhenEnabled() {
     FacebookWordpressPixelInjection::$render_cache = array();
     FacebookPixel::set_pixel_id( '1234' );
 
@@ -442,7 +442,7 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
     );
     $mocked_options->shouldReceive( 'get_capi_integration_status' )
       ->andReturn( '1' );
-    $mocked_options->shouldReceive( 'get_add_meta_capi' )
+    $mocked_options->shouldReceive( 'get_capig' )
       ->andReturn( '1' );
     $mocked_options->shouldReceive( 'get_agent_string' )
       ->andReturn( 'WordPress' );
@@ -476,6 +476,6 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
     $injection_obj->inject_pixel_code();
     $output = ob_get_clean();
 
-    $this->assertStringContainsString( '"addMetaCapi":"1"', $output );
+    $this->assertStringContainsString( '"capig":"1"', $output );
   }
 }

--- a/__tests__/core/FacebookWordpressPixelInjectionTest.php
+++ b/__tests__/core/FacebookWordpressPixelInjectionTest.php
@@ -210,6 +210,8 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
     );
     $mocked_options->shouldReceive( 'get_capi_integration_status' )
       ->andReturn( '1' );
+    $mocked_options->shouldReceive( 'get_add_meta_capi' )
+      ->andReturn( '0' );
     $mocked_options->shouldReceive( 'get_agent_string' )
       ->andReturn( 'WordPress' );
     $mocked_options->shouldReceive( 'get_user_info' )
@@ -285,6 +287,8 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
     );
     $mocked_options->shouldReceive( 'get_capi_integration_status' )
       ->andReturn( '1' );
+    $mocked_options->shouldReceive( 'get_add_meta_capi' )
+      ->andReturn( '0' );
     $mocked_options->shouldReceive( 'get_agent_string' )
       ->andReturn( 'WordPress' );
     $mocked_options->shouldReceive( 'get_user_info' )
@@ -368,6 +372,8 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
     );
     $mocked_options->shouldReceive( 'get_capi_integration_status' )
       ->andReturn( '1' );
+    $mocked_options->shouldReceive( 'get_add_meta_capi' )
+      ->andReturn( '0' );
     $mocked_options->shouldReceive( 'get_agent_string' )
       ->andReturn( 'WordPress' );
     $mocked_options->shouldReceive( 'get_user_info' )
@@ -417,7 +423,59 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
     $this->assertStringContainsString( 'FacebookSignal.init', $output );
     $this->assertStringContainsString( '"held":false', $output );
     $this->assertStringContainsString( '"attribution":{}', $output );
+    $this->assertStringContainsString( '"addMetaCapi":"0"', $output );
     $this->assertStringNotContainsString( 'fb.1.123.browser', $output );
     $this->assertStringNotContainsString( 'fb.1.123.click', $output );
+  }
+
+  /**
+   * The "Add Meta-enabled CAPI" toggle value is threaded into the
+   * FacebookSignal.init config so the JS init can emit
+   * fbq('optinMetaEnabledCapi', ...) before fbq('init', ...).
+   */
+  public function testInitConfigIncludesAddMetaCapiWhenEnabled() {
+    FacebookWordpressPixelInjection::$render_cache = array();
+    FacebookPixel::set_pixel_id( '1234' );
+
+    $mocked_options = \Mockery::mock(
+      'alias:FacebookPixelPlugin\Core\FacebookWordpressOptions'
+    );
+    $mocked_options->shouldReceive( 'get_capi_integration_status' )
+      ->andReturn( '1' );
+    $mocked_options->shouldReceive( 'get_add_meta_capi' )
+      ->andReturn( '1' );
+    $mocked_options->shouldReceive( 'get_agent_string' )
+      ->andReturn( 'WordPress' );
+    $mocked_options->shouldReceive( 'get_user_info' )
+      ->andReturn( array() );
+
+    $mocked_utils = \Mockery::mock(
+      'alias:FacebookPixelPlugin\Core\FacebookPluginUtils'
+    );
+    $mocked_utils->shouldReceive( 'is_internal_user' )
+      ->andReturn( false );
+
+    \WP_Mock::userFunction(
+      'wp_json_encode',
+      array(
+        'return' => function ( $data ) {
+          return json_encode( $data );
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'admin_url',
+      array(
+        'return' => 'https://www.pikachu.com/wp-admin/admin-ajax.php',
+      )
+    );
+
+    $injection_obj = new FacebookWordpressPixelInjection();
+
+    ob_start();
+    $injection_obj->inject_pixel_code();
+    $output = ob_get_clean();
+
+    $this->assertStringContainsString( '"addMetaCapi":"1"', $output );
   }
 }

--- a/core/class-facebookpluginconfig.php
+++ b/core/class-facebookpluginconfig.php
@@ -132,6 +132,13 @@ class FacebookPluginConfig {
     'save_capi_pii_caching_status';
     const CAPI_PII_CACHING_STATUS_UPDATE_ERROR            =
     'Status could not be saved, please refresh the page and continue.';
+    const ADD_META_CAPI                                   =
+    'facebook_add_meta_capi';
+    const ADD_META_CAPI_DEFAULT                           = '1';
+    const SAVE_ADD_META_CAPI_ACTION_NAME                  =
+    'save_add_meta_capi';
+    const ADD_META_CAPI_UPDATE_ERROR                      =
+    'Status could not be saved, please refresh the page and continue.';
 
     const CONNECTION_INVALID_TRANSIENT            =
     'facebook_pixel_connection_invalid';

--- a/core/class-facebookpluginconfig.php
+++ b/core/class-facebookpluginconfig.php
@@ -132,12 +132,12 @@ class FacebookPluginConfig {
     'save_capi_pii_caching_status';
     const CAPI_PII_CACHING_STATUS_UPDATE_ERROR            =
     'Status could not be saved, please refresh the page and continue.';
-    const ADD_META_CAPI                                   =
-    'facebook_add_meta_capi';
-    const ADD_META_CAPI_DEFAULT                           = '1';
-    const SAVE_ADD_META_CAPI_ACTION_NAME                  =
-    'save_add_meta_capi';
-    const ADD_META_CAPI_UPDATE_ERROR                      =
+    const CAPIG                                           =
+    'facebook_capig';
+    const CAPIG_DEFAULT                                   = '1';
+    const SAVE_CAPIG_ACTION_NAME                          =
+    'save_capig';
+    const CAPIG_UPDATE_ERROR                              =
     'Status could not be saved, please refresh the page and continue.';
 
     const CONNECTION_INVALID_TRANSIENT            =

--- a/core/class-facebookwordpressoptions.php
+++ b/core/class-facebookwordpressoptions.php
@@ -79,12 +79,13 @@ class FacebookWordpressOptions {
      */
     private static $capi_pii_caching_status = null;
     /**
-     * Whether the admin opted in to emit the Meta-enabled CAPI fbq command
-     * in the pixel init.
+     * Whether the admin opted in to the Conversions API Gateway (CAPIG)
+     * integration, which emits the optinMetaEnabledCapi fbq command in the
+     * pixel init.
      *
      * @var string|null
      */
-    private static $add_meta_capi           = null;
+    private static $capig                   = null;
     const AAM_SETTINGS_REFRESH_IN_MINUTES   = 20;
 
     /**
@@ -104,7 +105,7 @@ class FacebookWordpressOptions {
         self::set_capi_integration_status();
         self::set_capi_integration_events_filter();
         self::set_capi_pii_caching_status();
-        self::set_add_meta_capi();
+        self::set_capig();
     }
 
     /**
@@ -173,16 +174,16 @@ class FacebookWordpressOptions {
     }
 
     /**
-     * Loads the "Add Meta-enabled CAPI" toggle from WordPress options.
+     * Loads the Conversions API Gateway (CAPIG) toggle from WordPress options.
      *
      * Passes the default to get_option() so fresh installs and upgrades
      * from versions without this option seed the in-memory value with
      * the opt-in default rather than `false`.
      */
-    public static function set_add_meta_capi() {
-        self::$add_meta_capi = \get_option(
-            FacebookPluginConfig::ADD_META_CAPI,
-            FacebookPluginConfig::ADD_META_CAPI_DEFAULT
+    public static function set_capig() {
+        self::$capig = \get_option(
+            FacebookPluginConfig::CAPIG,
+            FacebookPluginConfig::CAPIG_DEFAULT
         );
     }
 
@@ -193,13 +194,13 @@ class FacebookWordpressOptions {
      *
      * @return string
      */
-    public static function get_add_meta_capi() {
-        if ( is_null( self::$add_meta_capi ) ||
-            '' === self::$add_meta_capi ||
-            false === self::$add_meta_capi ) {
-            return FacebookPluginConfig::ADD_META_CAPI_DEFAULT;
+    public static function get_capig() {
+        if ( is_null( self::$capig ) ||
+            '' === self::$capig ||
+            false === self::$capig ) {
+            return FacebookPluginConfig::CAPIG_DEFAULT;
         }
-        return self::$add_meta_capi;
+        return self::$capig;
     }
 
     /**

--- a/core/class-facebookwordpressoptions.php
+++ b/core/class-facebookwordpressoptions.php
@@ -78,6 +78,13 @@ class FacebookWordpressOptions {
      * @var bool|null
      */
     private static $capi_pii_caching_status = null;
+    /**
+     * Whether the admin opted in to emit the Meta-enabled CAPI fbq command
+     * in the pixel init.
+     *
+     * @var string|null
+     */
+    private static $add_meta_capi           = null;
     const AAM_SETTINGS_REFRESH_IN_MINUTES   = 20;
 
     /**
@@ -97,6 +104,7 @@ class FacebookWordpressOptions {
         self::set_capi_integration_status();
         self::set_capi_integration_events_filter();
         self::set_capi_pii_caching_status();
+        self::set_add_meta_capi();
     }
 
     /**
@@ -162,6 +170,36 @@ class FacebookWordpressOptions {
         return is_null( self::$capi_pii_caching_status ) ?
         FacebookPluginConfig::CAPI_PII_CACHING_STATUS_DEFAULT :
         self::$capi_pii_caching_status;
+    }
+
+    /**
+     * Loads the "Add Meta-enabled CAPI" toggle from WordPress options.
+     *
+     * Passes the default to get_option() so fresh installs and upgrades
+     * from versions without this option seed the in-memory value with
+     * the opt-in default rather than `false`.
+     */
+    public static function set_add_meta_capi() {
+        self::$add_meta_capi = \get_option(
+            FacebookPluginConfig::ADD_META_CAPI,
+            FacebookPluginConfig::ADD_META_CAPI_DEFAULT
+        );
+    }
+
+    /**
+     * Returns '1' when the admin has opted in to emit the fbq
+     * optinMetaEnabledCapi command, '0' otherwise. Default is '1'
+     * (opt-in by default — fresh installs and upgrades emit the command).
+     *
+     * @return string
+     */
+    public static function get_add_meta_capi() {
+        if ( is_null( self::$add_meta_capi ) ||
+            '' === self::$add_meta_capi ||
+            false === self::$add_meta_capi ) {
+            return FacebookPluginConfig::ADD_META_CAPI_DEFAULT;
+        }
+        return self::$add_meta_capi;
     }
 
     /**

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -196,7 +196,7 @@ class FacebookWordpressPixelInjection {
             'releaseAction' => ReleaseSignalsAjax::ACTION,
             'pixelId'       => $pixel_id,
             'attribution'   => (object) array(),
-            'addMetaCapi'   => FacebookWordpressOptions::get_add_meta_capi(),
+            'capig'         => FacebookWordpressOptions::get_capig(),
         );
 
         if ( FacebookSignalState::is_held() ) {

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -196,6 +196,7 @@ class FacebookWordpressPixelInjection {
             'releaseAction' => ReleaseSignalsAjax::ACTION,
             'pixelId'       => $pixel_id,
             'attribution'   => (object) array(),
+            'addMetaCapi'   => FacebookWordpressOptions::get_add_meta_capi(),
         );
 
         if ( FacebookSignalState::is_held() ) {

--- a/core/class-facebookwordpresssettingspage.php
+++ b/core/class-facebookwordpresssettingspage.php
@@ -226,12 +226,12 @@ class FacebookWordpressSettingsPage {
             When turned on, PII will be cached for non logged in users.
         </div>
         </div>
-        <div id="fb-add-meta-capi">
-        <input type="checkbox" id="add-meta-capi" name="add-meta-capi">
-        <label class="fb-capi-title" for="add-meta-capi">
+        <div id="fb-capig">
+        <input type="checkbox" id="capig" name="capig">
+        <label class="fb-capi-title" for="capig">
             Opt in to a Meta-enabled Conversions API integration
         </label>
-        <span id="fb-add-meta-capi-se" class="fb-capi-se"></span>
+        <span id="fb-capig-se" class="fb-capi-se"></span>
         <br/>
         <div class="fb-capi-desc">
             You hereby authorize and instruct Meta to set
@@ -589,19 +589,19 @@ class FacebookWordpressSettingsPage {
     }
 
     /**
-     * Builds the admin-ajax URL for persisting the
-     * "Add Meta-enabled CAPI" toggle.
+     * Builds the admin-ajax URL for persisting the Conversions API Gateway
+     * (CAPIG) toggle.
      *
      * @return string
      */
-    public function get_add_meta_capi_save_url() {
+    public function get_capig_save_url() {
         $nonce_value = wp_create_nonce(
-            FacebookPluginConfig::SAVE_ADD_META_CAPI_ACTION_NAME
+            FacebookPluginConfig::SAVE_CAPIG_ACTION_NAME
         );
         $simple_url  = admin_url( 'admin-ajax.php' );
         $args        = array(
             'action'   =>
-            FacebookPluginConfig::SAVE_ADD_META_CAPI_ACTION_NAME,
+            FacebookPluginConfig::SAVE_CAPIG_ACTION_NAME,
             '_wpnonce' => $nonce_value,
         );
         return add_query_arg( $args, $simple_url );
@@ -675,14 +675,14 @@ class FacebookWordpressSettingsPage {
                 FacebookPluginConfig::SAVE_CAPI_INTEGRATION_EVENTS_FILTER_ACTION_NAME,
             'capiIntegrationEventsFilterUpdateError' =>
                 FacebookPluginConfig::CAPI_INTEGRATION_EVENTS_FILTER_UPDATE_ERROR,
-            'addMetaCapi'                            =>
-                FacebookWordpressOptions::get_add_meta_capi(),
-            'addMetaCapiSaveUrl'                     =>
-                $this->get_add_meta_capi_save_url(),
-            'addMetaCapiActionName'                  =>
-                FacebookPluginConfig::SAVE_ADD_META_CAPI_ACTION_NAME,
-            'addMetaCapiUpdateError'                 =>
-                FacebookPluginConfig::ADD_META_CAPI_UPDATE_ERROR,
+            'capig'                                  =>
+                FacebookWordpressOptions::get_capig(),
+            'capigSaveUrl'                           =>
+                $this->get_capig_save_url(),
+            'capigActionName'                        =>
+                FacebookPluginConfig::SAVE_CAPIG_ACTION_NAME,
+            'capigUpdateError'                       =>
+                FacebookPluginConfig::CAPIG_UPDATE_ERROR,
         );
 
         // FBL4B config — only included if app_id is provisioned.

--- a/core/class-facebookwordpresssettingspage.php
+++ b/core/class-facebookwordpresssettingspage.php
@@ -226,6 +226,26 @@ class FacebookWordpressSettingsPage {
             When turned on, PII will be cached for non logged in users.
         </div>
         </div>
+        <div id="fb-add-meta-capi">
+        <input type="checkbox" id="add-meta-capi" name="add-meta-capi">
+        <label class="fb-capi-title" for="add-meta-capi">
+            Opt in to a Meta-enabled Conversions API integration
+        </label>
+        <span id="fb-add-meta-capi-se" class="fb-capi-se"></span>
+        <br/>
+        <div class="fb-capi-desc">
+            You hereby authorize and instruct Meta to set
+            up a Meta-enabled Conversions API integration on your behalf,
+            and you agree that your use of the integration will be subject
+            to Meta's
+            <a href="https://www.facebook.com/legal/terms"
+                target="_blank" rel="noopener noreferrer">Platform Terms</a>
+            and
+            <a href="https://www.facebook.com/legal/technology_terms"
+                target="_blank" rel="noopener noreferrer">Business Tools
+                Terms</a>.
+        </div>
+        </div>
     </div>
     </div>
 
@@ -569,6 +589,25 @@ class FacebookWordpressSettingsPage {
     }
 
     /**
+     * Builds the admin-ajax URL for persisting the
+     * "Add Meta-enabled CAPI" toggle.
+     *
+     * @return string
+     */
+    public function get_add_meta_capi_save_url() {
+        $nonce_value = wp_create_nonce(
+            FacebookPluginConfig::SAVE_ADD_META_CAPI_ACTION_NAME
+        );
+        $simple_url  = admin_url( 'admin-ajax.php' );
+        $args        = array(
+            'action'   =>
+            FacebookPluginConfig::SAVE_ADD_META_CAPI_ACTION_NAME,
+            '_wpnonce' => $nonce_value,
+        );
+        return add_query_arg( $args, $simple_url );
+    }
+
+    /**
      * Generates the AJAX route URL for deleting FBE settings.
      *
      * This function creates a nonce for the AJAX action to ensure
@@ -636,6 +675,14 @@ class FacebookWordpressSettingsPage {
                 FacebookPluginConfig::SAVE_CAPI_INTEGRATION_EVENTS_FILTER_ACTION_NAME,
             'capiIntegrationEventsFilterUpdateError' =>
                 FacebookPluginConfig::CAPI_INTEGRATION_EVENTS_FILTER_UPDATE_ERROR,
+            'addMetaCapi'                            =>
+                FacebookWordpressOptions::get_add_meta_capi(),
+            'addMetaCapiSaveUrl'                     =>
+                $this->get_add_meta_capi_save_url(),
+            'addMetaCapiActionName'                  =>
+                FacebookPluginConfig::SAVE_ADD_META_CAPI_ACTION_NAME,
+            'addMetaCapiUpdateError'                 =>
+                FacebookPluginConfig::ADD_META_CAPI_UPDATE_ERROR,
         );
 
         // FBL4B config — only included if app_id is provisioned.

--- a/core/class-facebookwordpresssettingsrecorder.php
+++ b/core/class-facebookwordpresssettingsrecorder.php
@@ -58,6 +58,13 @@ class FacebookWordpressSettingsRecorder {
                 'save_capi_pii_caching_status',
             )
         );
+        add_action(
+            'wp_ajax_save_add_meta_capi',
+            array(
+                $this,
+                'save_add_meta_capi',
+            )
+        );
         // FBL4B AJAX actions.
         add_action(
             'wp_ajax_save_fbl4b_settings',
@@ -331,6 +338,43 @@ class FacebookWordpressSettingsRecorder {
         }
 
         \update_option( FacebookPluginConfig::CAPI_PII_CACHING_STATUS, $val );
+        return $this->handle_success_request( $val );
+    }
+
+    /**
+     * Persists the "Add Meta-enabled CAPI" admin toggle.
+     *
+     * Accepts '1' (default — fbq optinMetaEnabledCapi command is emitted) or
+     * '0' (suppress the command). Admin-only.
+     *
+     * @return array response data
+     */
+    public function save_add_meta_capi() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return $this->handle_unauthorized_request();
+        }
+
+        if ( empty( FacebookWordpressOptions::get_active_pixel_id() ) ) {
+            \update_option(
+                FacebookPluginConfig::ADD_META_CAPI,
+                FacebookPluginConfig::ADD_META_CAPI_DEFAULT
+            );
+            return $this->handle_invalid_request();
+        }
+
+        check_admin_referer(
+            FacebookPluginConfig::SAVE_ADD_META_CAPI_ACTION_NAME
+        );
+        $val = sanitize_text_field(
+            isset( $_POST['val'] ) ?
+            wp_unslash( $_POST['val'] ) : ''
+        );
+
+        if ( ! ( '0' === $val || '1' === $val ) ) {
+            return $this->handle_invalid_request();
+        }
+
+        \update_option( FacebookPluginConfig::ADD_META_CAPI, $val );
         return $this->handle_success_request( $val );
     }
 

--- a/core/class-facebookwordpresssettingsrecorder.php
+++ b/core/class-facebookwordpresssettingsrecorder.php
@@ -59,10 +59,10 @@ class FacebookWordpressSettingsRecorder {
             )
         );
         add_action(
-            'wp_ajax_save_add_meta_capi',
+            'wp_ajax_save_capig',
             array(
                 $this,
-                'save_add_meta_capi',
+                'save_capig',
             )
         );
         // FBL4B AJAX actions.
@@ -342,28 +342,28 @@ class FacebookWordpressSettingsRecorder {
     }
 
     /**
-     * Persists the "Add Meta-enabled CAPI" admin toggle.
+     * Persists the Conversions API Gateway (CAPIG) admin toggle.
      *
      * Accepts '1' (default — fbq optinMetaEnabledCapi command is emitted) or
      * '0' (suppress the command). Admin-only.
      *
      * @return array response data
      */
-    public function save_add_meta_capi() {
+    public function save_capig() {
         if ( ! current_user_can( 'manage_options' ) ) {
             return $this->handle_unauthorized_request();
         }
 
         if ( empty( FacebookWordpressOptions::get_active_pixel_id() ) ) {
             \update_option(
-                FacebookPluginConfig::ADD_META_CAPI,
-                FacebookPluginConfig::ADD_META_CAPI_DEFAULT
+                FacebookPluginConfig::CAPIG,
+                FacebookPluginConfig::CAPIG_DEFAULT
             );
             return $this->handle_invalid_request();
         }
 
         check_admin_referer(
-            FacebookPluginConfig::SAVE_ADD_META_CAPI_ACTION_NAME
+            FacebookPluginConfig::SAVE_CAPIG_ACTION_NAME
         );
         $val = sanitize_text_field(
             isset( $_POST['val'] ) ?
@@ -374,7 +374,7 @@ class FacebookWordpressSettingsRecorder {
             return $this->handle_invalid_request();
         }
 
-        \update_option( FacebookPluginConfig::ADD_META_CAPI, $val );
+        \update_option( FacebookPluginConfig::CAPIG, $val );
         return $this->handle_success_request( $val );
     }
 

--- a/js/facebook_signal.js
+++ b/js/facebook_signal.js
@@ -69,6 +69,9 @@ window.FacebookSignal = window.FacebookSignal || {
     if (this._pixelInitialized || !this._pixelId || typeof fbq !== 'function') {
       return;
     }
+    if (this._config.addMetaCapi === '1') {
+      fbq('optinMetaEnabledCapi', this._pixelId);
+    }
     fbq('init', this._pixelId, this._pixelUserInfo, this._pixelOptions);
     this._pixelInitialized = true;
     this._flushPendingPixelEvents();

--- a/js/facebook_signal.js
+++ b/js/facebook_signal.js
@@ -69,7 +69,7 @@ window.FacebookSignal = window.FacebookSignal || {
     if (this._pixelInitialized || !this._pixelId || typeof fbq !== 'function') {
       return;
     }
-    if (this._config.addMetaCapi === '1') {
+    if (this._config.capig === '1') {
       fbq('optinMetaEnabledCapi', this._pixelId);
     }
     fbq('init', this._pixelId, this._pixelUserInfo, this._pixelOptions);

--- a/js/settings_page.js
+++ b/js/settings_page.js
@@ -62,6 +62,38 @@ if ("false" == hasAccessToken) {
     enablePageViewFilterCheckBox.addEventListener("change", function () {
         saveCapiIntegrationEventsFilter(this.checked ? "1" : "0");
     });
+
+    var addMetaCapiCheckbox = document.getElementById("add-meta-capi");
+    updateAddMetaCapiCheckbox(meta_wc_params.addMetaCapi);
+    addMetaCapiCheckbox.addEventListener("change", function () {
+        saveAddMetaCapi(this.checked ? "1" : "0");
+    });
+    function updateAddMetaCapiCheckbox(val) {
+        addMetaCapiCheckbox.checked = val === "1";
+    }
+    function saveAddMetaCapi(new_val) {
+        jQuery
+            .ajax({
+                type: "post",
+                dataType: "json",
+                url: meta_wc_params.addMetaCapiSaveUrl,
+                data: {
+                    action: meta_wc_params.addMetaCapiActionName,
+                    val: new_val,
+                },
+                success: function (response) {
+                    updateAddMetaCapiCheckbox(new_val);
+                },
+            })
+            .fail(function (jqXHR, textStatus, error) {
+                jQuery("#fb-add-meta-capi-se").text(
+                    meta_wc_params.addMetaCapiUpdateError
+                );
+                jQuery("#fb-add-meta-capi-se")
+                    .show().delay(3000).fadeOut();
+                updateAddMetaCapiCheckbox(new_val === "1" ? "0" : "1");
+            });
+    }
     function updateCapiPiiCachingCheckbox(val) {
         if (val === "1") {
             enablePiiCachingCheckbox.checked = true;

--- a/js/settings_page.js
+++ b/js/settings_page.js
@@ -63,35 +63,35 @@ if ("false" == hasAccessToken) {
         saveCapiIntegrationEventsFilter(this.checked ? "1" : "0");
     });
 
-    var addMetaCapiCheckbox = document.getElementById("add-meta-capi");
-    updateAddMetaCapiCheckbox(meta_wc_params.addMetaCapi);
-    addMetaCapiCheckbox.addEventListener("change", function () {
-        saveAddMetaCapi(this.checked ? "1" : "0");
+    var capigCheckbox = document.getElementById("capig");
+    updateCapigCheckbox(meta_wc_params.capig);
+    capigCheckbox.addEventListener("change", function () {
+        saveCapig(this.checked ? "1" : "0");
     });
-    function updateAddMetaCapiCheckbox(val) {
-        addMetaCapiCheckbox.checked = val === "1";
+    function updateCapigCheckbox(val) {
+        capigCheckbox.checked = val === "1";
     }
-    function saveAddMetaCapi(new_val) {
+    function saveCapig(new_val) {
         jQuery
             .ajax({
                 type: "post",
                 dataType: "json",
-                url: meta_wc_params.addMetaCapiSaveUrl,
+                url: meta_wc_params.capigSaveUrl,
                 data: {
-                    action: meta_wc_params.addMetaCapiActionName,
+                    action: meta_wc_params.capigActionName,
                     val: new_val,
                 },
                 success: function (response) {
-                    updateAddMetaCapiCheckbox(new_val);
+                    updateCapigCheckbox(new_val);
                 },
             })
             .fail(function (jqXHR, textStatus, error) {
-                jQuery("#fb-add-meta-capi-se").text(
-                    meta_wc_params.addMetaCapiUpdateError
+                jQuery("#fb-capig-se").text(
+                    meta_wc_params.capigUpdateError
                 );
-                jQuery("#fb-add-meta-capi-se")
+                jQuery("#fb-capig-se")
                     .show().delay(3000).fadeOut();
-                updateAddMetaCapiCheckbox(new_val === "1" ? "0" : "1");
+                updateCapigCheckbox(new_val === "1" ? "0" : "1");
             });
     }
     function updateCapiPiiCachingCheckbox(val) {


### PR DESCRIPTION
## Summary
- New **"Opt in to a Meta-enabled Conversions API integration"** checkbox in `Meta Advanced Configuration`, default **ON**.
- The toggle value (option `facebook_capig`) is threaded into the `FacebookSignal.init` config as `capig`. When it is `'1'`, `_runPixelInit()` in `js/facebook_signal.js` emits `fbq('optinMetaEnabledCapi', '<pixel_id>')` right before `fbq('init', ...)`. When `'0'`, the command is suppressed.

## Naming: CAPIG vs CAPI
Per review feedback, all **internal** identifiers use **CAPIG** (Conversions API Gateway — the Meta-enabled integration) to keep a clear distinction from **CAPI** (the direct S2S integration). The `fbq('optinMetaEnabledCapi', ...)` command (Meta pixel API contract) and the merchant-facing label/description text are intentionally left unchanged.

## Why
Adds an opt-out path for the `optinMetaEnabledCapi` fbq command so admins can suppress it without disabling the broader CAPI integration.

## Upgrade behavior
- The option is loaded via `get_option(FacebookPluginConfig::CAPIG, '1')`, so a missing row (fresh install or upgrade from a prior version) falls back to the `'1'` default instead of WordPress's normal `false`.
- The getter also defensively coerces `null` / `''` / `false` back to the default — protects against future code paths that bypass `set_capig()`.
- Net: existing installs continue to emit the command with no admin action.

## Wiring (6 production files + 3 test files)
| File | Change |
|---|---|
| `core/class-facebookpluginconfig.php` | `CAPIG` constants (option key `facebook_capig`, default, AJAX action `save_capig`, error msg) |
| `core/class-facebookwordpressoptions.php` | `set_capig()` / `get_capig()`, called from `initialize()` |
| `core/class-facebookwordpresssettingsrecorder.php` | `wp_ajax_save_capig` registration + `save_capig()` handler |
| `core/class-facebookwordpresssettingspage.php` | `#capig` checkbox + `get_capig_save_url()` helper + localized JS params (`capig`, `capigSaveUrl`, `capigActionName`, `capigUpdateError`) |
| `core/class-facebookwordpresspixelinjection.php` | threads `capig` into the `FacebookSignal.init` config |
| `js/facebook_signal.js` | `_runPixelInit()` emits `fbq('optinMetaEnabledCapi', ...)` when `capig === '1'` |
| `js/settings_page.js` | `change` listener + AJAX save |

## Test plan
- [x] `vendor/bin/phpunit --bootstrap __tests__/bootstrap.php __tests__` → 244 tests, 0 failures (2 skipped).
- [x] `testInitConfigIncludesCapigWhenEnabled` asserts the init config contains `"capig":"1"` when the option is `'1'`; the default-mock path asserts `"capig":"0"`.
- [ ] Manual: open WordPress admin → Meta Advanced Configuration → confirm the checkbox renders **checked** after upgrade. Uncheck → reload front-end → confirm `fbq('optinMetaEnabledCapi', ...)` is gone from the pixel `<script>`. Re-check → confirm it reappears.
- [ ] Manual: fresh install — install the plugin from scratch and confirm the checkbox renders checked and the command is emitted with no admin interaction.

## Notes
- #147 (CAPI fallback on auth failure) is stacked on top of this PR — merge this one first.
- This PR has **two commits**: the toggle, and a follow-up that renames the internal identifiers from `add_meta_capi` → `capig` (CAPIG) per review feedback. They squash to one commit on merge.
- The same `is_null(...) || '' === ...` fallback pattern in pre-existing options (e.g., `get_capi_pii_caching_status`) has the same `false`-not-handled potential issue. Out of scope here; could be a follow-up.
