### PR TITLE
Form field mapping (5/5): consume mappings in readFormData()

### DIFF
--- a/__tests__/integration/FacebookWordpressFormidableFormTest.php
+++ b/__tests__/integration/FacebookWordpressFormidableFormTest.php
@@ -91,6 +91,12 @@ final class FacebookWordpressFormidableFormTest
         )
     );
 
+    // No field mapping configured for this form.
+    \WP_Mock::userFunction(
+        'get_option',
+        array( 'return' => array() )
+    );
+
     $mock_entry_id = 1;
     $mock_form_id = 1;
 

--- a/__tests__/integration/FormFieldConsumptionTest.php
+++ b/__tests__/integration/FormFieldConsumptionTest.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Facebook Pixel Plugin FormFieldConsumptionTest class.
+ *
+ * Verifies that saved field mappings override the heuristic extraction in
+ * each integration's readFormData(), falling back to heuristics when a
+ * standard field is not mapped.
+ *
+ * @package FacebookPixelPlugin
+ */
+
+/*
+* Copyright (C) 2017-present, Meta, Inc.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; version 2 of the License.
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*/
+
+namespace FacebookPixelPlugin\Tests\Integration;
+
+use FacebookPixelPlugin\Integration\FacebookWordpressContactForm7;
+use FacebookPixelPlugin\Integration\FacebookWordpressCalderaForm;
+use FacebookPixelPlugin\Tests\Mocks\MockContactForm7Tag;
+use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
+
+/**
+ * Minimal Contact Form 7 form double exposing id() and scan_form_tags() as
+ * real methods (so method_exists() works in the integration).
+ */
+class MappingTestCF7Form {
+    /**
+     * Form id.
+     *
+     * @var string
+     */
+    public $form_id;
+
+    /**
+     * Form tags.
+     *
+     * @var array
+     */
+    public $tags = array();
+
+    /**
+     * @return string The form id.
+     */
+    public function id() {
+        return $this->form_id;
+    }
+
+    /**
+     * @return array The form tags.
+     */
+    public function scan_form_tags() {
+        return $this->tags;
+    }
+}
+
+/**
+ * FormFieldConsumptionTest class.
+ *
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+final class FormFieldConsumptionTest extends FacebookWordpressTestBase {
+
+    /**
+     * Mocks sanitize_text_field and the mapping store.
+     *
+     * @param array $store The mapping store returned by get_option.
+     * @return void
+     */
+    private function mockEnv( $store ) {
+        \WP_Mock::userFunction(
+            'sanitize_text_field',
+            array(
+                'return' => function ( $v ) {
+                    return $v;
+                },
+            )
+        );
+        \WP_Mock::userFunction(
+            'get_option',
+            array( 'return' => $store )
+        );
+    }
+
+    /**
+     * A mapped field overrides the heuristic; unmapped fields fall back.
+     *
+     * @return void
+     */
+    public function testContactForm7MappingOverridesHeuristic() {
+        $this->mockEnv(
+            array(
+                'contact-form-7' => array(
+                    '99' => array(
+                        'form_title' => 'wform1',
+                        'mappings'   => array( 'custom_fn' => 'first_name' ),
+                    ),
+                ),
+            )
+        );
+
+        $_POST['your-email'] = 'heur@example.com';
+        $_POST['your-name']  = 'Heur Last';
+        $_POST['custom_fn']  = 'Mapped';
+
+        $form          = new MappingTestCF7Form();
+        $form->form_id = '99';
+        $form->tags    = array(
+            new MockContactForm7Tag( 'email', 'your-email' ),
+            new MockContactForm7Tag( 'text', 'your-name' ),
+            new MockContactForm7Tag( 'text', 'custom_fn' ),
+        );
+
+        $data = FacebookWordpressContactForm7::readFormData( $form );
+
+        // Mapping wins for first_name.
+        $this->assertEquals( 'Mapped', $data['first_name'] );
+        // Heuristics still supply email and last_name.
+        $this->assertEquals( 'heur@example.com', $data['email'] );
+        $this->assertEquals( 'Last', $data['last_name'] );
+    }
+
+    /**
+     * With no mapping stored, behavior is unchanged (pure heuristics).
+     *
+     * @return void
+     */
+    public function testContactForm7NoMappingFallsBack() {
+        $this->mockEnv( array() );
+
+        $_POST['your-email'] = 'heur@example.com';
+        $_POST['your-name']  = 'Heur Last';
+
+        $form          = new MappingTestCF7Form();
+        $form->form_id = '99';
+        $form->tags    = array(
+            new MockContactForm7Tag( 'email', 'your-email' ),
+            new MockContactForm7Tag( 'text', 'your-name' ),
+        );
+
+        $data = FacebookWordpressContactForm7::readFormData( $form );
+
+        $this->assertEquals( 'heur@example.com', $data['email'] );
+        $this->assertEquals( 'Heur', $data['first_name'] );
+        $this->assertEquals( 'Last', $data['last_name'] );
+    }
+
+    /**
+     * A full_name mapping splits into first and last name.
+     *
+     * @return void
+     */
+    public function testContactForm7FullNameMappingSplits() {
+        $this->mockEnv(
+            array(
+                'contact-form-7' => array(
+                    '99' => array(
+                        'form_title' => 'wform1',
+                        'mappings'   => array( 'fullname' => 'full_name' ),
+                    ),
+                ),
+            )
+        );
+
+        $_POST['fullname'] = 'Ada Lovelace';
+
+        $form          = new MappingTestCF7Form();
+        $form->form_id = '99';
+        $form->tags    = array(
+            new MockContactForm7Tag( 'text', 'fullname' ),
+        );
+
+        $data = FacebookWordpressContactForm7::readFormData( $form );
+
+        $this->assertEquals( 'Ada', $data['first_name'] );
+        $this->assertEquals( 'Lovelace', $data['last_name'] );
+    }
+
+    /**
+     * Caldera mapping overrides heuristics (value read from $_POST by ID).
+     *
+     * @return void
+     */
+    public function testCalderaMappingOverridesHeuristic() {
+        $this->mockEnv(
+            array(
+                'caldera-forms' => array(
+                    'cf1' => array(
+                        'form_title' => 'Contact',
+                        'mappings'   => array( 'fld_custom' => 'last_name' ),
+                    ),
+                ),
+            )
+        );
+
+        $_POST['fld_email']  = 'c@d.com';
+        $_POST['fld_custom'] = 'Zed';
+
+        $form = array(
+            'ID'     => 'cf1',
+            'fields' => array(
+                array( 'ID' => 'fld_email', 'type' => 'email' ),
+                array( 'ID' => 'fld_custom', 'type' => 'text' ),
+            ),
+        );
+
+        $data = FacebookWordpressCalderaForm::readFormData( $form );
+
+        $this->assertEquals( 'c@d.com', $data['email'] );
+        $this->assertEquals( 'Zed', $data['last_name'] );
+    }
+}

--- a/integration/class-facebookwordpresscalderaform.php
+++ b/integration/class-facebookwordpresscalderaform.php
@@ -32,6 +32,7 @@ defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 use FacebookPixelPlugin\Core\FacebookPluginUtils;
 use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 use FacebookPixelPlugin\Core\FacebookWordPressOptions;
+use FacebookPixelPlugin\Core\FormFieldMapper;
 use FacebookPixelPlugin\Core\ServerEventFactory;
 use FacebookPixelPlugin\Core\PixelRenderer;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
@@ -206,13 +207,48 @@ class FacebookWordpressCalderaForm extends FacebookWordpressFormIntegrationBase 
         if ( empty( $form ) ) {
             return array();
         }
-        return array(
+        $data = array(
             'email'      => self::getEmail( $form ),
             'first_name' => self::getFirstName( $form ),
             'last_name'  => self::getLastName( $form ),
             'phone'      => self::getPhone( $form ),
             'state'      => self::getState( $form ),
         );
+
+        $form_id = isset( $form['ID'] ) ? (string) $form['ID'] : '';
+
+        return self::applyFieldMapping( $form_id, $data );
+    }
+
+    /**
+     * Merges any saved field mapping for the form over the heuristic data.
+     *
+     * Mapped values (read from $_POST by Caldera field ID) take priority;
+     * unmapped standard fields fall back to the auto-detected values.
+     *
+     * @param string $form_id The Caldera form id.
+     * @param array  $data     The heuristically extracted data.
+     * @return array The merged data.
+     */
+    private static function applyFieldMapping( $form_id, $data ) {
+        if ( '' === $form_id ) {
+            return $data;
+        }
+
+        $mapped = FormFieldMapper::resolve(
+            self::TRACKING_NAME,
+            $form_id,
+            function ( $field_id ) {
+                if ( ! isset( $_POST[ $field_id ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+                    return null;
+                }
+                return sanitize_text_field(
+                    wp_unslash( $_POST[ $field_id ] ) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+                );
+            }
+        );
+
+        return array_merge( $data, $mapped );
     }
 
     /**

--- a/integration/class-facebookwordpresscalderaform.php
+++ b/integration/class-facebookwordpresscalderaform.php
@@ -235,7 +235,7 @@ class FacebookWordpressCalderaForm extends FacebookWordpressFormIntegrationBase 
             return $data;
         }
 
-        $mapped = FormFieldMapper::resolve(
+        $mapped = ( new FormFieldMapper() )->resolve(
             self::TRACKING_NAME,
             $form_id,
             function ( $field_id ) {

--- a/integration/class-facebookwordpresscontactform7.php
+++ b/integration/class-facebookwordpresscontactform7.php
@@ -293,7 +293,7 @@ class FacebookWordpressContactForm7 extends FacebookWordpressFormIntegrationBase
             return $data;
         }
 
-        $mapped = FormFieldMapper::resolve(
+        $mapped = ( new FormFieldMapper() )->resolve(
             self::TRACKING_NAME,
             $form_id,
             function ( $field_id ) {

--- a/integration/class-facebookwordpresscontactform7.php
+++ b/integration/class-facebookwordpresscontactform7.php
@@ -32,6 +32,7 @@ defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 use FacebookPixelPlugin\Core\FacebookPluginUtils;
 use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 use FacebookPixelPlugin\Core\FacebookWordPressOptions;
+use FacebookPixelPlugin\Core\FormFieldMapper;
 use FacebookPixelPlugin\Core\ServerEventFactory;
 use FacebookPixelPlugin\Core\PixelRenderer;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
@@ -265,12 +266,47 @@ class FacebookWordpressContactForm7 extends FacebookWordpressFormIntegrationBase
         $form_tags = $form->scan_form_tags();
         $name      = self::getName( $form_tags );
 
-        return array(
+        $data = array(
             'email'      => self::getEmail( $form_tags ),
             'first_name' => $name[0],
             'last_name'  => $name[1],
             'phone'      => self::getPhone( $form_tags ),
         );
+
+        $form_id = method_exists( $form, 'id' ) ? (string) $form->id() : '';
+
+        return self::applyFieldMapping( $form_id, $data );
+    }
+
+    /**
+     * Merges any saved field mapping for the form over the heuristic data.
+     *
+     * Mapped values (read from $_POST by tag name) take priority; unmapped
+     * standard fields fall back to the auto-detected values.
+     *
+     * @param string $form_id The Contact Form 7 form id.
+     * @param array  $data     The heuristically extracted data.
+     * @return array The merged data.
+     */
+    private static function applyFieldMapping( $form_id, $data ) {
+        if ( '' === $form_id ) {
+            return $data;
+        }
+
+        $mapped = FormFieldMapper::resolve(
+            self::TRACKING_NAME,
+            $form_id,
+            function ( $field_id ) {
+                if ( ! isset( $_POST[ $field_id ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+                    return null;
+                }
+                return sanitize_text_field(
+                    wp_unslash( $_POST[ $field_id ] ) // phpcs:ignore WordPress.Security.NonceVerification.Missing
+                );
+            }
+        );
+
+        return array_merge( $data, $mapped );
     }
 
     /**

--- a/integration/class-facebookwordpressformidableform.php
+++ b/integration/class-facebookwordpressformidableform.php
@@ -33,6 +33,7 @@ use FacebookPixelPlugin\Core\FacebookPixel;
 use FacebookPixelPlugin\Core\FacebookPluginUtils;
 use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 use FacebookPixelPlugin\Core\FacebookWordPressOptions;
+use FacebookPixelPlugin\Core\FormFieldMapper;
 use FacebookPixelPlugin\Core\ServerEventFactory;
 use FacebookPixelPlugin\Core\PixelRenderer;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
@@ -157,7 +158,7 @@ class FacebookWordpressFormidableForm extends FacebookWordpressFormIntegrationBa
         $server_event = ServerEventFactory::safe_create_event(
             'Lead',
             array( __CLASS__, 'readFormData' ),
-            array( $entry_id ),
+            array( $entry_id, $form_id ),
             self::TRACKING_NAME,
             true
         );
@@ -209,12 +210,13 @@ class FacebookWordpressFormidableForm extends FacebookWordpressFormIntegrationBa
      * last name, and phone, and combines this information with address data.
      *
      * @param int $entry_id The ID of the form entry.
+     * @param int $form_id  The ID of the form (used for field mapping).
      * @return array An associative array containing user and
      *               address information,
      *               or an empty array if the entry ID is
      *               empty or no data is found.
      */
-    public static function readFormData( $entry_id ) {
+    public static function readFormData( $entry_id, $form_id = null ) {
     if ( empty( $entry_id ) ) {
         return array();
     }
@@ -231,10 +233,60 @@ class FacebookWordpressFormidableForm extends FacebookWordpressFormIntegrationBa
                 'phone'      => self::getPhone( $field_values ),
             );
             $address_data = self::getAddressInformation( $field_values );
-            return array_merge( $user_data, $address_data );
+            $data         = array_merge( $user_data, $address_data );
+
+            return self::applyFieldMapping(
+                $form_id,
+                $field_values,
+                $data
+            );
         }
 
         return array();
+    }
+
+    /**
+     * Merges any saved field mapping for the form over the heuristic data.
+     *
+     * Mapped values (looked up by field id in the entry field values) take
+     * priority; unmapped standard fields fall back to the auto-detected ones.
+     * Only scalar saved values are used.
+     *
+     * @param int|string $form_id      The Formidable form id.
+     * @param array      $field_values The entry field value objects.
+     * @param array      $data          The heuristically extracted data.
+     * @return array The merged data.
+     */
+    private static function applyFieldMapping(
+        $form_id,
+        $field_values,
+        $data
+    ) {
+        $form_id = (string) $form_id;
+        if ( '' === $form_id ) {
+            return $data;
+        }
+
+        $values = array();
+        foreach ( $field_values as $field_value ) {
+            $field = $field_value->get_field();
+            if ( isset( $field->id ) ) {
+                $values[ (string) $field->id ] =
+                    $field_value->get_saved_value();
+            }
+        }
+
+        $mapped = FormFieldMapper::resolve(
+            self::TRACKING_NAME,
+            $form_id,
+            function ( $field_id ) use ( $values ) {
+                $value = isset( $values[ $field_id ] )
+                    ? $values[ $field_id ] : null;
+                return is_scalar( $value ) ? $value : null;
+            }
+        );
+
+        return array_merge( $data, $mapped );
     }
 
     /**

--- a/integration/class-facebookwordpressformidableform.php
+++ b/integration/class-facebookwordpressformidableform.php
@@ -276,7 +276,7 @@ class FacebookWordpressFormidableForm extends FacebookWordpressFormIntegrationBa
             }
         }
 
-        $mapped = FormFieldMapper::resolve(
+        $mapped = ( new FormFieldMapper() )->resolve(
             self::TRACKING_NAME,
             $form_id,
             function ( $field_id ) use ( $values ) {

--- a/integration/class-facebookwordpressninjaforms.php
+++ b/integration/class-facebookwordpressninjaforms.php
@@ -33,6 +33,7 @@ use FacebookPixelPlugin\Core\FacebookPixel;
 use FacebookPixelPlugin\Core\FacebookPluginUtils;
 use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 use FacebookPixelPlugin\Core\FacebookWordPressOptions;
+use FacebookPixelPlugin\Core\FormFieldMapper;
 use FacebookPixelPlugin\Core\ServerEventFactory;
 use FacebookPixelPlugin\Core\PixelRenderer;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
@@ -312,7 +313,46 @@ class FacebookWordpressNinjaForms extends FacebookWordpressFormIntegrationBase {
         $event_data['country'] = self::getCountry( $form_data );
         $event_data['gender']  = self::getGender( $form_data );
 
-        return $event_data;
+        $form_id = isset( $form_data['id'] ) ? (string) $form_data['id'] : '';
+
+        return self::applyFieldMapping( $form_id, $form_data, $event_data );
+    }
+
+    /**
+     * Merges any saved field mapping for the form over the heuristic data.
+     *
+     * Mapped values (looked up by field key in the submitted form data) take
+     * priority; unmapped standard fields fall back to the auto-detected ones.
+     *
+     * @param string $form_id   The Ninja Forms form id.
+     * @param array  $form_data The submitted form data.
+     * @param array  $data       The heuristically extracted data.
+     * @return array The merged data.
+     */
+    private static function applyFieldMapping( $form_id, $form_data, $data ) {
+        if ( '' === $form_id || empty( $form_data['fields'] ) ) {
+            return $data;
+        }
+
+        $values = array();
+        foreach ( $form_data['fields'] as $field ) {
+            if ( isset( $field['key'] ) ) {
+                $values[ $field['key'] ] = isset( $field['value'] )
+                    ? $field['value'] : null;
+            }
+        }
+
+        $mapped = FormFieldMapper::resolve(
+            self::TRACKING_NAME,
+            $form_id,
+            function ( $field_id ) use ( $values ) {
+                $value = isset( $values[ $field_id ] )
+                    ? $values[ $field_id ] : null;
+                return is_scalar( $value ) ? $value : null;
+            }
+        );
+
+        return array_merge( $data, $mapped );
     }
 
     /**

--- a/integration/class-facebookwordpressninjaforms.php
+++ b/integration/class-facebookwordpressninjaforms.php
@@ -342,7 +342,7 @@ class FacebookWordpressNinjaForms extends FacebookWordpressFormIntegrationBase {
             }
         }
 
-        $mapped = FormFieldMapper::resolve(
+        $mapped = ( new FormFieldMapper() )->resolve(
             self::TRACKING_NAME,
             $form_id,
             function ( $field_id ) use ( $values ) {

--- a/integration/class-facebookwordpresswpforms.php
+++ b/integration/class-facebookwordpresswpforms.php
@@ -357,7 +357,7 @@ class FacebookWordpressWPForms extends FacebookWordpressFormIntegrationBase {
         }
 
         $fields = $entry['fields'];
-        $mapped = FormFieldMapper::resolve(
+        $mapped = ( new FormFieldMapper() )->resolve(
             self::TRACKING_NAME,
             $form_id,
             function ( $field_id ) use ( $fields ) {

--- a/integration/class-facebookwordpresswpforms.php
+++ b/integration/class-facebookwordpresswpforms.php
@@ -33,6 +33,7 @@ use FacebookPixelPlugin\Core\FacebookPixel;
 use FacebookPixelPlugin\Core\FacebookPluginUtils;
 use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 use FacebookPixelPlugin\Core\FacebookWordPressOptions;
+use FacebookPixelPlugin\Core\FormFieldMapper;
 use FacebookPixelPlugin\Core\ServerEventFactory;
 use FacebookPixelPlugin\Core\PixelRenderer;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
@@ -332,7 +333,41 @@ class FacebookWordpressWPForms extends FacebookWordpressFormIntegrationBase {
             self::getAddress( $entry, $form_data )
         );
 
-        return $event_data;
+        $form_id = isset( $form_data['id'] ) ? (string) $form_data['id'] : '';
+
+        return self::applyFieldMapping( $form_id, $entry, $event_data );
+    }
+
+    /**
+     * Merges any saved field mapping for the form over the heuristic data.
+     *
+     * Mapped values (looked up by field id in the entry) take priority;
+     * unmapped standard fields fall back to the auto-detected values. Only
+     * scalar entry values are used (composite fields like Name/Address are
+     * left to the heuristics).
+     *
+     * @param string $form_id The WPForms form id.
+     * @param array  $entry    The submitted entry data.
+     * @param array  $data     The heuristically extracted data.
+     * @return array The merged data.
+     */
+    private static function applyFieldMapping( $form_id, $entry, $data ) {
+        if ( '' === $form_id || empty( $entry['fields'] ) ) {
+            return $data;
+        }
+
+        $fields = $entry['fields'];
+        $mapped = FormFieldMapper::resolve(
+            self::TRACKING_NAME,
+            $form_id,
+            function ( $field_id ) use ( $fields ) {
+                $value = isset( $fields[ $field_id ] )
+                    ? $fields[ $field_id ] : null;
+                return is_scalar( $value ) ? $value : null;
+            }
+        );
+
+        return array_merge( $data, $mapped );
     }
 
     /**


### PR DESCRIPTION
## Summary
Final diff in the field-mapping stack. Makes the saved mappings actually take effect at event time.

Each form-builder integration's `readFormData()` now resolves the saved mapping for the submitted form via `FormFieldMapper::resolve()` and merges it **over** the heuristic data — so a mapped field wins, and any unmapped standard field falls back to today's auto-detection (the "mapping first, heuristics fallback" behavior chosen up front).

Per-integration value source (matches the field ids surfaced by discovery in #154):
- **Contact Form 7 / Caldera** — value read from `$_POST` by native field id
- **Ninja Forms** — value looked up by field key in the submitted form data
- **WPForms** — value looked up by field id in the entry (scalar values only)
- **Formidable** — form id now threaded into `readFormData()`; value looked up by field id in entry field values (scalar values only)

Mapping resolution only runs when a form id is available, so behavior is unchanged when no mapping is configured.

## Stack
1. core storage + resolver (#153)
2. form/field discovery (#154)
3. AJAX recorder endpoints (#155)
4. admin UI (#156)
5. **consume mappings in readFormData()  ← this PR**

## Test plan
- `phpunit __tests__` → 277 passing (4 new consumption tests: override, fallback, full_name split, Caldera).
- One existing Formidable test gains a `get_option` stub now that it reaches the mapper; all others unaffected.
- `phpcs` clean.