### PR TITLE
Form field mapping (4/5): admin UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,46 @@ https://www.facebook.com/business/help/881403525362441
 
 You can reference to integration/FacebookWordpressContactForm7.php and tests/FacebookWordpressContactForm7Test.php as an example
 
+# Form Field Mapping
+
+The plugin can map a form's fields to the standard Pixel / Conversions API
+fields used for matching (e.g. `email`, `first_name`, `phone`). Site admins
+configure this under **Settings → Meta → Form Field Mapping**: pick a supported
+form plugin, pick a form, then map each field to a standard field. A saved
+mapping takes priority over the plugin's automatic field detection; unmapped
+fields fall back to auto-detection. One mapping is stored per form.
+
+## Adding custom target fields (filter)
+
+The list of standard target fields shown in the mapping screen is extensible
+via the `facebook_pixel_form_mapping_target_fields` filter. It receives the
+fields grouped by section label (`field_key => label`) and must return the same
+shape. Use it to add, relabel, or remove target fields or whole groups:
+
+```php
+add_filter(
+    'facebook_pixel_form_mapping_target_fields',
+    function ( $groups ) {
+        // Relabel an existing field.
+        $groups['User Data']['email'] = 'Email address';
+
+        // Add a new group with a custom field.
+        $groups['Loyalty'] = array(
+            'loyalty_tier' => 'Loyalty Tier',
+        );
+
+        return $groups;
+    }
+);
+```
+
+Whatever the filter returns becomes both the options rendered in the UI and the
+set of keys accepted as valid mapping targets. A field whose key is one of the
+plugin's built-in standard keys (`email`, `first_name`, `value`, …) is
+forwarded to the Pixel / Conversions API event. A brand-new custom key will
+appear in the UI and be stored, but is only transmitted once the event pipeline
+(`ServerEventFactory`) is taught to handle it.
+
 # Testing
 
 There are two test suites:

--- a/core/class-facebookwordpresssettingspage.php
+++ b/core/class-facebookwordpresssettingspage.php
@@ -43,12 +43,25 @@ class FacebookWordpressSettingsPage {
     private $options_page = '';
 
     /**
+     * Mapper used to read stored form field mappings for the UI.
+     *
+     * @var FormFieldMapper
+     */
+    private $field_mapper;
+
+    /**
      * Registers the plugin's settings page, and adds the necessary hooks
      * for registering the plugin's scripts, notices, and menu items.
      *
-     * @param string $plugin_name the name of the plugin.
+     * @param string               $plugin_name  The name of the plugin.
+     * @param FormFieldMapper|null $field_mapper Optional mapper. Defaults to a
+     *                                           WordPress option-backed mapper.
      */
-    public function __construct( $plugin_name ) {
+    public function __construct( $plugin_name, $field_mapper = null ) {
+        $this->field_mapper = $field_mapper instanceof FormFieldMapper
+            ? $field_mapper
+            : new FormFieldMapper();
+
         add_filter(
             'plugin_action_links_' . $plugin_name,
             array( $this, 'add_settings_link' )
@@ -711,7 +724,7 @@ class FacebookWordpressSettingsPage {
             'integrations'    => $this->get_available_mapping_integrations(),
             'groupedFields'   =>
                 FormFieldMappingConfig::get_grouped_fields(),
-            'list'            => FormFieldMapper::get_flat_list(),
+            'list'            => $this->field_mapper->get_flat_list(),
             'saveError'       =>
                 FacebookPluginConfig::FIELD_MAPPING_SAVE_ERROR,
             'deleteError'     =>

--- a/core/class-facebookwordpresssettingspage.php
+++ b/core/class-facebookwordpresssettingspage.php
@@ -86,6 +86,13 @@ class FacebookWordpressSettingsPage {
             FacebookPluginConfig::PLUGIN_VERSION,
             false
         );
+        wp_register_script(
+            'meta_field_mapping_script',
+            plugins_url( '../js/field_mapping.js', __FILE__ ),
+            array( 'jquery' ),
+            FacebookPluginConfig::PLUGIN_VERSION,
+            true
+        );
         wp_register_style(
             'official-facebook-pixel',
             plugins_url( '../css/admin.css', __FILE__ ),
@@ -482,8 +489,18 @@ class FacebookWordpressSettingsPage {
 
         <?php
         $initial_script   = ob_get_clean();
+        $initial_script  .= $this->get_field_mapping_section();
         $access_token     = FacebookWordpressOptions::get_active_access_token();
         $has_access_token = ! empty( $access_token );
+
+        wp_enqueue_script( 'meta_field_mapping_script' );
+        wp_add_inline_script(
+            'meta_field_mapping_script',
+            'const meta_field_mapping_params = ' . wp_json_encode(
+                $this->get_field_mapping_params()
+            ) . ';',
+            'before'
+        );
 
         wp_enqueue_script( 'meta_settings_page_script' );
 
@@ -626,6 +643,169 @@ class FacebookWordpressSettingsPage {
             '_wpnonce' => $nonce_value,
         );
         return add_query_arg( $args, $simple_url );
+    }
+
+    /**
+     * Builds an admin-ajax URL for a field mapping action with a nonce.
+     *
+     * @param string $action_name The AJAX action name (also the nonce action).
+     * @return string The URL with action and nonce query args.
+     */
+    private function get_field_mapping_ajax_url( $action_name ) {
+        return add_query_arg(
+            array(
+                'action'   => $action_name,
+                '_wpnonce' => wp_create_nonce( $action_name ),
+            ),
+            admin_url( 'admin-ajax.php' )
+        );
+    }
+
+    /**
+     * Returns the integrations available for field mapping as
+     * tracking_name => human label (only active form plugins).
+     *
+     * @return array<string,string>
+     */
+    private function get_available_mapping_integrations() {
+        $integrations = array();
+        foreach (
+            FacebookPluginConfig::get_field_mapping_integrations()
+            as $tracking_name => $fqcn
+        ) {
+            if ( ! $fqcn::is_available() ) {
+                continue;
+            }
+            $integrations[ $tracking_name ] = $fqcn::get_integration_label();
+        }
+        return $integrations;
+    }
+
+    /**
+     * Builds the JS parameters for the field mapping screen.
+     *
+     * @return array The field mapping configuration parameters.
+     */
+    private function get_field_mapping_params() {
+        return array(
+            'getFormsUrl'     => $this->get_field_mapping_ajax_url(
+                FacebookPluginConfig::GET_MAPPING_FORMS_ACTION_NAME
+            ),
+            'getFormsAction'  =>
+                FacebookPluginConfig::GET_MAPPING_FORMS_ACTION_NAME,
+            'getFieldsUrl'    => $this->get_field_mapping_ajax_url(
+                FacebookPluginConfig::GET_MAPPING_FIELDS_ACTION_NAME
+            ),
+            'getFieldsAction' =>
+                FacebookPluginConfig::GET_MAPPING_FIELDS_ACTION_NAME,
+            'saveUrl'         => $this->get_field_mapping_ajax_url(
+                FacebookPluginConfig::SAVE_FIELD_MAPPING_ACTION_NAME
+            ),
+            'saveAction'      =>
+                FacebookPluginConfig::SAVE_FIELD_MAPPING_ACTION_NAME,
+            'deleteUrl'       => $this->get_field_mapping_ajax_url(
+                FacebookPluginConfig::DELETE_FIELD_MAPPING_ACTION_NAME
+            ),
+            'deleteAction'    =>
+                FacebookPluginConfig::DELETE_FIELD_MAPPING_ACTION_NAME,
+            'integrations'    => $this->get_available_mapping_integrations(),
+            'groupedFields'   =>
+                FormFieldMappingConfig::get_grouped_fields(),
+            'list'            => FormFieldMapper::get_flat_list(),
+            'saveError'       =>
+                FacebookPluginConfig::FIELD_MAPPING_SAVE_ERROR,
+            'deleteError'     =>
+                FacebookPluginConfig::FIELD_MAPPING_DELETE_ERROR,
+        );
+    }
+
+    /**
+     * Renders the Form Field Mapping admin section.
+     *
+     * Outputs an overview table of existing per-form mappings and an editor
+     * to create or modify a single form's mapping. Behavior is driven by
+     * js/field_mapping.js using the localized parameters.
+     *
+     * @return string The section HTML.
+     */
+    private function get_field_mapping_section() {
+        $integrations = $this->get_available_mapping_integrations();
+        ob_start();
+        ?>
+<div id="fb-field-mapping" class="fb-adv-conf">
+    <div class="fb-adv-conf-title">Form Field Mapping</div>
+    <div class="fb-capi-desc">
+        Map your form fields to standard fields used for Conversions API and
+        Pixel events. Saved mappings take priority over automatic detection.
+        Only one mapping is stored per form.
+    </div>
+
+        <?php if ( empty( $integrations ) ) : ?>
+    <p class="fb-mapping-empty">
+        No supported form plugins are currently active. Activate a supported
+        form plugin (Contact Form 7, WPForms, Ninja Forms, Formidable, or
+        Caldera) to configure field mappings.
+    </p>
+    <?php else : ?>
+    <h4>Configured Mappings</h4>
+    <table id="fb-mapping-list" class="widefat fb-mapping-list">
+        <thead>
+            <tr>
+                <th>Integration</th>
+                <th>Form</th>
+                <th>Mapped Fields</th>
+                <th>Actions</th>
+            </tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+
+    <h4 class="fb-mapping-editor-title">Add / Edit Mapping</h4>
+    <div id="fb-mapping-editor">
+        <div class="fb-mapping-row">
+            <label for="fb-mapping-integration">Form plugin</label>
+            <select id="fb-mapping-integration">
+                <option value="">Select a form plugin</option>
+                <?php foreach ( $integrations as $tracking => $label ) : ?>
+                <option value="<?php echo esc_attr( $tracking ); ?>">
+                    <?php echo esc_html( $label ); ?>
+                </option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="fb-mapping-row">
+            <label for="fb-mapping-form">Form</label>
+            <select id="fb-mapping-form" disabled>
+                <option value="">Select a form</option>
+            </select>
+        </div>
+
+        <table id="fb-mapping-fields" class="widefat fb-mapping-fields hidden">
+            <thead>
+                <tr>
+                    <th>Form Field</th>
+                    <th>Type</th>
+                    <th>Standard Field</th>
+                </tr>
+            </thead>
+            <tbody></tbody>
+        </table>
+
+        <p id="fb-mapping-no-fields" class="hidden">
+            This form has no mappable fields.
+        </p>
+
+        <div class="fb-mapping-actions">
+            <button id="fb-mapping-save" class="button button-primary hidden">
+                Save Mapping
+            </button>
+            <span id="fb-mapping-status" class="fb-capi-se"></span>
+        </div>
+    </div>
+    <?php endif; ?>
+</div>
+        <?php
+        return ob_get_clean();
     }
 
     /**

--- a/core/class-facebookwordpresssettingspage.php
+++ b/core/class-facebookwordpresssettingspage.php
@@ -50,17 +50,35 @@ class FacebookWordpressSettingsPage {
     private $field_mapper;
 
     /**
+     * Registry of standard target fields used to render the mapping UI.
+     *
+     * @var FormFieldMappingConfig
+     */
+    private $field_config;
+
+    /**
      * Registers the plugin's settings page, and adds the necessary hooks
      * for registering the plugin's scripts, notices, and menu items.
      *
-     * @param string               $plugin_name  The name of the plugin.
-     * @param FormFieldMapper|null $field_mapper Optional mapper. Defaults to a
-     *                                           WordPress option-backed mapper.
+     * @param string                      $plugin_name  The name of the plugin.
+     * @param FormFieldMapper|null        $field_mapper Optional mapper.
+     *                                                  Defaults to a WordPress
+     *                                                  option-backed mapper.
+     * @param FormFieldMappingConfig|null $field_config Optional target-field
+     *                                                  registry. Defaults to
+     *                                                  the standard registry.
      */
-    public function __construct( $plugin_name, $field_mapper = null ) {
+    public function __construct(
+        $plugin_name,
+        $field_mapper = null,
+        $field_config = null
+    ) {
         $this->field_mapper = $field_mapper instanceof FormFieldMapper
             ? $field_mapper
             : new FormFieldMapper();
+        $this->field_config = $field_config instanceof FormFieldMappingConfig
+            ? $field_config
+            : new FormFieldMappingConfig();
 
         add_filter(
             'plugin_action_links_' . $plugin_name,
@@ -723,7 +741,7 @@ class FacebookWordpressSettingsPage {
                 FacebookPluginConfig::DELETE_FIELD_MAPPING_ACTION_NAME,
             'integrations'    => $this->get_available_mapping_integrations(),
             'groupedFields'   =>
-                FormFieldMappingConfig::get_grouped_fields(),
+                $this->field_config->get_grouped_fields(),
             'list'            => $this->field_mapper->get_flat_list(),
             'saveError'       =>
                 FacebookPluginConfig::FIELD_MAPPING_SAVE_ERROR,

--- a/css/admin.css
+++ b/css/admin.css
@@ -1140,3 +1140,62 @@
     margin: 0px 10px 10px 0px;
   }
 }
+
+/* Form Field Mapping section */
+#fb-field-mapping {
+  margin: 10px 10px 20px 0;
+  padding: 16px;
+}
+
+#fb-field-mapping h4 {
+  margin: 18px 0 8px;
+}
+
+.fb-mapping-list,
+.fb-mapping-fields {
+  margin-bottom: 12px;
+  max-width: 760px;
+}
+
+.fb-mapping-list th,
+.fb-mapping-fields th {
+  text-align: left;
+}
+
+.fb-mapping-row {
+  margin-bottom: 12px;
+  max-width: 760px;
+}
+
+.fb-mapping-row label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 4px;
+}
+
+.fb-mapping-row select,
+.fb-mapping-target {
+  min-width: 280px;
+  max-width: 100%;
+}
+
+.fb-mapping-actions {
+  margin-top: 12px;
+}
+
+#fb-mapping-status {
+  margin-left: 10px;
+}
+
+.fb-mapping-edit,
+.fb-mapping-delete {
+  text-decoration: none;
+}
+
+.fb-mapping-empty {
+  font-style: italic;
+}
+
+#fb-field-mapping .hidden {
+  display: none;
+}

--- a/js/field_mapping.js
+++ b/js/field_mapping.js
@@ -1,0 +1,321 @@
+/**
+ * Copyright (C) 2017-present, Meta, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * Drives the admin Form Field Mapping screen: lists existing per-form
+ * mappings and provides an editor to create or modify a single form's
+ * mapping. All persistence goes through admin-ajax endpoints whose URLs
+ * (with nonces) and action names are provided in meta_field_mapping_params.
+ */
+(function ($) {
+    "use strict";
+
+    if (typeof meta_field_mapping_params === "undefined") {
+        return;
+    }
+
+    var params = meta_field_mapping_params;
+
+    var $integration = $("#fb-mapping-integration");
+    var $form = $("#fb-mapping-form");
+    var $fieldsTable = $("#fb-mapping-fields");
+    var $fieldsBody = $fieldsTable.find("tbody");
+    var $noFields = $("#fb-mapping-no-fields");
+    var $saveButton = $("#fb-mapping-save");
+    var $status = $("#fb-mapping-status");
+    var $listBody = $("#fb-mapping-list").find("tbody");
+
+    function escapeHtml(value) {
+        return $("<div>").text(value == null ? "" : value).html();
+    }
+
+    function showStatus(message, isError) {
+        $status
+            .text(message)
+            .css("color", isError ? "#d63638" : "#008a20")
+            .stop(true, true)
+            .show()
+            .delay(3000)
+            .fadeOut();
+    }
+
+    function integrationLabel(trackingName) {
+        return params.integrations[trackingName] || trackingName;
+    }
+
+    // Builds the "Standard Field" <select> for a single form field row.
+    function buildTargetSelect(selected) {
+        var $select = $("<select>").addClass("fb-mapping-target");
+        $select.append(
+            $("<option>").val("").text("— Do not map —")
+        );
+        $.each(params.groupedFields, function (groupLabel, fields) {
+            var $group = $("<optgroup>").attr("label", groupLabel);
+            $.each(fields, function (key, label) {
+                var $option = $("<option>").val(key).text(label);
+                if (key === selected) {
+                    $option.prop("selected", true);
+                }
+                $group.append($option);
+            });
+            $select.append($group);
+        });
+        return $select;
+    }
+
+    // Renders the overview table of all stored mappings.
+    function renderList(list) {
+        $listBody.empty();
+        if (!list || list.length === 0) {
+            $listBody.append(
+                $("<tr>").append(
+                    $("<td colspan='4'>").text("No mappings configured yet.")
+                )
+            );
+            return;
+        }
+        $.each(list, function (i, row) {
+            var $actions = $("<td>");
+            $("<a href='#'>")
+                .addClass("fb-mapping-edit")
+                .text("Edit")
+                .data("integration", row.tracking_name)
+                .data("form_id", row.form_id)
+                .appendTo($actions);
+            $actions.append(document.createTextNode(" | "));
+            $("<a href='#'>")
+                .addClass("fb-mapping-delete")
+                .text("Delete")
+                .data("integration", row.tracking_name)
+                .data("form_id", row.form_id)
+                .appendTo($actions);
+
+            $("<tr>")
+                .append(
+                    $("<td>").text(integrationLabel(row.tracking_name))
+                )
+                .append($("<td>").text(row.form_title || row.form_id))
+                .append($("<td>").text(row.mapped_count))
+                .append($actions)
+                .appendTo($listBody);
+        });
+    }
+
+    function resetFields() {
+        $fieldsBody.empty();
+        $fieldsTable.addClass("hidden");
+        $noFields.addClass("hidden");
+        $saveButton.addClass("hidden");
+    }
+
+    // Renders one row per form field, preselecting any saved target.
+    function renderFields(fields, mapping) {
+        $fieldsBody.empty();
+        mapping = mapping || {};
+
+        if (!fields || fields.length === 0) {
+            $fieldsTable.addClass("hidden");
+            $noFields.removeClass("hidden");
+            $saveButton.addClass("hidden");
+            return;
+        }
+
+        $.each(fields, function (i, field) {
+            var $target = buildTargetSelect(mapping[field.id] || "");
+            $target.data("field_id", field.id);
+            $("<tr>")
+                .append($("<td>").text(field.label || field.id))
+                .append($("<td>").text(field.type || ""))
+                .append($("<td>").append($target))
+                .appendTo($fieldsBody);
+        });
+
+        $fieldsTable.removeClass("hidden");
+        $noFields.addClass("hidden");
+        $saveButton.removeClass("hidden");
+    }
+
+    function populateForms(forms, selectedFormId) {
+        $form.empty().append($("<option>").val("").text("Select a form"));
+        $.each(forms || [], function (i, form) {
+            var $option = $("<option>").val(form.id).text(
+                form.title || form.id
+            );
+            if (selectedFormId && String(form.id) === String(selectedFormId)) {
+                $option.prop("selected", true);
+            }
+            $form.append($option);
+        });
+        $form.prop("disabled", false);
+    }
+
+    function loadForms(integration, selectedFormId, onLoaded) {
+        $.ajax({
+            type: "post",
+            dataType: "json",
+            url: params.getFormsUrl,
+            data: { action: params.getFormsAction, integration: integration }
+        })
+            .done(function (response) {
+                if (response && response.success && response.msg) {
+                    populateForms(response.msg.forms, selectedFormId);
+                    if (onLoaded) {
+                        onLoaded();
+                    }
+                }
+            })
+            .fail(function () {
+                showStatus(params.saveError, true);
+            });
+    }
+
+    function loadFields(integration, formId) {
+        $.ajax({
+            type: "post",
+            dataType: "json",
+            url: params.getFieldsUrl,
+            data: {
+                action: params.getFieldsAction,
+                integration: integration,
+                form_id: formId
+            }
+        })
+            .done(function (response) {
+                if (response && response.success && response.msg) {
+                    renderFields(response.msg.fields, response.msg.mapping);
+                }
+            })
+            .fail(function () {
+                showStatus(params.saveError, true);
+            });
+    }
+
+    function collectMapping() {
+        var mapping = {};
+        $fieldsBody.find(".fb-mapping-target").each(function () {
+            var value = $(this).val();
+            if (value) {
+                mapping[$(this).data("field_id")] = value;
+            }
+        });
+        return mapping;
+    }
+
+    function saveMapping() {
+        var integration = $integration.val();
+        var formId = $form.val();
+        if (!integration || !formId) {
+            return;
+        }
+        var formTitle = $form.find("option:selected").text().trim();
+
+        $.ajax({
+            type: "post",
+            dataType: "json",
+            url: params.saveUrl,
+            data: {
+                action: params.saveAction,
+                integration: integration,
+                form_id: formId,
+                form_title: formTitle,
+                mapping: JSON.stringify(collectMapping())
+            }
+        })
+            .done(function (response) {
+                if (response && response.success && response.msg) {
+                    renderList(response.msg.list);
+                    showStatus("Mapping saved.", false);
+                } else {
+                    showStatus(params.saveError, true);
+                }
+            })
+            .fail(function () {
+                showStatus(params.saveError, true);
+            });
+    }
+
+    function deleteMapping(integration, formId) {
+        $.ajax({
+            type: "post",
+            dataType: "json",
+            url: params.deleteUrl,
+            data: {
+                action: params.deleteAction,
+                integration: integration,
+                form_id: formId
+            }
+        })
+            .done(function (response) {
+                if (response && response.success && response.msg) {
+                    renderList(response.msg.list);
+                    showStatus("Mapping deleted.", false);
+                } else {
+                    showStatus(params.deleteError, true);
+                }
+            })
+            .fail(function () {
+                showStatus(params.deleteError, true);
+            });
+    }
+
+    $integration.on("change", function () {
+        var integration = $(this).val();
+        resetFields();
+        $form.empty()
+            .append($("<option>").val("").text("Select a form"))
+            .prop("disabled", true);
+        if (integration) {
+            loadForms(integration, null, null);
+        }
+    });
+
+    $form.on("change", function () {
+        var integration = $integration.val();
+        var formId = $(this).val();
+        resetFields();
+        if (integration && formId) {
+            loadFields(integration, formId);
+        }
+    });
+
+    $saveButton.on("click", function (e) {
+        e.preventDefault();
+        saveMapping();
+    });
+
+    $listBody.on("click", ".fb-mapping-edit", function (e) {
+        e.preventDefault();
+        var integration = $(this).data("integration");
+        var formId = String($(this).data("form_id"));
+        $integration.val(integration);
+        resetFields();
+        loadForms(integration, formId, function () {
+            loadFields(integration, formId);
+        });
+        $("html, body").animate(
+            { scrollTop: $("#fb-mapping-editor").offset().top - 40 },
+            300
+        );
+    });
+
+    $listBody.on("click", ".fb-mapping-delete", function (e) {
+        e.preventDefault();
+        if (!window.confirm("Delete this form's field mapping?")) {
+            return;
+        }
+        deleteMapping(
+            $(this).data("integration"),
+            String($(this).data("form_id"))
+        );
+    });
+
+    // Initial render of the overview table.
+    renderList(params.list);
+})(window.jQuery);


### PR DESCRIPTION
## Summary
Fourth diff in the field-mapping stack. Adds the admin screen on the plugin Settings page.

**Two parts**, exactly as requested:
- **Configured Mappings** overview table — every saved per-form mapping (Integration · Form · # fields mapped) with **Edit** and **Delete**. Edit loads that form into the editor prefilled; Delete removes it. The list refreshes after save/delete.
- **Add / Edit Mapping** editor — pick a form plugin → pick a form (loaded via AJAX) → a row per form field with a "Standard Field" dropdown (grouped User Data / Custom Data, default "— Do not map —", pre-selected from the saved mapping) → **Save Mapping**. One mapping per form (re-saving upserts).

Implementation:
- `FacebookWordpressSettingsPage` renders the section, registers/enqueues `field_mapping.js`, builds nonce-protected route URLs, and localizes params (routes, available integrations, grouped target fields, current list, error strings).
- `js/field_mapping.js` drives load/edit/save/delete and list rendering.
- `css/admin.css` styling.
- Shows guidance when no supported form plugin is active.

## Stack
1. core storage + resolver (#153)
2. form/field discovery (#154)
3. AJAX recorder endpoints (#155)
4. **admin UI  ← this PR**
5. consumption wiring

## Test plan
- `phpunit __tests__` → 273 passing (existing settings-page test still green).
- `phpcs` clean; `node --check` clean on the new JS.
- Manual: with a supported form plugin active, the section lists/edits/saves/deletes mappings.