### PR TITLE
Form field mapping (3/5): AJAX recorder endpoints

### DIFF
--- a/__tests__/core/FormFieldMappingRecorderTest.php
+++ b/__tests__/core/FormFieldMappingRecorderTest.php
@@ -1,0 +1,263 @@
+<?php
+/**
+ * Facebook Pixel Plugin FormFieldMappingRecorderTest class.
+ *
+ * Covers the AJAX handlers that back the admin Field Mapping screen.
+ *
+ * @package FacebookPixelPlugin
+ */
+
+/*
+* Copyright (C) 2017-present, Meta, Inc.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; version 2 of the License.
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*/
+
+namespace FacebookPixelPlugin\Tests\Core;
+
+use FacebookPixelPlugin\Core\FacebookPluginConfig;
+use FacebookPixelPlugin\Core\FacebookWordpressSettingsRecorder;
+use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
+
+/**
+ * FormFieldMappingRecorderTest class.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
+
+    /**
+     * Mocks the WordPress functions used by the mapping handlers.
+     *
+     * @param bool $can_manage Whether current_user_can returns true.
+     * @return void
+     */
+    private function mockMappingFunctions( $can_manage = true ) {
+        \WP_Mock::userFunction(
+            'current_user_can',
+            array( 'return' => $can_manage )
+        );
+        \WP_Mock::userFunction(
+            'check_admin_referer',
+            array( 'return' => true )
+        );
+        \WP_Mock::userFunction(
+            'wp_send_json',
+            array( 'return' => true )
+        );
+        \WP_Mock::userFunction(
+            'sanitize_text_field',
+            array(
+                'return' => function ( $v ) {
+                    return $v;
+                },
+            )
+        );
+        \WP_Mock::userFunction(
+            'sanitize_textarea_field',
+            array(
+                'return' => function ( $v ) {
+                    return $v;
+                },
+            )
+        );
+        \WP_Mock::userFunction(
+            'get_option',
+            array( 'return' => array() )
+        );
+        \WP_Mock::userFunction(
+            'update_option',
+            array( 'return' => true )
+        );
+    }
+
+    /**
+     * The four mapping AJAX actions are registered.
+     *
+     * @return void
+     */
+    public function testMappingAjaxActionsAdded() {
+        $recorder = new FacebookWordpressSettingsRecorder();
+        \WP_Mock::expectActionAdded(
+            'wp_ajax_' . FacebookPluginConfig::GET_MAPPING_FORMS_ACTION_NAME,
+            array( $recorder, 'get_mapping_forms' )
+        );
+        \WP_Mock::expectActionAdded(
+            'wp_ajax_' . FacebookPluginConfig::GET_MAPPING_FIELDS_ACTION_NAME,
+            array( $recorder, 'get_mapping_fields' )
+        );
+        \WP_Mock::expectActionAdded(
+            'wp_ajax_' . FacebookPluginConfig::SAVE_FIELD_MAPPING_ACTION_NAME,
+            array( $recorder, 'save_field_mapping' )
+        );
+        \WP_Mock::expectActionAdded(
+            'wp_ajax_' . FacebookPluginConfig::DELETE_FIELD_MAPPING_ACTION_NAME,
+            array( $recorder, 'delete_field_mapping' )
+        );
+
+        $recorder->init();
+
+        $this->assertConditionsMet();
+    }
+
+    /**
+     * Unauthorized users are rejected by get_mapping_forms.
+     *
+     * @return void
+     */
+    public function testGetMappingFormsUnauthorized() {
+        $this->mockMappingFunctions( false );
+        $recorder = new FacebookWordpressSettingsRecorder();
+
+        $res = $recorder->get_mapping_forms();
+
+        $this->assertFalse( $res['success'] );
+    }
+
+    /**
+     * An unknown integration is rejected.
+     *
+     * @return void
+     */
+    public function testGetMappingFormsInvalidIntegration() {
+        $this->mockMappingFunctions();
+        $_POST['integration'] = 'not-a-real-integration';
+        $recorder             = new FacebookWordpressSettingsRecorder();
+
+        $res = $recorder->get_mapping_forms();
+
+        $this->assertFalse( $res['success'] );
+    }
+
+    /**
+     * A valid integration returns a forms list (empty when plugin inactive).
+     *
+     * @return void
+     */
+    public function testGetMappingFormsSuccess() {
+        $this->mockMappingFunctions();
+        $_POST['integration'] = 'contact-form-7';
+        $recorder             = new FacebookWordpressSettingsRecorder();
+
+        $res = $recorder->get_mapping_forms();
+
+        $this->assertTrue( $res['success'] );
+        $this->assertArrayHasKey( 'forms', $res['msg'] );
+        $this->assertSame( array(), $res['msg']['forms'] );
+    }
+
+    /**
+     * get_mapping_fields requires a form id.
+     *
+     * @return void
+     */
+    public function testGetMappingFieldsRequiresFormId() {
+        $this->mockMappingFunctions();
+        $_POST['integration'] = 'contact-form-7';
+        $_POST['form_id']     = '';
+        $recorder             = new FacebookWordpressSettingsRecorder();
+
+        $res = $recorder->get_mapping_fields();
+
+        $this->assertFalse( $res['success'] );
+    }
+
+    /**
+     * get_mapping_fields returns fields plus the saved mapping.
+     *
+     * @return void
+     */
+    public function testGetMappingFieldsSuccess() {
+        $this->mockMappingFunctions();
+        $_POST['integration'] = 'contact-form-7';
+        $_POST['form_id']     = '123';
+        $recorder             = new FacebookWordpressSettingsRecorder();
+
+        $res = $recorder->get_mapping_fields();
+
+        $this->assertTrue( $res['success'] );
+        $this->assertArrayHasKey( 'fields', $res['msg'] );
+        $this->assertArrayHasKey( 'mapping', $res['msg'] );
+    }
+
+    /**
+     * save_field_mapping persists a valid mapping and returns the list.
+     *
+     * @return void
+     */
+    public function testSaveFieldMappingPersists() {
+        $this->mockMappingFunctions();
+        $_POST['integration'] = 'contact-form-7';
+        $_POST['form_id']     = '123';
+        $_POST['form_title']  = 'wform1';
+        $_POST['mapping']     = json_encode(
+            array(
+                'FN_1' => 'first_name',
+                'EM_2' => 'email',
+            )
+        );
+        $recorder = new FacebookWordpressSettingsRecorder();
+
+        $res = $recorder->save_field_mapping();
+
+        $this->assertTrue( $res['success'] );
+        $this->assertArrayHasKey( 'list', $res['msg'] );
+    }
+
+    /**
+     * save_field_mapping rejects an unknown integration.
+     *
+     * @return void
+     */
+    public function testSaveFieldMappingInvalidIntegration() {
+        $this->mockMappingFunctions();
+        $_POST['integration'] = 'bogus';
+        $_POST['form_id']     = '123';
+        $_POST['mapping']     = json_encode( array( 'FN_1' => 'first_name' ) );
+        $recorder             = new FacebookWordpressSettingsRecorder();
+
+        $res = $recorder->save_field_mapping();
+
+        $this->assertFalse( $res['success'] );
+    }
+
+    /**
+     * delete_field_mapping succeeds for a valid request.
+     *
+     * @return void
+     */
+    public function testDeleteFieldMapping() {
+        $this->mockMappingFunctions();
+        $_POST['integration'] = 'contact-form-7';
+        $_POST['form_id']     = '123';
+        $recorder             = new FacebookWordpressSettingsRecorder();
+
+        $res = $recorder->delete_field_mapping();
+
+        $this->assertTrue( $res['success'] );
+        $this->assertArrayHasKey( 'list', $res['msg'] );
+    }
+
+    /**
+     * delete_field_mapping requires integration and form id.
+     *
+     * @return void
+     */
+    public function testDeleteFieldMappingRequiresParams() {
+        $this->mockMappingFunctions();
+        $_POST['integration'] = '';
+        $_POST['form_id']     = '';
+        $recorder             = new FacebookWordpressSettingsRecorder();
+
+        $res = $recorder->delete_field_mapping();
+
+        $this->assertFalse( $res['success'] );
+    }
+}

--- a/__tests__/core/FormFieldMappingRecorderTest.php
+++ b/__tests__/core/FormFieldMappingRecorderTest.php
@@ -24,14 +24,14 @@ namespace FacebookPixelPlugin\Tests\Core;
 use FacebookPixelPlugin\Core\FacebookPluginConfig;
 use FacebookPixelPlugin\Core\FacebookWordpressSettingsRecorder;
 use FacebookPixelPlugin\Core\FormFieldMapper;
-use FacebookPixelPlugin\Tests\Mocks\InMemoryFormFieldMappingStore;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 
 /**
  * FormFieldMappingRecorderTest class.
  *
- * The recorder is given a mapper backed by an in-memory store, so the
- * handlers can be tested without WordPress option mocking.
+ * The recorder is given a PHPUnit mock of FormFieldMapper, so the handlers can
+ * be tested in isolation. WP_Mock is used only at the WordPress boundary
+ * (auth, nonce, sanitize, wp_send_json).
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
@@ -39,27 +39,24 @@ use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
 
     /**
-     * In-memory store backing the injected mapper.
+     * Mock mapper injected into the recorder.
      *
-     * @var InMemoryFormFieldMappingStore
+     * @var \PHPUnit\Framework\MockObject\MockObject
      */
-    private $store;
+    private $mapper;
 
     /**
-     * Builds a recorder whose mapper is backed by an in-memory store.
+     * Builds a recorder with a mock FormFieldMapper.
      *
-     * @param array $seed Initial mapping store contents.
      * @return FacebookWordpressSettingsRecorder
      */
-    private function makeRecorder( $seed = array() ) {
-        $this->store = new InMemoryFormFieldMappingStore( $seed );
-        return new FacebookWordpressSettingsRecorder(
-            new FormFieldMapper( $this->store )
-        );
+    private function makeRecorder() {
+        $this->mapper = $this->createMock( FormFieldMapper::class );
+        return new FacebookWordpressSettingsRecorder( $this->mapper );
     }
 
     /**
-     * Mocks the WordPress functions used by the mapping handlers.
+     * Mocks the WordPress boundary functions used by the mapping handlers.
      *
      * @param bool $can_manage Whether current_user_can returns true.
      * @return void
@@ -187,7 +184,7 @@ final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
     }
 
     /**
-     * get_mapping_fields returns fields plus the saved mapping.
+     * get_mapping_fields returns fields plus the saved mapping from the mapper.
      *
      * @return void
      */
@@ -195,16 +192,11 @@ final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
         $this->mockMappingFunctions();
         $_POST['integration'] = 'contact-form-7';
         $_POST['form_id']     = '123';
-        $recorder             = $this->makeRecorder(
-            array(
-                'contact-form-7' => array(
-                    '123' => array(
-                        'form_title' => 'wform1',
-                        'mappings'   => array( 'your-email' => 'email' ),
-                    ),
-                ),
-            )
-        );
+        $recorder             = $this->makeRecorder();
+
+        $this->mapper->method( 'get_mappings' )
+            ->with( 'contact-form-7', '123' )
+            ->willReturn( array( 'your-email' => 'email' ) );
 
         $res = $recorder->get_mapping_fields();
 
@@ -217,7 +209,7 @@ final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
     }
 
     /**
-     * save_field_mapping persists a valid mapping to the store.
+     * save_field_mapping forwards a sanitized mapping to the mapper.
      *
      * @return void
      */
@@ -234,22 +226,27 @@ final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
         );
         $recorder = $this->makeRecorder();
 
+        $this->mapper->expects( $this->once() )
+            ->method( 'save_form_mapping' )
+            ->with(
+                'contact-form-7',
+                '123',
+                'wform1',
+                array(
+                    'FN_1' => 'first_name',
+                    'EM_2' => 'email',
+                )
+            );
+        $this->mapper->method( 'get_flat_list' )->willReturn( array() );
+
         $res = $recorder->save_field_mapping();
 
         $this->assertTrue( $res['success'] );
         $this->assertArrayHasKey( 'list', $res['msg'] );
-        // The mapping was actually written to the store.
-        $this->assertEquals(
-            array(
-                'FN_1' => 'first_name',
-                'EM_2' => 'email',
-            ),
-            $this->store->read()['contact-form-7']['123']['mappings']
-        );
     }
 
     /**
-     * save_field_mapping rejects an unknown integration.
+     * save_field_mapping rejects an unknown integration and never saves.
      *
      * @return void
      */
@@ -260,14 +257,15 @@ final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
         $_POST['mapping']     = json_encode( array( 'FN_1' => 'first_name' ) );
         $recorder             = $this->makeRecorder();
 
+        $this->mapper->expects( $this->never() )->method( 'save_form_mapping' );
+
         $res = $recorder->save_field_mapping();
 
         $this->assertFalse( $res['success'] );
-        $this->assertSame( array(), $this->store->read() );
     }
 
     /**
-     * delete_field_mapping removes a stored mapping.
+     * delete_field_mapping forwards to the mapper.
      *
      * @return void
      */
@@ -275,22 +273,17 @@ final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
         $this->mockMappingFunctions();
         $_POST['integration'] = 'contact-form-7';
         $_POST['form_id']     = '123';
-        $recorder             = $this->makeRecorder(
-            array(
-                'contact-form-7' => array(
-                    '123' => array(
-                        'form_title' => 'wform1',
-                        'mappings'   => array( 'FN_1' => 'first_name' ),
-                    ),
-                ),
-            )
-        );
+        $recorder             = $this->makeRecorder();
+
+        $this->mapper->expects( $this->once() )
+            ->method( 'delete_form_mapping' )
+            ->with( 'contact-form-7', '123' );
+        $this->mapper->method( 'get_flat_list' )->willReturn( array() );
 
         $res = $recorder->delete_field_mapping();
 
         $this->assertTrue( $res['success'] );
         $this->assertArrayHasKey( 'list', $res['msg'] );
-        $this->assertSame( array(), $this->store->read() );
     }
 
     /**
@@ -303,6 +296,8 @@ final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
         $_POST['integration'] = '';
         $_POST['form_id']     = '';
         $recorder             = $this->makeRecorder();
+
+        $this->mapper->expects( $this->never() )->method( 'delete_form_mapping' );
 
         $res = $recorder->delete_field_mapping();
 

--- a/__tests__/core/FormFieldMappingRecorderTest.php
+++ b/__tests__/core/FormFieldMappingRecorderTest.php
@@ -23,15 +23,40 @@ namespace FacebookPixelPlugin\Tests\Core;
 
 use FacebookPixelPlugin\Core\FacebookPluginConfig;
 use FacebookPixelPlugin\Core\FacebookWordpressSettingsRecorder;
+use FacebookPixelPlugin\Core\FormFieldMapper;
+use FacebookPixelPlugin\Tests\Mocks\InMemoryFormFieldMappingStore;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 
 /**
  * FormFieldMappingRecorderTest class.
  *
+ * The recorder is given a mapper backed by an in-memory store, so the
+ * handlers can be tested without WordPress option mocking.
+ *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
 final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
+
+    /**
+     * In-memory store backing the injected mapper.
+     *
+     * @var InMemoryFormFieldMappingStore
+     */
+    private $store;
+
+    /**
+     * Builds a recorder whose mapper is backed by an in-memory store.
+     *
+     * @param array $seed Initial mapping store contents.
+     * @return FacebookWordpressSettingsRecorder
+     */
+    private function makeRecorder( $seed = array() ) {
+        $this->store = new InMemoryFormFieldMappingStore( $seed );
+        return new FacebookWordpressSettingsRecorder(
+            new FormFieldMapper( $this->store )
+        );
+    }
 
     /**
      * Mocks the WordPress functions used by the mapping handlers.
@@ -68,14 +93,6 @@ final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
                 },
             )
         );
-        \WP_Mock::userFunction(
-            'get_option',
-            array( 'return' => array() )
-        );
-        \WP_Mock::userFunction(
-            'update_option',
-            array( 'return' => true )
-        );
     }
 
     /**
@@ -84,7 +101,7 @@ final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
      * @return void
      */
     public function testMappingAjaxActionsAdded() {
-        $recorder = new FacebookWordpressSettingsRecorder();
+        $recorder = $this->makeRecorder();
         \WP_Mock::expectActionAdded(
             'wp_ajax_' . FacebookPluginConfig::GET_MAPPING_FORMS_ACTION_NAME,
             array( $recorder, 'get_mapping_forms' )
@@ -114,7 +131,7 @@ final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
      */
     public function testGetMappingFormsUnauthorized() {
         $this->mockMappingFunctions( false );
-        $recorder = new FacebookWordpressSettingsRecorder();
+        $recorder = $this->makeRecorder();
 
         $res = $recorder->get_mapping_forms();
 
@@ -129,7 +146,7 @@ final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
     public function testGetMappingFormsInvalidIntegration() {
         $this->mockMappingFunctions();
         $_POST['integration'] = 'not-a-real-integration';
-        $recorder             = new FacebookWordpressSettingsRecorder();
+        $recorder             = $this->makeRecorder();
 
         $res = $recorder->get_mapping_forms();
 
@@ -144,7 +161,7 @@ final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
     public function testGetMappingFormsSuccess() {
         $this->mockMappingFunctions();
         $_POST['integration'] = 'contact-form-7';
-        $recorder             = new FacebookWordpressSettingsRecorder();
+        $recorder             = $this->makeRecorder();
 
         $res = $recorder->get_mapping_forms();
 
@@ -162,7 +179,7 @@ final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
         $this->mockMappingFunctions();
         $_POST['integration'] = 'contact-form-7';
         $_POST['form_id']     = '';
-        $recorder             = new FacebookWordpressSettingsRecorder();
+        $recorder             = $this->makeRecorder();
 
         $res = $recorder->get_mapping_fields();
 
@@ -178,17 +195,29 @@ final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
         $this->mockMappingFunctions();
         $_POST['integration'] = 'contact-form-7';
         $_POST['form_id']     = '123';
-        $recorder             = new FacebookWordpressSettingsRecorder();
+        $recorder             = $this->makeRecorder(
+            array(
+                'contact-form-7' => array(
+                    '123' => array(
+                        'form_title' => 'wform1',
+                        'mappings'   => array( 'your-email' => 'email' ),
+                    ),
+                ),
+            )
+        );
 
         $res = $recorder->get_mapping_fields();
 
         $this->assertTrue( $res['success'] );
         $this->assertArrayHasKey( 'fields', $res['msg'] );
-        $this->assertArrayHasKey( 'mapping', $res['msg'] );
+        $this->assertEquals(
+            array( 'your-email' => 'email' ),
+            $res['msg']['mapping']
+        );
     }
 
     /**
-     * save_field_mapping persists a valid mapping and returns the list.
+     * save_field_mapping persists a valid mapping to the store.
      *
      * @return void
      */
@@ -203,12 +232,20 @@ final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
                 'EM_2' => 'email',
             )
         );
-        $recorder = new FacebookWordpressSettingsRecorder();
+        $recorder = $this->makeRecorder();
 
         $res = $recorder->save_field_mapping();
 
         $this->assertTrue( $res['success'] );
         $this->assertArrayHasKey( 'list', $res['msg'] );
+        // The mapping was actually written to the store.
+        $this->assertEquals(
+            array(
+                'FN_1' => 'first_name',
+                'EM_2' => 'email',
+            ),
+            $this->store->read()['contact-form-7']['123']['mappings']
+        );
     }
 
     /**
@@ -221,15 +258,16 @@ final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
         $_POST['integration'] = 'bogus';
         $_POST['form_id']     = '123';
         $_POST['mapping']     = json_encode( array( 'FN_1' => 'first_name' ) );
-        $recorder             = new FacebookWordpressSettingsRecorder();
+        $recorder             = $this->makeRecorder();
 
         $res = $recorder->save_field_mapping();
 
         $this->assertFalse( $res['success'] );
+        $this->assertSame( array(), $this->store->read() );
     }
 
     /**
-     * delete_field_mapping succeeds for a valid request.
+     * delete_field_mapping removes a stored mapping.
      *
      * @return void
      */
@@ -237,12 +275,22 @@ final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
         $this->mockMappingFunctions();
         $_POST['integration'] = 'contact-form-7';
         $_POST['form_id']     = '123';
-        $recorder             = new FacebookWordpressSettingsRecorder();
+        $recorder             = $this->makeRecorder(
+            array(
+                'contact-form-7' => array(
+                    '123' => array(
+                        'form_title' => 'wform1',
+                        'mappings'   => array( 'FN_1' => 'first_name' ),
+                    ),
+                ),
+            )
+        );
 
         $res = $recorder->delete_field_mapping();
 
         $this->assertTrue( $res['success'] );
         $this->assertArrayHasKey( 'list', $res['msg'] );
+        $this->assertSame( array(), $this->store->read() );
     }
 
     /**
@@ -254,7 +302,7 @@ final class FormFieldMappingRecorderTest extends FacebookWordpressTestBase {
         $this->mockMappingFunctions();
         $_POST['integration'] = '';
         $_POST['form_id']     = '';
-        $recorder             = new FacebookWordpressSettingsRecorder();
+        $recorder             = $this->makeRecorder();
 
         $res = $recorder->delete_field_mapping();
 

--- a/core/class-facebookpluginconfig.php
+++ b/core/class-facebookpluginconfig.php
@@ -182,4 +182,25 @@ class FacebookPluginConfig {
             'WOOCOMMERCE'           => 'FacebookWordpressWooCommerce',
         );
     }
+
+    /**
+     * Returns the integrations that support the admin Field Mapping screen,
+     * keyed by tracking name => fully-qualified integration class name.
+     *
+     * @return array<string,string>
+     */
+    public static function get_field_mapping_integrations() {
+        $result = array();
+        foreach ( self::integration_config() as $class ) {
+            $fqcn = 'FacebookPixelPlugin\\Integration\\' . $class;
+            if ( ! class_exists( $fqcn ) ) {
+                continue;
+            }
+            if ( ! $fqcn::supports_field_mapping() ) {
+                continue;
+            }
+            $result[ $fqcn::TRACKING_NAME ] = $fqcn;
+        }
+        return $result;
+    }
 }

--- a/core/class-facebookwordpresssettingsrecorder.php
+++ b/core/class-facebookwordpresssettingsrecorder.php
@@ -90,6 +90,203 @@ class FacebookWordpressSettingsRecorder {
             'wp_ajax_fbl4b_clear_pixel',
             array( $this, 'fbl4b_clear_pixel' )
         );
+
+        // Form field mapping AJAX actions.
+        add_action(
+            'wp_ajax_' . FacebookPluginConfig::GET_MAPPING_FORMS_ACTION_NAME,
+            array( $this, 'get_mapping_forms' )
+        );
+        add_action(
+            'wp_ajax_' . FacebookPluginConfig::GET_MAPPING_FIELDS_ACTION_NAME,
+            array( $this, 'get_mapping_fields' )
+        );
+        add_action(
+            'wp_ajax_' . FacebookPluginConfig::SAVE_FIELD_MAPPING_ACTION_NAME,
+            array( $this, 'save_field_mapping' )
+        );
+        add_action(
+            'wp_ajax_' . FacebookPluginConfig::DELETE_FIELD_MAPPING_ACTION_NAME,
+            array( $this, 'delete_field_mapping' )
+        );
+    }
+
+    /**
+     * Resolves the integration class for a tracking name received over AJAX.
+     *
+     * Only integrations that support the Field Mapping screen are eligible,
+     * preventing arbitrary class resolution from request input.
+     *
+     * @param string $tracking_name The integration tracking name.
+     * @return string|null The fully-qualified class name, or null if invalid.
+     */
+    private function resolve_mapping_integration( $tracking_name ) {
+        $integrations =
+            FacebookPluginConfig::get_field_mapping_integrations();
+        return isset( $integrations[ $tracking_name ] )
+            ? $integrations[ $tracking_name ]
+            : null;
+    }
+
+    /**
+     * Returns the list of forms for the requested integration.
+     *
+     * @return array response data
+     */
+    public function get_mapping_forms() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return $this->handle_unauthorized_request();
+        }
+        check_admin_referer(
+            FacebookPluginConfig::GET_MAPPING_FORMS_ACTION_NAME
+        );
+
+        $tracking_name = sanitize_text_field(
+            isset( $_POST['integration'] ) ?
+            wp_unslash( $_POST['integration'] ) : ''
+        );
+        $class         = $this->resolve_mapping_integration( $tracking_name );
+        if ( null === $class ) {
+            return $this->handle_invalid_request();
+        }
+
+        return $this->handle_success_request(
+            array( 'forms' => $class::get_forms() )
+        );
+    }
+
+    /**
+     * Returns the fields for a form plus its currently saved mapping.
+     *
+     * @return array response data
+     */
+    public function get_mapping_fields() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return $this->handle_unauthorized_request();
+        }
+        check_admin_referer(
+            FacebookPluginConfig::GET_MAPPING_FIELDS_ACTION_NAME
+        );
+
+        $tracking_name = sanitize_text_field(
+            isset( $_POST['integration'] ) ?
+            wp_unslash( $_POST['integration'] ) : ''
+        );
+        $form_id       = sanitize_text_field(
+            isset( $_POST['form_id'] ) ?
+            wp_unslash( $_POST['form_id'] ) : ''
+        );
+        $class         = $this->resolve_mapping_integration( $tracking_name );
+        if ( null === $class || '' === $form_id ) {
+            return $this->handle_invalid_request();
+        }
+
+        return $this->handle_success_request(
+            array(
+                'fields'  => $class::get_form_fields( $form_id ),
+                'mapping' => FormFieldMapper::get_mappings(
+                    $tracking_name,
+                    $form_id
+                ),
+            )
+        );
+    }
+
+    /**
+     * Persists a form's field mapping (upsert; one mapping per form).
+     *
+     * Expects POST: integration, form_id, form_title, and mapping as a JSON
+     * object of field_id => standard_field. Invalid targets are dropped by
+     * FormFieldMapper.
+     *
+     * @return array response data
+     */
+    public function save_field_mapping() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return $this->handle_unauthorized_request();
+        }
+        check_admin_referer(
+            FacebookPluginConfig::SAVE_FIELD_MAPPING_ACTION_NAME
+        );
+
+        $tracking_name = sanitize_text_field(
+            isset( $_POST['integration'] ) ?
+            wp_unslash( $_POST['integration'] ) : ''
+        );
+        $form_id       = sanitize_text_field(
+            isset( $_POST['form_id'] ) ?
+            wp_unslash( $_POST['form_id'] ) : ''
+        );
+        $form_title    = sanitize_text_field(
+            isset( $_POST['form_title'] ) ?
+            wp_unslash( $_POST['form_title'] ) : ''
+        );
+        $class         = $this->resolve_mapping_integration( $tracking_name );
+        if ( null === $class || '' === $form_id ) {
+            return $this->handle_invalid_request();
+        }
+
+        $raw_mapping = isset( $_POST['mapping'] )
+            ? json_decode(
+                sanitize_textarea_field( wp_unslash( $_POST['mapping'] ) ),
+                true
+            )
+            : array();
+        if ( ! is_array( $raw_mapping ) ) {
+            return $this->handle_invalid_request();
+        }
+
+        $mapping = array();
+        foreach ( $raw_mapping as $field_id => $standard ) {
+            $field_id = sanitize_text_field( (string) $field_id );
+            $standard = sanitize_text_field( (string) $standard );
+            if ( '' === $field_id || '' === $standard ) {
+                continue;
+            }
+            $mapping[ $field_id ] = $standard;
+        }
+
+        FormFieldMapper::save_form_mapping(
+            $tracking_name,
+            $form_id,
+            $form_title,
+            $mapping
+        );
+
+        return $this->handle_success_request(
+            array( 'list' => FormFieldMapper::get_flat_list() )
+        );
+    }
+
+    /**
+     * Deletes a form's saved field mapping.
+     *
+     * @return array response data
+     */
+    public function delete_field_mapping() {
+        if ( ! current_user_can( 'manage_options' ) ) {
+            return $this->handle_unauthorized_request();
+        }
+        check_admin_referer(
+            FacebookPluginConfig::DELETE_FIELD_MAPPING_ACTION_NAME
+        );
+
+        $tracking_name = sanitize_text_field(
+            isset( $_POST['integration'] ) ?
+            wp_unslash( $_POST['integration'] ) : ''
+        );
+        $form_id       = sanitize_text_field(
+            isset( $_POST['form_id'] ) ?
+            wp_unslash( $_POST['form_id'] ) : ''
+        );
+        if ( '' === $tracking_name || '' === $form_id ) {
+            return $this->handle_invalid_request();
+        }
+
+        FormFieldMapper::delete_form_mapping( $tracking_name, $form_id );
+
+        return $this->handle_success_request(
+            array( 'list' => FormFieldMapper::get_flat_list() )
+        );
     }
 
     /**

--- a/core/class-facebookwordpresssettingsrecorder.php
+++ b/core/class-facebookwordpresssettingsrecorder.php
@@ -21,6 +21,26 @@ namespace FacebookPixelPlugin\Core;
 class FacebookWordpressSettingsRecorder {
 
     /**
+     * Mapper used for the form field mapping AJAX handlers.
+     *
+     * @var FormFieldMapper
+     */
+    private $field_mapper;
+
+    /**
+     * Constructor.
+     *
+     * @param FormFieldMapper|null $field_mapper Optional mapper. Defaults to a
+     *                                           WordPress option-backed mapper;
+     *                                           inject a fake in tests.
+     */
+    public function __construct( $field_mapper = null ) {
+        $this->field_mapper = $field_mapper instanceof FormFieldMapper
+            ? $field_mapper
+            : new FormFieldMapper();
+    }
+
+    /**
      * Registers ajax actions for saving FBE,
      * CAPI integration status, CAPI events filter
      * and CAPI PII caching status.
@@ -183,7 +203,7 @@ class FacebookWordpressSettingsRecorder {
         return $this->handle_success_request(
             array(
                 'fields'  => $class::get_form_fields( $form_id ),
-                'mapping' => FormFieldMapper::get_mappings(
+                'mapping' => $this->field_mapper->get_mappings(
                     $tracking_name,
                     $form_id
                 ),
@@ -245,7 +265,7 @@ class FacebookWordpressSettingsRecorder {
             $mapping[ $field_id ] = $standard;
         }
 
-        FormFieldMapper::save_form_mapping(
+        $this->field_mapper->save_form_mapping(
             $tracking_name,
             $form_id,
             $form_title,
@@ -253,7 +273,7 @@ class FacebookWordpressSettingsRecorder {
         );
 
         return $this->handle_success_request(
-            array( 'list' => FormFieldMapper::get_flat_list() )
+            array( 'list' => $this->field_mapper->get_flat_list() )
         );
     }
 
@@ -282,10 +302,10 @@ class FacebookWordpressSettingsRecorder {
             return $this->handle_invalid_request();
         }
 
-        FormFieldMapper::delete_form_mapping( $tracking_name, $form_id );
+        $this->field_mapper->delete_form_mapping( $tracking_name, $form_id );
 
         return $this->handle_success_request(
-            array( 'list' => FormFieldMapper::get_flat_list() )
+            array( 'list' => $this->field_mapper->get_flat_list() )
         );
     }
 


### PR DESCRIPTION
## Summary
Third diff in the field-mapping stack. Adds the admin-ajax endpoints the screen calls.

- `FacebookPluginConfig::get_field_mapping_integrations()` — shared helper mapping `tracking_name => integration class` for integrations that opt into mapping. Used to **safely resolve request input** to a class (no arbitrary class resolution).
- Four handlers on `FacebookWordpressSettingsRecorder`, all `manage_options` + `check_admin_referer`, reusing the existing success/invalid/unauthorized helpers:
  - `get_mapping_forms` — lists an integration's forms
  - `get_mapping_fields` — a form's fields **plus its saved mapping** (so the UI can load existing mappings to edit)
  - `save_field_mapping` — upserts a form's mapping (JSON `field_id => standard`), sanitized; invalid targets dropped by `FormFieldMapper`
  - `delete_field_mapping` — removes a form's mapping
- Save/delete return the refreshed flat list for the overview UI.

## Stack
1. core storage + resolver (#153)
2. form/field discovery (#154)
3. **AJAX recorder endpoints  ← this PR**
4. admin UI
5. consumption wiring

## Test plan
- `phpunit __tests__` → 273 passing (10 new): auth, validation, and success path of each handler.
- `phpcs` clean.