### PR TITLE
Fix YITH subscription null product

### DIFF
--- a/__tests__/integration/FacebookWordpressWooCommerceTest.php
+++ b/__tests__/integration/FacebookWordpressWooCommerceTest.php
@@ -179,6 +179,109 @@ final class FacebookWordpressWooCommerceTest extends FacebookWordpressTestBase {
     }
 
     /**
+     * Tests createPurchaseEvent skips items when wc_get_product() returns
+     * false and does not fail.
+     *
+     * @return void
+     */
+    public function testCreatePurchaseEventSkipsMissingProduct() {
+        $order = new MockWCOrder(
+            'Pika',
+            'Chu',
+            'pika.chu@s2s.com',
+            '2062062006',
+            'Springfield',
+            '12345',
+            'Ohio',
+            'US'
+        );
+        $order->add_item( 404, 1, 100 );
+        $order->add_item( 1, 2, 200 );
+
+        \WP_Mock::userFunction(
+            'wc_get_order',
+            array(
+                'return' => $order,
+            )
+        );
+
+        \WP_Mock::userFunction(
+            'wc_get_product',
+            array(
+                'return' => function ( $product_id ) {
+                    if ( 404 === $product_id ) {
+                        return false;
+                    }
+
+                    return new MockWCProduct( $product_id, 'single_product' );
+                },
+            )
+        );
+
+        \WP_Mock::userFunction(
+            'get_woocommerce_currency',
+            array(
+                'return' => 'USD',
+            )
+        );
+
+        $event_data = FacebookWordpressWooCommerce::createPurchaseEvent( 1 );
+
+        $this->assertEquals( array( 'wc_post_id_1' ), $event_data['content_ids'] );
+        $this->assertCount( 1, $event_data['contents'] );
+        $this->assertEquals(
+            'wc_post_id_1',
+            $event_data['contents'][0]->getProductId()
+        );
+    }
+
+    /**
+     * Tests createPurchaseEvent handles all missing products and returns
+     * empty content arrays.
+     *
+     * @return void
+     */
+    public function testCreatePurchaseEventWithAllMissingProducts() {
+        $order = new MockWCOrder(
+            'Pika',
+            'Chu',
+            'pika.chu@s2s.com',
+            '2062062006',
+            'Springfield',
+            '12345',
+            'Ohio',
+            'US'
+        );
+        $order->add_item( 404, 1, 100 );
+
+        \WP_Mock::userFunction(
+            'wc_get_order',
+            array(
+                'return' => $order,
+            )
+        );
+
+        \WP_Mock::userFunction(
+            'wc_get_product',
+            array(
+                'return' => false,
+            )
+        );
+
+        \WP_Mock::userFunction(
+            'get_woocommerce_currency',
+            array(
+                'return' => 'USD',
+            )
+        );
+
+        $event_data = FacebookWordpressWooCommerce::createPurchaseEvent( 1 );
+
+        $this->assertSame( array(), $event_data['content_ids'] );
+        $this->assertSame( array(), $event_data['contents'] );
+    }
+
+    /**
      * Tests that the trackInitiateCheckout method correctly records an
      * 'InitiateCheckout' event when the user is not an internal user.
      *
@@ -335,6 +438,29 @@ final class FacebookWordpressWooCommerceTest extends FacebookWordpressTestBase {
         'woocommerce',
         $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
     );
+    }
+
+    /**
+     * Tests createAddToCartEvent when the cart item key is missing from
+     * WC()->cart (e.g. private cart key from another plugin).
+     *
+     * @return void
+     */
+    public function testCreateAddToCartEventWithMissingCartItemKey() {
+        self::mockIsInternalUser( false );
+        self::mockFacebookWordpressOptions();
+        $this->setupMocks();
+        $this->setupCustomerBillingAddress();
+
+        $event_data = FacebookWordpressWooCommerce::createAddToCartEvent(
+            'missing-cart-key',
+            1,
+            3
+        );
+
+        $this->assertEquals( 'USD', $event_data['currency'] );
+        $this->assertArrayNotHasKey( 'content_ids', $event_data );
+        $this->assertArrayNotHasKey( 'value', $event_data );
     }
 
     /**

--- a/__tests__/integration/FacebookWordpressWooCommerceTest.php
+++ b/__tests__/integration/FacebookWordpressWooCommerceTest.php
@@ -449,12 +449,49 @@ final class FacebookWordpressWooCommerceTest extends FacebookWordpressTestBase {
     public function testCreateAddToCartEventWithMissingCartItemKey() {
         self::mockIsInternalUser( false );
         self::mockFacebookWordpressOptions();
-        $this->setupMocks();
+        $this->setupMocks( false );
         $this->setupCustomerBillingAddress();
+
+        \WP_Mock::userFunction(
+            'wc_get_product',
+            array(
+                'return' => new MockWCProduct( 1, 'single_product', null, 10 ),
+            )
+        );
 
         $event_data = FacebookWordpressWooCommerce::createAddToCartEvent(
             'missing-cart-key',
             1,
+            3
+        );
+
+        $this->assertEquals( 'USD', $event_data['currency'] );
+        $this->assertEquals( array( 'wc_post_id_1' ), $event_data['content_ids'] );
+        $this->assertEquals( 30.0, $event_data['value'] );
+    }
+
+    /**
+     * Tests createAddToCartEvent fallback returns partial event data when
+     * product lookup also fails.
+     *
+     * @return void
+     */
+    public function testCreateAddToCartEventWithMissingCartItemAndProduct() {
+        self::mockIsInternalUser( false );
+        self::mockFacebookWordpressOptions();
+        $this->setupMocks( false );
+        $this->setupCustomerBillingAddress();
+
+        \WP_Mock::userFunction(
+            'wc_get_product',
+            array(
+                'return' => false,
+            )
+        );
+
+        $event_data = FacebookWordpressWooCommerce::createAddToCartEvent(
+            'missing-cart-key',
+            404,
             3
         );
 
@@ -856,7 +893,7 @@ final class FacebookWordpressWooCommerceTest extends FacebookWordpressTestBase {
      *
      * @return void
      */
-    private function setupMocks() {
+    private function setupMocks( $mock_wc_get_product = true ) {
         $this->mocked_fbpixel->shouldReceive( 'get_logged_in_user_info' )
     ->andReturn(
         array(
@@ -902,6 +939,7 @@ final class FacebookWordpressWooCommerceTest extends FacebookWordpressTestBase {
         )
     );
 
+    if ( $mock_wc_get_product ) {
     \WP_Mock::userFunction(
         'wc_get_product',
         array(
@@ -913,6 +951,7 @@ final class FacebookWordpressWooCommerceTest extends FacebookWordpressTestBase {
             ),
         )
     );
+    }
 
     \WP_Mock::userFunction(
         'get_current_user_id',

--- a/integration/class-facebookwordpresswoocommerce.php
+++ b/integration/class-facebookwordpresswoocommerce.php
@@ -290,6 +290,10 @@ class FacebookWordpressWooCommerce extends FacebookWordpressIntegrationBase {
 
         foreach ( $order->get_items() as $item ) {
             $product = wc_get_product( $item->get_product_id() );
+            if ( ! is_object( $product ) || ! method_exists( $product, 'get_id' ) ) {
+                continue;
+            }
+
             if ( 'product_group' !== $content_type
             && $product->is_type( 'variable' ) ) {
             $content_type = 'product_group';
@@ -427,7 +431,7 @@ class FacebookWordpressWooCommerce extends FacebookWordpressIntegrationBase {
         $event_data['currency']     = \get_woocommerce_currency();
 
         $cart_item = self::getCartItem( $cart_item_key );
-        if ( ! empty( $cart_item_key ) ) {
+        if ( ! empty( $cart_item ) && ! empty( $cart_item['data'] ) ) {
             $event_data['content_ids'] = array(
                 self::getProductId(
                     $cart_item['data']
@@ -649,6 +653,10 @@ class FacebookWordpressWooCommerce extends FacebookWordpressIntegrationBase {
      * @since 1.0.0
      */
     private static function getProductId( $product ) {
+        if ( ! is_object( $product ) || ! method_exists( $product, 'get_id' ) ) {
+            return null;
+        }
+
         $woo_id = $product->get_id();
 
         return $product->get_sku() ? $product->get_sku() . '_' .

--- a/integration/class-facebookwordpresswoocommerce.php
+++ b/integration/class-facebookwordpresswoocommerce.php
@@ -356,7 +356,7 @@ class FacebookWordpressWooCommerce extends FacebookWordpressIntegrationBase {
         $server_event = ServerEventFactory::safe_create_event(
             'AddToCart',
             array( __CLASS__, 'createAddToCartEvent' ),
-            array( $cart_item_key, $product_id, $quantity ),
+            array( $cart_item_key, $product_id, $quantity, $variation_id ),
             self::TRACKING_NAME
         );
 
@@ -416,6 +416,7 @@ class FacebookWordpressWooCommerce extends FacebookWordpressIntegrationBase {
      * @param string $cart_item_key The cart item key.
      * @param int    $product_id    The product ID.
      * @param int    $quantity      The quantity.
+     * @param int    $variation_id  The variation ID.
      *
      * @return array The event data.
      *
@@ -424,7 +425,8 @@ class FacebookWordpressWooCommerce extends FacebookWordpressIntegrationBase {
     public static function createAddToCartEvent(
         $cart_item_key,
         $product_id,
-        $quantity
+        $quantity,
+        $variation_id = null
     ) {
         $event_data                 = self::getPIIFromSession();
         $event_data['content_type'] = 'product';
@@ -441,6 +443,22 @@ class FacebookWordpressWooCommerce extends FacebookWordpressIntegrationBase {
                 $cart_item,
                 $quantity
             );
+
+            return $event_data;
+        }
+
+        // Fallback for integrations that call Woo add_to_cart() on a
+        // temporary/private cart (e.g. subscription cloning flows).
+        $product_lookup_id = ! empty( $variation_id ) ? $variation_id : $product_id;
+        $product           = wc_get_product( $product_lookup_id );
+        $product_fb_id     = self::getProductId( $product );
+
+        if ( ! empty( $product_fb_id ) ) {
+            $event_data['content_ids'] = array( $product_fb_id );
+
+            if ( is_object( $product ) && method_exists( $product, 'get_price' ) ) {
+                $event_data['value'] = (float) $quantity * (float) $product->get_price();
+            }
         }
 
         return $event_data;


### PR DESCRIPTION
## Description

Fixes a WooCommerce fatal in YITH Subscriptions checkout flow and adds regression tests.

YITH Subscriptions may fire WooCommerce hooks using a private cart item key (not present in `WC()->cart`) and order items where `wc_get_product()` returns `false` (missing/deleted product). This could cause a fatal when product methods are called on null/invalid values.

Changes included:
- Guard `createAddToCartEvent()` against missing cart item / missing `data`.
- Guard `getProductId()` against invalid/non-product input.
- Guard `createPurchaseEvent()` when `wc_get_product()` is missing/invalid and skip that item.
- Add regression tests for all above missing-product / missing-cart-item scenarios.

Related issue: fatal in `integration/class-facebookwordpresswoocommerce.php` during YITH subscription checkout.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have confirmed that my changes do not introduce any new PHPCS warnings or errors. 
- [X] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors. 
- [X] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/b2b0midg)).
- [X] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [X] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary).


## Changelog entry

Fix WooCommerce/YITH subscription fatal on missing products/cart items and add regression tests.


## Test Plan

1. Install and activate:
   - **YITH WooCommerce Subscription** plugin
2. In WooCommerce, create a new **subscription product** (YITH subscription type), publish it.
3. Visit storefront as a customer, add the subscription product to cart.
4. Proceed to checkout and place the order.
5. Verify expected behavior:
   - Checkout completes successfully.
   - No PHP fatal error is thrown.
   - No `Call to a member function get_id() on null` in logs.
   - Plugin debug logs / PHP error logs show no new warnings/fatals related to AddToCart/Purchase event generation.