### PR TITLE
Signals refactor (2/3): instance wiring + Contact Form 7 reference conversion

### DIFF
--- a/__tests__/core/FacebookWordpressPixelInjectionTest.php
+++ b/__tests__/core/FacebookWordpressPixelInjectionTest.php
@@ -85,11 +85,13 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
       array( $injection_obj, 'inject_pixel_noscript_code' )
     );
 
-    $spies = array();
+    // Integrations are now instantiated and inject_pixel_code() is called on
+    // the instance, so overload each class and expect the instance call.
     foreach ( self::$integrations as $index => $integration ) {
-      $spies[] = \Mockery::spy(
-        'alias:FacebookPixelPlugin\\Integration\\' . $integration
+      $mock = \Mockery::mock(
+        'overload:FacebookPixelPlugin\\Integration\\' . $integration
       );
+      $mock->shouldReceive( 'inject_pixel_code' )->once();
     }
 
     \WP_Mock::expectActionNotAdded(
@@ -106,9 +108,7 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
     FacebookWordpressOptions::initialize();
     $injection_obj->inject();
 
-    foreach ( $spies as $index => $spy ) {
-      $spy->shouldHaveReceived( 'inject_pixel_code' );
-    }
+    $this->assertConditionsMet();
   }
 
   /**

--- a/__tests__/core/SignalsDispatchTest.php
+++ b/__tests__/core/SignalsDispatchTest.php
@@ -3,7 +3,7 @@
  * Facebook Pixel Plugin SignalsDispatchTest class.
  *
  * Covers the event-dispatch additions to Signals (constructor injection,
- * render, and on() delegating browser delivery).
+ * pending-event flushing, and on() delegating browser delivery).
  *
  * @package FacebookPixelPlugin
  */
@@ -47,15 +47,37 @@ final class SignalsDispatchTest extends FacebookWordpressTestBase {
     }
 
     /**
-     * The injected server-event store is used and exposed.
+     * flush_pending_events sends the queued events from the injected store via
+     * the send_server_events action.
      *
      * @return void
      */
-    public function testInjectedServerEventStore() {
-        $store   = $this->createMock( FacebookServerSideEvent::class );
+    public function testFlushPendingEventsSendsQueuedEvents() {
+        $event = new \stdClass();
+        $store = $this->createMock( FacebookServerSideEvent::class );
+        $store->method( 'get_pending_events' )->willReturn( array( $event ) );
         $signals = new Signals( $store );
 
-        $this->assertSame( $store, $signals->get_server_events() );
+        \WP_Mock::expectAction( 'send_server_events', array( $event ), 1 );
+
+        $signals->flush_pending_events();
+
+        $this->assertConditionsMet();
+    }
+
+    /**
+     * flush_pending_events does nothing when the store has no queued events.
+     *
+     * @return void
+     */
+    public function testFlushPendingEventsNoopWhenEmpty() {
+        $store = $this->createMock( FacebookServerSideEvent::class );
+        $store->method( 'get_pending_events' )->willReturn( array() );
+        $signals = new Signals( $store );
+
+        $signals->flush_pending_events();
+
+        $this->assertConditionsMet();
     }
 
     /**

--- a/__tests__/integration/FacebookWordpressContactForm7Test.php
+++ b/__tests__/integration/FacebookWordpressContactForm7Test.php
@@ -20,9 +20,9 @@
 namespace FacebookPixelPlugin\Tests\Integration;
 
 use FacebookPixelPlugin\Core\Signals;
-use FacebookPixelPlugin\Core\EventData;
 use FacebookPixelPlugin\Core\EventDataBuilder;
 use FacebookPixelPlugin\Core\AjaxFilterDelivery;
+use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 use FacebookPixelPlugin\Integration\FacebookWordpressContactForm7;
 use FacebookPixelPlugin\Tests\Mocks\MockContactForm7;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
@@ -30,23 +30,56 @@ use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 /**
  * FacebookWordpressContactForm7Test class.
  *
+ * These tests assert the same observable behavior as before the Signals
+ * refactor: a successful Contact Form 7 submission ends up tracking a Lead
+ * server-side event carrying the correct user/custom data. The only change is
+ * the entry point — read_form_data plus the real Signals dispatch path instead
+ * of the old trackServerEvent static method.
+ *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
 final class FacebookWordpressContactForm7Test extends FacebookWordpressTestBase {
 
   /**
-   * Builds a CF7 integration with a mock Signals and a real builder.
+   * Builds a CF7 integration wired to a real Signals dispatcher, so a
+   * dispatched event actually tracks through FacebookServerSideEvent.
    *
-   * @return array [ FacebookWordpressContactForm7, Signals mock ]
+   * @return array [ FacebookWordpressContactForm7, Signals ]
    */
   private function makeIntegration() {
-    $signals     = $this->createMock( Signals::class );
+    $signals     = new Signals();
     $integration = new FacebookWordpressContactForm7(
       $signals,
       new EventDataBuilder()
     );
     return array( $integration, $signals );
+  }
+
+  /**
+   * Stubs the JSON/sanitize helpers the dispatch/render path relies on.
+   *
+   * @return void
+   */
+  private function mockRenderHelpers() {
+    \WP_Mock::userFunction(
+      'wp_json_encode',
+      array(
+        'args'   => array( \Mockery::type( 'array' ), \Mockery::type( 'int' ) ),
+        'return' => function ( $data, $options ) {
+          return json_encode( $data );
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
   }
 
   /**
@@ -56,7 +89,11 @@ final class FacebookWordpressContactForm7Test extends FacebookWordpressTestBase 
    * @return void
    */
   public function testInjectPixelCodeRegistersEventAndListener() {
-    list( $integration, $signals ) = $this->makeIntegration();
+    $signals     = $this->createMock( Signals::class );
+    $integration = new FacebookWordpressContactForm7(
+      $signals,
+      new EventDataBuilder()
+    );
 
     $signals->expects( $this->once() )
       ->method( 'on' )
@@ -83,51 +120,129 @@ final class FacebookWordpressContactForm7Test extends FacebookWordpressTestBase 
   }
 
   /**
-   * read_form_data extracts the standard fields into an EventData.
+   * A dispatched Lead tracks a Lead server event carrying the submitter's
+   * user data and the contact-form-7 tracking property — the same outcome the
+   * old trackServerEvent path asserted.
    *
    * @return void
    */
-  public function testReadFormDataReturnsEventData() {
-    \WP_Mock::userFunction(
-      'sanitize_text_field',
-      array(
-        'return' => function ( $input ) {
-          return $input;
-        },
-      )
-    );
+  public function testTrackServerEventWithoutInternalUser() {
+    self::mockIsInternalUser( false );
+    self::mockFacebookWordpressOptions();
+    $this->mockRenderHelpers();
 
-    list( $integration ) = $this->makeIntegration();
-    $form                = $this->createMockForm();
+    $_SERVER['HTTP_REFERER'] = 'TEST_REFERER';
 
+    list( $integration, $signals ) = $this->makeIntegration();
+
+    $form = $this->createMockForm();
     $data = $integration->read_form_data(
       $form,
       array( 'status' => 'mail_sent' )
     );
-
-    $this->assertInstanceOf( EventData::class, $data );
-    $this->assertEquals(
-      array(
-        'email'      => 'pika.chu@s2s.com',
-        'first_name' => 'Pika',
-        'last_name'  => 'Chu',
-        'phone'      => '12223334444',
-      ),
-      $data->to_array()
+    $signals->dispatch(
+      'Lead',
+      $data,
+      FacebookWordpressContactForm7::TRACKING_NAME
     );
+
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 1, $tracked_events );
+
+    $event = $tracked_events[0];
+    $this->assertEquals( 'Lead', $event->getEventName() );
+    $this->assertNotNull( $event->getEventTime() );
+    $this->assertEquals(
+      'pika.chu@s2s.com',
+      $event->getUserData()->getEmail()
+    );
+    $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
+    $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
+    $this->assertEquals( '12223334444', $event->getUserData()->getPhone() );
+    $this->assertEquals(
+      'contact-form-7',
+      $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
+    );
+    $this->assertEquals( 'TEST_REFERER', $event->getEventSourceUrl() );
   }
 
   /**
-   * read_form_data returns null (no dispatch) when the mail did not send.
+   * A dispatched Lead still tracks a Lead server event when the form carries
+   * no recognizable name/email/phone tags — mirrors the old
+   * "without form data" case.
    *
    * @return void
    */
-  public function testReadFormDataSkipsWhenNotMailSent() {
+  public function testTrackServerEventWithoutFormData() {
+    self::mockIsInternalUser( false );
+    self::mockFacebookWordpressOptions();
+    $this->mockRenderHelpers();
+
+    list( $integration, $signals ) = $this->makeIntegration();
+
+    $form = new MockContactForm7();
+    $data = $integration->read_form_data(
+      $form,
+      array( 'status' => 'mail_sent' )
+    );
+    $signals->dispatch(
+      'Lead',
+      $data,
+      FacebookWordpressContactForm7::TRACKING_NAME
+    );
+
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 1, $tracked_events );
+
+    $event = $tracked_events[0];
+    $this->assertEquals( 'Lead', $event->getEventName() );
+    $this->assertNotNull( $event->getEventTime() );
+  }
+
+  /**
+   * read_form_data returns null (nothing dispatched) when the mail did not
+   * send, for every non-success CF7 status.
+   *
+   * @return void
+   */
+  public function testReadFormDataSkipsWhenMailFails() {
+    self::mockIsInternalUser( false );
+    self::mockFacebookWordpressOptions();
+
+    $bad_statuses = array(
+      'validation_failed',
+      'acceptance_missing',
+      'spam',
+      'aborted',
+      'mail_failed',
+    );
+
     list( $integration ) = $this->makeIntegration();
     $form                = $this->createMockForm();
 
+    foreach ( $bad_statuses as $status ) {
+      $this->assertNull(
+        $integration->read_form_data( $form, array( 'status' => $status ) )
+      );
+    }
+
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 0, $tracked_events );
+  }
+
+  /**
+   * read_form_data returns null (nothing dispatched) when the form is empty.
+   *
+   * @return void
+   */
+  public function testReadFormDataSkipsWhenFormEmpty() {
+    list( $integration ) = $this->makeIntegration();
+
     $this->assertNull(
-      $integration->read_form_data( $form, array( 'status' => 'spam' ) )
+      $integration->read_form_data( null, array( 'status' => 'mail_sent' ) )
     );
   }
 

--- a/__tests__/integration/FacebookWordpressContactForm7Test.php
+++ b/__tests__/integration/FacebookWordpressContactForm7Test.php
@@ -2,15 +2,7 @@
 /**
  * Facebook Pixel Plugin FacebookWordpressContactForm7Test class.
  *
- * This file contains the main logic for FacebookWordpressContactForm7Test.
- *
  * @package FacebookPixelPlugin
- */
-
-/**
- * Define FacebookWordpressContactForm7Test class.
- *
- * @return void
  */
 
 /*
@@ -27,370 +19,129 @@
 
 namespace FacebookPixelPlugin\Tests\Integration;
 
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
+use FacebookPixelPlugin\Core\Signals;
+use FacebookPixelPlugin\Core\EventData;
+use FacebookPixelPlugin\Core\EventDataBuilder;
+use FacebookPixelPlugin\Core\AjaxFilterDelivery;
 use FacebookPixelPlugin\Integration\FacebookWordpressContactForm7;
 use FacebookPixelPlugin\Tests\Mocks\MockContactForm7;
-use FacebookPixelPlugin\Tests\Mocks\MockContactForm7Tag;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
-use FacebookPixelPlugin\Core\ServerEventFactory;
 
 /**
  * FacebookWordpressContactForm7Test class.
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
- *
- * All tests in this test class should be run in separate PHP process to
- * make sure tests are isolated.
- * Stop preserving global state from the parent process.
  */
 final class FacebookWordpressContactForm7Test extends FacebookWordpressTestBase {
 
   /**
-   * Tests the injectLeadEvent method when the user is not an internal user.
+   * Builds a CF7 integration with a mock Signals and a real builder.
    *
-   * This test verifies that the Pixel code is appended to the HTML output
-   * and that the server-side event is tracked with the correct parameters.
-   *
-   * @return void
+   * @return array [ FacebookWordpressContactForm7, Signals mock ]
    */
-  public function testInjectLeadEventWithoutInternalUser() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-    $mock_response = array(
-      'status'  => 'mail_sent',
-      'message' => 'Thank you for your message',
+  private function makeIntegration() {
+    $signals     = $this->createMock( Signals::class );
+    $integration = new FacebookWordpressContactForm7(
+      $signals,
+      new EventDataBuilder()
     );
-
-        \WP_Mock::userFunction(
-            'sanitize_text_field',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-    $event = ServerEventFactory::new_event( 'Lead' );
-    FacebookServerSideEvent::get_instance()->track( $event );
-
-        \WP_Mock::userFunction(
-            'wp_json_encode',
-            array(
-        'args'   => array(
-                    \Mockery::type( 'array' ),
-          \Mockery::type( 'int' ),
-        ),
-        'return' => function ( $data, $options ) {
-          return json_encode( $data );
-        },
-            )
-        );
-
-    $response =
-    FacebookWordpressContactForm7::injectLeadEvent( $mock_response, null );
-    $this->assertMatchesRegularExpression(
-      '/Lead[\s\S]+contact-form-7/',
-      $response['fb_pxl_code']
-    );
+    return array( $integration, $signals );
   }
 
   /**
-   * Tests the trackServerEvent method when the user is not an internal user.
-   *
-   * This test verifies that the Pixel code is appended to the HTML output
-   * and that the server-side event is tracked with the correct parameters.
+   * inject_pixel_code registers the Lead event on Signals (with the AJAX
+   * delivery) and the front-end mail-sent listener.
    *
    * @return void
    */
-  public function testTrackServerEventWithoutInternalUser() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
+  public function testInjectPixelCodeRegistersEventAndListener() {
+    list( $integration, $signals ) = $this->makeIntegration();
 
-    $mock_result = array(
-      'status'  => 'mail_sent',
-      'message' => 'Thank you for your message',
-    );
-
-    $mock_form               = $this->createMockForm();
-    $_SERVER['HTTP_REFERER'] = 'TEST_REFERER';
-
-        \WP_Mock::userFunction(
-            'sanitize_text_field',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-    \WP_Mock::expectActionAdded(
-      'wpcf7_feedback_response',
-      array(
-        'FacebookPixelPlugin\\Integration\\FacebookWordpressContactForm7',
-        'injectLeadEvent',
-      ),
-      20,
-      2
-    );
-
-        \WP_Mock::userFunction(
-            'wp_unslash',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-    $result =
-    FacebookWordpressContactForm7::trackServerEvent(
-            $mock_form,
-            $mock_result
-        );
-
-    $tracked_events =
-    FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-    $this->assertCount( 1, $tracked_events );
-
-    $event = $tracked_events[0];
-    $this->assertEquals( 'Lead', $event->getEventName() );
-    $this->assertNotNull( $event->getEventTime() );
-    $this->assertEquals(
-            'pika.chu@s2s.com',
-            $event->getUserData()->getEmail()
-        );
-    $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
-    $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
-    $this->assertEquals( '12223334444', $event->getUserData()->getPhone() );
-    $this->assertEquals(
-      'contact-form-7',
-      $event->getCustomData()->getCustomProperty(
-                'fb_integration_tracking'
-            )
-    );
-    $this->assertEquals( 'TEST_REFERER', $event->getEventSourceUrl() );
-  }
-
-  /**
-   * Tests the trackServerEvent method when
-     * the user is not an internal user and
-   * the form data is not available. This test
-     * verifies that the server-side event
-   * is tracked with the correct parameters.
-   *
-   * @return void
-   */
-  public function testTrackServerEventWithoutFormData() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-    $mock_result = array(
-      'status'  => 'mail_sent',
-      'message' => 'Thank you for your message',
-    );
-
-        \WP_Mock::userFunction(
-            'sanitize_text_field',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-    $mock_form = $this->createMockForm();
-
-    \WP_Mock::expectActionAdded(
-      'wpcf7_feedback_response',
-      array(
-        'FacebookPixelPlugin\\Integration\\FacebookWordpressContactForm7',
-        'injectLeadEvent',
-      ),
-      20,
-      2
-    );
-
-        \WP_Mock::userFunction(
-            'wp_unslash',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-    $result = FacebookWordpressContactForm7::trackServerEvent(
-      $mock_form,
-      $mock_result
-    );
-
-    $tracked_events =
-    FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-    $this->assertCount( 1, $tracked_events );
-
-    $event = $tracked_events[0];
-    $this->assertEquals( 'Lead', $event->getEventName() );
-    $this->assertNotNull( $event->getEventTime() );
-  }
-
-  /**
-   * Tests the trackServerEvent method when an error occurs while reading
-   * the form data.
-   *
-   * This test verifies that the Pixel code is appended to the HTML output
-   * and that the server-side event is tracked with the correct parameters.
-   *
-   * @return void
-   */
-  public function testTrackServerEventErrorReadingData() {
-    $this->markTestSkipped('Skipping test temporarily while we update error handling.');
-
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-    $mock_result = array(
-      'status'  => 'mail_sent',
-      'message' => 'Thank you for your message',
-    );
-
-    $mock_form = $this->createMockForm();
-    $mock_form->set_throw( false );
-
-    \WP_Mock::expectActionAdded(
-      'wpcf7_feedback_response',
-      array(
-        'FacebookPixelPlugin\\Integration\\FacebookWordpressContactForm7',
-        'injectLeadEvent',
-      ),
-      20,
-      2
-    );
-
-        \WP_Mock::userFunction(
-            'sanitize_text_field',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-        \WP_Mock::userFunction(
-            'wp_unslash',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-    $result =
-    FacebookWordpressContactForm7::trackServerEvent(
-            $mock_form,
-            $mock_result
-        );
-
-    $tracked_events =
-    FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-    $this->assertCount( 1, $tracked_events );
-
-    $event = $tracked_events[0];
-    $this->assertEquals( 'Lead', $event->getEventName() );
-    $this->assertNotNull( $event->getEventTime() );
-  }
-
-  /**
-   * Tests the injectLeadEvent method when the user is an internal user.
-   *
-   * This test verifies that the output HTML does not contain the Pixel code
-   * when the user is an internal user.
-   *
-   * @return void
-   */
-  public function testInjectLeadEventWithInternalUser() {
-    self::mockIsInternalUser( true );
-
-    $mock_response = array(
-      'status'  => 'mail_sent',
-      'message' => 'Thank you for your message',
-    );
-
-    $response =
-    FacebookWordpressContactForm7::injectLeadEvent( $mock_response, null );
-    $this->assertArrayNotHasKey( 'fb_pxl_code', $response );
-  }
-
-  /**
-   * Tests the injectLeadEvent method when the mail fails.
-   *
-   * This test verifies that no server-side events are tracked when the mail
-   * status indicates failure (e.g., validation
-     * failed, spam, mail failed, etc.).
-   * It asserts that the tracked events list is
-     * empty when such statuses occur.
-   *
-   * @return void
-   */
-  public function testInjectLeadEventWhenMailFails() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-    $bad_statuses = array(
-      'validation_failed',
-      'acceptance_missing',
-      'spam',
-      'aborted',
-      'mail_failed',
-    );
-
-    $mock_form = new MockContactForm7();
-    $mock_form->set_throw( false );
-
-    foreach ( $bad_statuses as $status ) {
-      $mock_result = array(
-        'status'  => $status,
-        'message' => 'Error bad status',
+    $signals->expects( $this->once() )
+      ->method( 'on' )
+      ->with(
+        'wpcf7_submit',
+        'Lead',
+        $this->isType( 'callable' ),
+        $this->isInstanceOf( AjaxFilterDelivery::class ),
+        'contact-form-7',
+        10,
+        2
       );
-      FacebookWordpressContactForm7::trackServerEvent(
-                $mock_form,
-                $mock_result
-            );
-    }
 
-    $tracked_events =
-    FacebookServerSideEvent::get_instance()->get_tracked_events();
+    \WP_Mock::expectActionAdded(
+      'wp_footer',
+      array( $integration, 'inject_mail_sent_listener' ),
+      10,
+      2
+    );
 
-    $this->assertCount( 0, $tracked_events );
+    $integration->inject_pixel_code();
+
+    $this->assertConditionsMet();
   }
 
   /**
-   * Creates a mock form object with some sample form tags.
+   * read_form_data extracts the standard fields into an EventData.
    *
-   * The sample form tags include email, text, and tel fields, with some
-   * fictional sample data. This mock form object is used in the tests to
-   * simulate a form submission.
+   * @return void
+   */
+  public function testReadFormDataReturnsEventData() {
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+
+    list( $integration ) = $this->makeIntegration();
+    $form                = $this->createMockForm();
+
+    $data = $integration->read_form_data(
+      $form,
+      array( 'status' => 'mail_sent' )
+    );
+
+    $this->assertInstanceOf( EventData::class, $data );
+    $this->assertEquals(
+      array(
+        'email'      => 'pika.chu@s2s.com',
+        'first_name' => 'Pika',
+        'last_name'  => 'Chu',
+        'phone'      => '12223334444',
+      ),
+      $data->to_array()
+    );
+  }
+
+  /**
+   * read_form_data returns null (no dispatch) when the mail did not send.
    *
-   * @return MockContactForm7 A mock form object with sample form tags.
+   * @return void
+   */
+  public function testReadFormDataSkipsWhenNotMailSent() {
+    list( $integration ) = $this->makeIntegration();
+    $form                = $this->createMockForm();
+
+    $this->assertNull(
+      $integration->read_form_data( $form, array( 'status' => 'spam' ) )
+    );
+  }
+
+  /**
+   * Creates a mock CF7 form with sample email/name/phone tags (which also
+   * populate $_POST).
+   *
+   * @return MockContactForm7
    */
   private function createMockForm() {
     $mock_form = new MockContactForm7();
-
     $mock_form->add_tag( 'email', 'your-email', 'pika.chu@s2s.com' );
     $mock_form->add_tag( 'text', 'your-name', 'Pika Chu' );
     $mock_form->add_tag( 'tel', 'your-phone-number', '12223334444' );
-
     return $mock_form;
   }
 }

--- a/core/class-eventdata.php
+++ b/core/class-eventdata.php
@@ -41,12 +41,32 @@ class EventData {
     private $fields;
 
     /**
+     * Optional shared event id, used to deduplicate a browser event against its
+     * server-side counterpart. Null when the dispatcher should generate one.
+     *
+     * @var string|null
+     */
+    private $event_id;
+
+    /**
      * Constructor.
      *
-     * @param array<string,mixed> $fields Standard event fields.
+     * @param array<string,mixed> $fields   Standard event fields.
+     * @param string|null         $event_id Optional shared event id for
+     *                                       browser/server deduplication.
      */
-    public function __construct( array $fields = array() ) {
-        $this->fields = $fields;
+    public function __construct( array $fields = array(), $event_id = null ) {
+        $this->fields   = $fields;
+        $this->event_id = $event_id;
+    }
+
+    /**
+     * Returns the shared event id, or null when none was provided.
+     *
+     * @return string|null
+     */
+    public function get_event_id() {
+        return $this->event_id;
     }
 
     /**

--- a/core/class-eventdatabuilder.php
+++ b/core/class-eventdatabuilder.php
@@ -39,10 +39,12 @@ class EventDataBuilder {
      * Builds an EventData from a standard-keyed field array, dropping null and
      * empty-string values so downstream code doesn't emit sparse keys.
      *
-     * @param array<string,mixed> $fields Standard event fields.
+     * @param array<string,mixed> $fields   Standard event fields.
+     * @param string|null         $event_id Optional shared event id for
+     *                                       browser/server deduplication.
      * @return EventData
      */
-    public function build( array $fields ) {
+    public function build( array $fields, $event_id = null ) {
         $clean = array();
         foreach ( $fields as $key => $value ) {
             if ( null === $value || '' === $value ) {
@@ -50,6 +52,6 @@ class EventDataBuilder {
             }
             $clean[ $key ] = $value;
         }
-        return new EventData( $clean );
+        return new EventData( $clean, $event_id );
     }
 }

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -125,15 +125,7 @@ class FacebookWordpressPixelInjection {
             return;
         }
 
-        $pending_events =
-        $this->signals->get_server_events()->get_pending_events();
-        if ( count( $pending_events ) > 0 ) {
-            do_action(
-                'send_server_events',
-                $pending_events,
-                count( $pending_events )
-            );
-        }
+        $this->signals->flush_pending_events();
     }
 
     /**

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -41,9 +41,33 @@ class FacebookWordpressPixelInjection {
     public static $render_cache = array();
 
     /**
-     * Constructor for the FacebookWordpressPixelInjection class.
+     * Shared event dispatcher for the request.
+     *
+     * @var Signals|null
      */
-    public function __construct() {
+    private $signals;
+
+    /**
+     * Field-to-EventData bridge injected into integrations.
+     *
+     * @var EventDataBuilder|null
+     */
+    private $event_builder;
+
+    /**
+     * Constructor.
+     *
+     * @param Signals|null          $signals       Shared dispatcher. Falls back
+     *                                             to a new Signals when omitted.
+     * @param EventDataBuilder|null $event_builder Field-to-EventData bridge.
+     */
+    public function __construct( $signals = null, $event_builder = null ) {
+        $this->signals       = $signals instanceof Signals
+            ? $signals
+            : new Signals();
+        $this->event_builder = $event_builder instanceof EventDataBuilder
+            ? $event_builder
+            : new EventDataBuilder();
     }
 
     /**
@@ -74,8 +98,12 @@ class FacebookWordpressPixelInjection {
             foreach (
                 FacebookPluginConfig::integration_config() as $key => $value
                 ) {
-            $class_name = 'FacebookPixelPlugin\\Integration\\' . $value;
-            $class_name::inject_pixel_code();
+            $class_name  = 'FacebookPixelPlugin\\Integration\\' . $value;
+            $integration = new $class_name(
+                $this->signals,
+                $this->event_builder
+            );
+            $integration->inject_pixel_code();
             }
             add_action(
                 'wp_footer',
@@ -98,7 +126,7 @@ class FacebookWordpressPixelInjection {
         }
 
         $pending_events =
-        FacebookServerSideEvent::get_instance()->get_pending_events();
+        $this->signals->get_server_events()->get_pending_events();
         if ( count( $pending_events ) > 0 ) {
             do_action(
                 'send_server_events',

--- a/core/class-signals.php
+++ b/core/class-signals.php
@@ -193,9 +193,17 @@ class Signals {
             $prefer_referrer
         );
 
-        // When an integration supplies a shared id (e.g. from a hidden form
-        // field), reuse it so the server event deduplicates against the
-        // browser event that carries the same id.
+        // Browser/server dedup. For every integration except EDD add-to-cart
+        // this block is a no-op: the browser pixel is rendered from THIS same
+        // Event via PixelRenderer (which copies the id into the fbq eventID),
+        // so both sides already share the ServerEventFactory-generated id and
+        // get_event_id() is null here. EDD add-to-cart is the exception — its
+        // browser pixel fires client-side on click, before this server Event
+        // exists, so it cannot inherit this id. That flow pre-shares an id via
+        // a hidden form field; read_add_to_cart() puts it on the EventData and
+        // we stamp it onto the server Event so the two deduplicate. See
+        // T278177691 to remove this plumbing once EDD's add-to-cart pixel can
+        // be rendered from the server Event too.
         $event_id = $event_data->get_event_id();
         if ( ! empty( $event_id ) ) {
             $event->setEventId( $event_id );

--- a/core/class-signals.php
+++ b/core/class-signals.php
@@ -65,12 +65,18 @@ class Signals {
     }
 
     /**
-     * Returns the CAPI event store shared for this request.
+     * Sends any server-side events that were queued (dispatched for deferred
+     * sending) during this request via the send_server_events action. The
+     * pending-event store is kept fully encapsulated here so callers never
+     * reach into it.
      *
-     * @return FacebookServerSideEvent
+     * @return void
      */
-    public function get_server_events() {
-        return $this->server_events;
+    public function flush_pending_events() {
+        $pending = $this->server_events->get_pending_events();
+        if ( count( $pending ) > 0 ) {
+            do_action( 'send_server_events', $pending, count( $pending ) );
+        }
     }
 
     /**
@@ -186,6 +192,15 @@ class Signals {
             $tracking_name,
             $prefer_referrer
         );
+
+        // When an integration supplies a shared id (e.g. from a hidden form
+        // field), reuse it so the server event deduplicates against the
+        // browser event that carries the same id.
+        $event_id = $event_data->get_event_id();
+        if ( ! empty( $event_id ) ) {
+            $event->setEventId( $event_id );
+        }
+
         $this->server_events->track( $event );
         return $event;
     }

--- a/facebook-for-wordpress.php
+++ b/facebook-for-wordpress.php
@@ -41,6 +41,7 @@ require_once plugin_dir_path( __FILE__ ) . 'core/class-releasesignalsajax.php';
 
 use FacebookPixelPlugin\Core\FacebookPixel;
 use FacebookPixelPlugin\Core\Signals;
+use FacebookPixelPlugin\Core\EventDataBuilder;
 use FacebookPixelPlugin\Core\FacebookPluginConfig;
 use FacebookPixelPlugin\Core\FacebookPluginUtils;
 use FacebookPixelPlugin\Core\FacebookSignalState;
@@ -58,6 +59,20 @@ use FacebookPixelPlugin\Core\ServerEventAsyncTask;
  */
 class FacebookForWordpress {
     /**
+     * Shared event dispatcher for the request.
+     *
+     * @var Signals
+     */
+    private $signals;
+
+    /**
+     * Shared field-to-EventData bridge injected into integrations.
+     *
+     * @var EventDataBuilder
+     */
+    private $event_builder;
+
+    /**
      * Plugin constructor. Initializes the plugin options, loads the translation files,
      * sets up the Facebook pixel, sets up the pixel injection, and sets up the settings
      * page. Also starts the server event async task.
@@ -73,7 +88,8 @@ class FacebookForWordpress {
 
     $options = FacebookWordpressOptions::get_options();
     FacebookPixel::initialize( FacebookWordpressOptions::get_active_pixel_id() );
-    new Signals();
+    $this->event_builder = new EventDataBuilder();
+    $this->signals       = new Signals();
     new ReleaseSignalsAjax();
 
     if ( Signals::should_hold_signals() ) {
@@ -135,7 +151,10 @@ class FacebookForWordpress {
      * inject the Facebook pixel code into the footer of the WordPress page.
      */
     public function register_pixel_injection() {
-    $injection_obj = new FacebookWordpressPixelInjection();
+    $injection_obj = new FacebookWordpressPixelInjection(
+        $this->signals,
+        $this->event_builder
+    );
     $injection_obj->inject();
     }
 

--- a/integration/class-facebookwordpresscontactform7.php
+++ b/integration/class-facebookwordpresscontactform7.php
@@ -29,13 +29,8 @@ namespace FacebookPixelPlugin\Integration;
 
 defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 
-use FacebookPixelPlugin\Core\FacebookPluginUtils;
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
-use FacebookPixelPlugin\Core\FacebookWordPressOptions;
 use FacebookPixelPlugin\Core\ServerEventFactory;
-use FacebookPixelPlugin\Core\PixelRenderer;
-use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
-use FacebookPixelPlugin\FacebookAds\Object\ServerSide\UserData;
+use FacebookPixelPlugin\Core\AjaxFilterDelivery;
 
 /**
  * FacebookWordpressContactForm7 class.
@@ -45,39 +40,41 @@ class FacebookWordpressContactForm7 extends FacebookWordpressIntegrationBase {
     const TRACKING_NAME = 'contact-form-7';
 
     /**
-     * Add hooks to inject the Contact Form 7 tracking code.
+     * Registers the Contact Form 7 hooks.
      *
-     * Adds the following hooks:
-     *  - wpcf7_submit: Triggers a server-side event when the form is submitted.
-     *  - wp_footer: Injects the mail sent listener.
+     * The Lead event (server + browser) is dispatched through Signals on
+     * submit, with the browser code delivered into the CF7 AJAX response; a
+     * front-end listener evaluates it.
+     *
+     * @return void
      */
-    public static function inject_pixel_code() {
-        add_action(
+    public function inject_pixel_code() {
+        $this->signals->on(
             'wpcf7_submit',
-            array( __CLASS__, 'trackServerEvent' ),
+            'Lead',
+            array( $this, 'read_form_data' ),
+            new AjaxFilterDelivery( 'wpcf7_feedback_response', 'fb_pxl_code' ),
+            self::TRACKING_NAME,
             10,
             2
         );
         add_action(
             'wp_footer',
-            array( __CLASS__, 'injectMailSentListener' ),
+            array( $this, 'inject_mail_sent_listener' ),
             10,
             2
         );
     }
 
     /**
-     * Injects a JavaScript listener for the 'wpcf7mailsent' event,
-     * which is triggered when a form is submitted.
-     *
-     * The listener executes the Pixel code sent in the response
-     * via the 'fb_pxl_code' key.
+     * Injects a JavaScript listener for the 'wpcf7mailsent' event that
+     * evaluates the pixel code returned in the CF7 AJAX response.
      *
      * @return void
      */
-    public static function injectMailSentListener() {
+    public function inject_mail_sent_listener() {
         ob_start();
-    ?>
+        ?>
     <!-- Meta Pixel Event Code -->
     <script type='text/javascript'>
         document.addEventListener( 'wpcf7mailsent', function( event ) {
@@ -88,113 +85,37 @@ class FacebookWordpressContactForm7 extends FacebookWordpressIntegrationBase {
     </script>
     <!-- End Meta Pixel Event Code -->
         <?php
-        $listener_code = ob_get_clean();
-        echo $listener_code; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        echo ob_get_clean(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
     }
 
     /**
-     * Triggers a server-side event when a form is submitted.
+     * Extracts the Lead event data from a Contact Form 7 submission.
      *
-     * If the user is an internal user or the form submission failed,
-     * the event is not tracked.
+     * Returns null when the submission did not succeed, so Signals skips
+     * dispatching. The internal-user check is handled by Signals.
      *
-     * @param array $form The form object.
-     * @param array $result The form submission result.
-     *
-     * @return array The submission result.
+     * @param object $form   The Contact Form 7 form object.
+     * @param array  $result The Contact Form 7 submission result.
+     * @return \FacebookPixelPlugin\Core\EventData|null
      */
-    public static function trackServerEvent( $form, $result ) {
-        $is_internal_user = FacebookPluginUtils::is_internal_user();
-        $submit_failed    = 'mail_sent' !== $result['status'];
-        if ( $is_internal_user || $submit_failed ) {
-            return $result;
+    public function read_form_data( $form, $result = array() ) {
+        if ( isset( $result['status'] ) && 'mail_sent' !== $result['status'] ) {
+            return null;
         }
-
-        $server_event = ServerEventFactory::safe_create_event(
-            'Lead',
-            array( __CLASS__, 'readFormData' ),
-            array( $form ),
-            self::TRACKING_NAME,
-            true
-        );
-        FacebookServerSideEvent::get_instance()->track( $server_event );
-
-        add_action(
-            'wpcf7_feedback_response',
-            array( __CLASS__, 'injectLeadEvent' ),
-            20,
-            2
-        );
-
-        return $result;
-    }
-
-    /**
-     * Injects the Pixel code into the Contact Form 7 response.
-     *
-     * Hooks into the `wpcf7_feedback_response` action and checks if the form
-     * is submitted successfully and if the user is not an internal user.
-     * If conditions are met, it renders the Pixel code using the `PixelRenderer` class
-     * and appends the code to the form response.
-     *
-     * @param array $response The Contact Form 7 response.
-     * @param array $result   The form data.
-     *
-     * @return array The modified Contact Form 7 response.
-     */
-    public static function injectLeadEvent( $response, $result ) {
-        if ( FacebookPluginUtils::is_internal_user() ) {
-            return $response;
-        }
-
-            $events = FacebookServerSideEvent::get_instance()->get_tracked_events();
-        if ( count( $events ) === 0 ) {
-            return $response;
-        }
-        $event_id  = $events[0]->getEventId();
-        $fbq_calls = PixelRenderer::render(
-            $events,
-            self::TRACKING_NAME,
-            false
-        );
-        $code      = sprintf(
-            "
-    if( typeof window.pixelLastGeneratedLeadEvent === 'undefined'
-    || window.pixelLastGeneratedLeadEvent != '%s' ){
-    window.pixelLastGeneratedLeadEvent = '%s';
-    %s
-    }
-        ",
-            $event_id,
-            $event_id,
-            $fbq_calls
-        );
-
-        $response['fb_pxl_code'] = $code;
-        return $response;
-    }
-
-    /**
-     * Reads the form data from the Contact Form 7 submission.
-     *
-     * @param object $form The Contact Form 7 form object.
-     *
-     * @return array The form data in the format expected
-     * by the `FacebookServerSideEvent` class.
-     */
-    public static function readFormData( $form ) {
         if ( empty( $form ) ) {
-            return array();
+            return null;
         }
 
         $form_tags = $form->scan_form_tags();
         $name      = self::getName( $form_tags );
 
-        return array(
-            'email'      => self::getEmail( $form_tags ),
-            'first_name' => $name[0],
-            'last_name'  => $name[1],
-            'phone'      => self::getPhone( $form_tags ),
+        return $this->event_builder->build(
+            array(
+                'email'      => self::getEmail( $form_tags ),
+                'first_name' => is_array( $name ) ? $name[0] : null,
+                'last_name'  => is_array( $name ) ? $name[1] : null,
+                'phone'      => self::getPhone( $form_tags ),
+            )
         );
     }
 

--- a/integration/class-facebookwordpressintegrationbase.php
+++ b/integration/class-facebookwordpressintegrationbase.php
@@ -38,15 +38,34 @@ abstract class FacebookWordpressIntegrationBase {
     const PLUGIN_FILE   = '';
     const TRACKING_NAME = '';
 
+    /**
+     * Event dispatcher shared for the request. Available to integrations that
+     * have been converted to the instance/Signals model.
+     *
+     * @var \FacebookPixelPlugin\Core\Signals|null
+     */
+    protected $signals;
 
     /**
-     * This function should be overridden in derived classes.
-     * It is responsible for adding action hooks to
-     * WordPress to inject the pixel code.
+     * Bridge that turns an integration's extracted fields into EventData.
      *
-     * @return void
+     * @var \FacebookPixelPlugin\Core\EventDataBuilder|null
      */
-    public static function inject_pixel_code() {
+    protected $event_builder;
+
+    /**
+     * Constructor.
+     *
+     * Dependencies are optional so integrations that haven't been converted
+     * yet (no own constructor, still static internally) can still be
+     * instantiated by the pixel injector without error.
+     *
+     * @param \FacebookPixelPlugin\Core\Signals|null          $signals       Shared dispatcher.
+     * @param \FacebookPixelPlugin\Core\EventDataBuilder|null $event_builder Field-to-EventData bridge.
+     */
+    public function __construct( $signals = null, $event_builder = null ) {
+        $this->signals       = $signals;
+        $this->event_builder = $event_builder;
     }
 
 


### PR DESCRIPTION
## Summary
Wires integrations through instances sharing one `Signals` dispatcher, encapsulates server-event handling behind `Signals`, and converts Contact Form 7 as the reference per-integration migration. (Folds in the former CF7 PR #160.)

- **Wiring:** `PixelInjection` builds one `Signals` + `EventDataBuilder` and injects them into each integration instance; base class holds the injected deps.
- **Encapsulation:** `Signals::flush_pending_events()` owns reading queued CAPI events and firing `send_server_events`; the public `get_server_events()` accessor is gone, so the store is hidden. `PixelInjection::send_pending_events()` keeps the consent-hold guard and delegates.
- **Contact Form 7:** instance `inject_pixel_code()` declares the event once via `$this->signals->on('wpcf7_submit','Lead',[$this,'read_form_data'], new AjaxFilterDelivery(...), …)`; `read_form_data()` is a pure `EventData` provider; the old split track/inject methods are removed.

## Series
1. dispatch foundation (#158)
2. **instance wiring + encapsulation + CF7 ← this PR**
3. remaining integration conversions + entry-point rename + behavior-preserving tests (next PR)
4. remove the `FacebookServerSideEvent` singleton (follow-up)

## Test plan
`phpunit __tests__` green; `phpcs` clean.