### PR TITLE
Signals refactor (R3/N): convert Contact Form 7

### DIFF
--- a/__tests__/integration/FacebookWordpressContactForm7Test.php
+++ b/__tests__/integration/FacebookWordpressContactForm7Test.php
@@ -2,15 +2,7 @@
 /**
  * Facebook Pixel Plugin FacebookWordpressContactForm7Test class.
  *
- * This file contains the main logic for FacebookWordpressContactForm7Test.
- *
  * @package FacebookPixelPlugin
- */
-
-/**
- * Define FacebookWordpressContactForm7Test class.
- *
- * @return void
  */
 
 /*
@@ -27,370 +19,129 @@
 
 namespace FacebookPixelPlugin\Tests\Integration;
 
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
+use FacebookPixelPlugin\Core\Signals;
+use FacebookPixelPlugin\Core\EventData;
+use FacebookPixelPlugin\Core\EventDataBuilder;
+use FacebookPixelPlugin\Core\AjaxFilterDelivery;
 use FacebookPixelPlugin\Integration\FacebookWordpressContactForm7;
 use FacebookPixelPlugin\Tests\Mocks\MockContactForm7;
-use FacebookPixelPlugin\Tests\Mocks\MockContactForm7Tag;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
-use FacebookPixelPlugin\Core\ServerEventFactory;
 
 /**
  * FacebookWordpressContactForm7Test class.
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
- *
- * All tests in this test class should be run in separate PHP process to
- * make sure tests are isolated.
- * Stop preserving global state from the parent process.
  */
 final class FacebookWordpressContactForm7Test extends FacebookWordpressTestBase {
 
   /**
-   * Tests the injectLeadEvent method when the user is not an internal user.
+   * Builds a CF7 integration with a mock Signals and a real builder.
    *
-   * This test verifies that the Pixel code is appended to the HTML output
-   * and that the server-side event is tracked with the correct parameters.
-   *
-   * @return void
+   * @return array [ FacebookWordpressContactForm7, Signals mock ]
    */
-  public function testInjectLeadEventWithoutInternalUser() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-    $mock_response = array(
-      'status'  => 'mail_sent',
-      'message' => 'Thank you for your message',
+  private function makeIntegration() {
+    $signals     = $this->createMock( Signals::class );
+    $integration = new FacebookWordpressContactForm7(
+      $signals,
+      new EventDataBuilder()
     );
-
-        \WP_Mock::userFunction(
-            'sanitize_text_field',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-    $event = ServerEventFactory::new_event( 'Lead' );
-    FacebookServerSideEvent::get_instance()->track( $event );
-
-        \WP_Mock::userFunction(
-            'wp_json_encode',
-            array(
-        'args'   => array(
-                    \Mockery::type( 'array' ),
-          \Mockery::type( 'int' ),
-        ),
-        'return' => function ( $data, $options ) {
-          return json_encode( $data );
-        },
-            )
-        );
-
-    $response =
-    FacebookWordpressContactForm7::injectLeadEvent( $mock_response, null );
-    $this->assertMatchesRegularExpression(
-      '/Lead[\s\S]+contact-form-7/',
-      $response['fb_pxl_code']
-    );
+    return array( $integration, $signals );
   }
 
   /**
-   * Tests the trackServerEvent method when the user is not an internal user.
-   *
-   * This test verifies that the Pixel code is appended to the HTML output
-   * and that the server-side event is tracked with the correct parameters.
+   * inject_pixel_code registers the Lead event on Signals (with the AJAX
+   * delivery) and the front-end mail-sent listener.
    *
    * @return void
    */
-  public function testTrackServerEventWithoutInternalUser() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
+  public function testInjectPixelCodeRegistersEventAndListener() {
+    list( $integration, $signals ) = $this->makeIntegration();
 
-    $mock_result = array(
-      'status'  => 'mail_sent',
-      'message' => 'Thank you for your message',
-    );
-
-    $mock_form               = $this->createMockForm();
-    $_SERVER['HTTP_REFERER'] = 'TEST_REFERER';
-
-        \WP_Mock::userFunction(
-            'sanitize_text_field',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-    \WP_Mock::expectActionAdded(
-      'wpcf7_feedback_response',
-      array(
-        'FacebookPixelPlugin\\Integration\\FacebookWordpressContactForm7',
-        'injectLeadEvent',
-      ),
-      20,
-      2
-    );
-
-        \WP_Mock::userFunction(
-            'wp_unslash',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-    $result =
-    FacebookWordpressContactForm7::trackServerEvent(
-            $mock_form,
-            $mock_result
-        );
-
-    $tracked_events =
-    FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-    $this->assertCount( 1, $tracked_events );
-
-    $event = $tracked_events[0];
-    $this->assertEquals( 'Lead', $event->getEventName() );
-    $this->assertNotNull( $event->getEventTime() );
-    $this->assertEquals(
-            'pika.chu@s2s.com',
-            $event->getUserData()->getEmail()
-        );
-    $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
-    $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
-    $this->assertEquals( '12223334444', $event->getUserData()->getPhone() );
-    $this->assertEquals(
-      'contact-form-7',
-      $event->getCustomData()->getCustomProperty(
-                'fb_integration_tracking'
-            )
-    );
-    $this->assertEquals( 'TEST_REFERER', $event->getEventSourceUrl() );
-  }
-
-  /**
-   * Tests the trackServerEvent method when
-     * the user is not an internal user and
-   * the form data is not available. This test
-     * verifies that the server-side event
-   * is tracked with the correct parameters.
-   *
-   * @return void
-   */
-  public function testTrackServerEventWithoutFormData() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-    $mock_result = array(
-      'status'  => 'mail_sent',
-      'message' => 'Thank you for your message',
-    );
-
-        \WP_Mock::userFunction(
-            'sanitize_text_field',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-    $mock_form = $this->createMockForm();
-
-    \WP_Mock::expectActionAdded(
-      'wpcf7_feedback_response',
-      array(
-        'FacebookPixelPlugin\\Integration\\FacebookWordpressContactForm7',
-        'injectLeadEvent',
-      ),
-      20,
-      2
-    );
-
-        \WP_Mock::userFunction(
-            'wp_unslash',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-    $result = FacebookWordpressContactForm7::trackServerEvent(
-      $mock_form,
-      $mock_result
-    );
-
-    $tracked_events =
-    FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-    $this->assertCount( 1, $tracked_events );
-
-    $event = $tracked_events[0];
-    $this->assertEquals( 'Lead', $event->getEventName() );
-    $this->assertNotNull( $event->getEventTime() );
-  }
-
-  /**
-   * Tests the trackServerEvent method when an error occurs while reading
-   * the form data.
-   *
-   * This test verifies that the Pixel code is appended to the HTML output
-   * and that the server-side event is tracked with the correct parameters.
-   *
-   * @return void
-   */
-  public function testTrackServerEventErrorReadingData() {
-    $this->markTestSkipped('Skipping test temporarily while we update error handling.');
-
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-    $mock_result = array(
-      'status'  => 'mail_sent',
-      'message' => 'Thank you for your message',
-    );
-
-    $mock_form = $this->createMockForm();
-    $mock_form->set_throw( false );
-
-    \WP_Mock::expectActionAdded(
-      'wpcf7_feedback_response',
-      array(
-        'FacebookPixelPlugin\\Integration\\FacebookWordpressContactForm7',
-        'injectLeadEvent',
-      ),
-      20,
-      2
-    );
-
-        \WP_Mock::userFunction(
-            'sanitize_text_field',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-        \WP_Mock::userFunction(
-            'wp_unslash',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-    $result =
-    FacebookWordpressContactForm7::trackServerEvent(
-            $mock_form,
-            $mock_result
-        );
-
-    $tracked_events =
-    FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-    $this->assertCount( 1, $tracked_events );
-
-    $event = $tracked_events[0];
-    $this->assertEquals( 'Lead', $event->getEventName() );
-    $this->assertNotNull( $event->getEventTime() );
-  }
-
-  /**
-   * Tests the injectLeadEvent method when the user is an internal user.
-   *
-   * This test verifies that the output HTML does not contain the Pixel code
-   * when the user is an internal user.
-   *
-   * @return void
-   */
-  public function testInjectLeadEventWithInternalUser() {
-    self::mockIsInternalUser( true );
-
-    $mock_response = array(
-      'status'  => 'mail_sent',
-      'message' => 'Thank you for your message',
-    );
-
-    $response =
-    FacebookWordpressContactForm7::injectLeadEvent( $mock_response, null );
-    $this->assertArrayNotHasKey( 'fb_pxl_code', $response );
-  }
-
-  /**
-   * Tests the injectLeadEvent method when the mail fails.
-   *
-   * This test verifies that no server-side events are tracked when the mail
-   * status indicates failure (e.g., validation
-     * failed, spam, mail failed, etc.).
-   * It asserts that the tracked events list is
-     * empty when such statuses occur.
-   *
-   * @return void
-   */
-  public function testInjectLeadEventWhenMailFails() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-    $bad_statuses = array(
-      'validation_failed',
-      'acceptance_missing',
-      'spam',
-      'aborted',
-      'mail_failed',
-    );
-
-    $mock_form = new MockContactForm7();
-    $mock_form->set_throw( false );
-
-    foreach ( $bad_statuses as $status ) {
-      $mock_result = array(
-        'status'  => $status,
-        'message' => 'Error bad status',
+    $signals->expects( $this->once() )
+      ->method( 'on' )
+      ->with(
+        'wpcf7_submit',
+        'Lead',
+        $this->isType( 'callable' ),
+        $this->isInstanceOf( AjaxFilterDelivery::class ),
+        'contact-form-7',
+        10,
+        2
       );
-      FacebookWordpressContactForm7::trackServerEvent(
-                $mock_form,
-                $mock_result
-            );
-    }
 
-    $tracked_events =
-    FacebookServerSideEvent::get_instance()->get_tracked_events();
+    \WP_Mock::expectActionAdded(
+      'wp_footer',
+      array( $integration, 'inject_mail_sent_listener' ),
+      10,
+      2
+    );
 
-    $this->assertCount( 0, $tracked_events );
+    $integration->inject_pixel_code();
+
+    $this->assertConditionsMet();
   }
 
   /**
-   * Creates a mock form object with some sample form tags.
+   * read_form_data extracts the standard fields into an EventData.
    *
-   * The sample form tags include email, text, and tel fields, with some
-   * fictional sample data. This mock form object is used in the tests to
-   * simulate a form submission.
+   * @return void
+   */
+  public function testReadFormDataReturnsEventData() {
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+
+    list( $integration ) = $this->makeIntegration();
+    $form                = $this->createMockForm();
+
+    $data = $integration->read_form_data(
+      $form,
+      array( 'status' => 'mail_sent' )
+    );
+
+    $this->assertInstanceOf( EventData::class, $data );
+    $this->assertEquals(
+      array(
+        'email'      => 'pika.chu@s2s.com',
+        'first_name' => 'Pika',
+        'last_name'  => 'Chu',
+        'phone'      => '12223334444',
+      ),
+      $data->to_array()
+    );
+  }
+
+  /**
+   * read_form_data returns null (no dispatch) when the mail did not send.
    *
-   * @return MockContactForm7 A mock form object with sample form tags.
+   * @return void
+   */
+  public function testReadFormDataSkipsWhenNotMailSent() {
+    list( $integration ) = $this->makeIntegration();
+    $form                = $this->createMockForm();
+
+    $this->assertNull(
+      $integration->read_form_data( $form, array( 'status' => 'spam' ) )
+    );
+  }
+
+  /**
+   * Creates a mock CF7 form with sample email/name/phone tags (which also
+   * populate $_POST).
+   *
+   * @return MockContactForm7
    */
   private function createMockForm() {
     $mock_form = new MockContactForm7();
-
     $mock_form->add_tag( 'email', 'your-email', 'pika.chu@s2s.com' );
     $mock_form->add_tag( 'text', 'your-name', 'Pika Chu' );
     $mock_form->add_tag( 'tel', 'your-phone-number', '12223334444' );
-
     return $mock_form;
   }
 }

--- a/integration/class-facebookwordpresscontactform7.php
+++ b/integration/class-facebookwordpresscontactform7.php
@@ -29,13 +29,8 @@ namespace FacebookPixelPlugin\Integration;
 
 defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 
-use FacebookPixelPlugin\Core\FacebookPluginUtils;
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
-use FacebookPixelPlugin\Core\FacebookWordPressOptions;
 use FacebookPixelPlugin\Core\ServerEventFactory;
-use FacebookPixelPlugin\Core\PixelRenderer;
-use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
-use FacebookPixelPlugin\FacebookAds\Object\ServerSide\UserData;
+use FacebookPixelPlugin\Core\AjaxFilterDelivery;
 
 /**
  * FacebookWordpressContactForm7 class.
@@ -45,39 +40,41 @@ class FacebookWordpressContactForm7 extends FacebookWordpressIntegrationBase {
     const TRACKING_NAME = 'contact-form-7';
 
     /**
-     * Add hooks to inject the Contact Form 7 tracking code.
+     * Registers the Contact Form 7 hooks.
      *
-     * Adds the following hooks:
-     *  - wpcf7_submit: Triggers a server-side event when the form is submitted.
-     *  - wp_footer: Injects the mail sent listener.
+     * The Lead event (server + browser) is dispatched through Signals on
+     * submit, with the browser code delivered into the CF7 AJAX response; a
+     * front-end listener evaluates it.
+     *
+     * @return void
      */
-    public static function inject_pixel_code() {
-        add_action(
+    public function inject_pixel_code() {
+        $this->signals->on(
             'wpcf7_submit',
-            array( __CLASS__, 'trackServerEvent' ),
+            'Lead',
+            array( $this, 'read_form_data' ),
+            new AjaxFilterDelivery( 'wpcf7_feedback_response', 'fb_pxl_code' ),
+            self::TRACKING_NAME,
             10,
             2
         );
         add_action(
             'wp_footer',
-            array( __CLASS__, 'injectMailSentListener' ),
+            array( $this, 'inject_mail_sent_listener' ),
             10,
             2
         );
     }
 
     /**
-     * Injects a JavaScript listener for the 'wpcf7mailsent' event,
-     * which is triggered when a form is submitted.
-     *
-     * The listener executes the Pixel code sent in the response
-     * via the 'fb_pxl_code' key.
+     * Injects a JavaScript listener for the 'wpcf7mailsent' event that
+     * evaluates the pixel code returned in the CF7 AJAX response.
      *
      * @return void
      */
-    public static function injectMailSentListener() {
+    public function inject_mail_sent_listener() {
         ob_start();
-    ?>
+        ?>
     <!-- Meta Pixel Event Code -->
     <script type='text/javascript'>
         document.addEventListener( 'wpcf7mailsent', function( event ) {
@@ -88,113 +85,37 @@ class FacebookWordpressContactForm7 extends FacebookWordpressIntegrationBase {
     </script>
     <!-- End Meta Pixel Event Code -->
         <?php
-        $listener_code = ob_get_clean();
-        echo $listener_code; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        echo ob_get_clean(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
     }
 
     /**
-     * Triggers a server-side event when a form is submitted.
+     * Extracts the Lead event data from a Contact Form 7 submission.
      *
-     * If the user is an internal user or the form submission failed,
-     * the event is not tracked.
+     * Returns null when the submission did not succeed, so Signals skips
+     * dispatching. The internal-user check is handled by Signals.
      *
-     * @param array $form The form object.
-     * @param array $result The form submission result.
-     *
-     * @return array The submission result.
+     * @param object $form   The Contact Form 7 form object.
+     * @param array  $result The Contact Form 7 submission result.
+     * @return \FacebookPixelPlugin\Core\EventData|null
      */
-    public static function trackServerEvent( $form, $result ) {
-        $is_internal_user = FacebookPluginUtils::is_internal_user();
-        $submit_failed    = 'mail_sent' !== $result['status'];
-        if ( $is_internal_user || $submit_failed ) {
-            return $result;
+    public function read_form_data( $form, $result = array() ) {
+        if ( isset( $result['status'] ) && 'mail_sent' !== $result['status'] ) {
+            return null;
         }
-
-        $server_event = ServerEventFactory::safe_create_event(
-            'Lead',
-            array( __CLASS__, 'readFormData' ),
-            array( $form ),
-            self::TRACKING_NAME,
-            true
-        );
-        FacebookServerSideEvent::get_instance()->track( $server_event );
-
-        add_action(
-            'wpcf7_feedback_response',
-            array( __CLASS__, 'injectLeadEvent' ),
-            20,
-            2
-        );
-
-        return $result;
-    }
-
-    /**
-     * Injects the Pixel code into the Contact Form 7 response.
-     *
-     * Hooks into the `wpcf7_feedback_response` action and checks if the form
-     * is submitted successfully and if the user is not an internal user.
-     * If conditions are met, it renders the Pixel code using the `PixelRenderer` class
-     * and appends the code to the form response.
-     *
-     * @param array $response The Contact Form 7 response.
-     * @param array $result   The form data.
-     *
-     * @return array The modified Contact Form 7 response.
-     */
-    public static function injectLeadEvent( $response, $result ) {
-        if ( FacebookPluginUtils::is_internal_user() ) {
-            return $response;
-        }
-
-            $events = FacebookServerSideEvent::get_instance()->get_tracked_events();
-        if ( count( $events ) === 0 ) {
-            return $response;
-        }
-        $event_id  = $events[0]->getEventId();
-        $fbq_calls = PixelRenderer::render(
-            $events,
-            self::TRACKING_NAME,
-            false
-        );
-        $code      = sprintf(
-            "
-    if( typeof window.pixelLastGeneratedLeadEvent === 'undefined'
-    || window.pixelLastGeneratedLeadEvent != '%s' ){
-    window.pixelLastGeneratedLeadEvent = '%s';
-    %s
-    }
-        ",
-            $event_id,
-            $event_id,
-            $fbq_calls
-        );
-
-        $response['fb_pxl_code'] = $code;
-        return $response;
-    }
-
-    /**
-     * Reads the form data from the Contact Form 7 submission.
-     *
-     * @param object $form The Contact Form 7 form object.
-     *
-     * @return array The form data in the format expected
-     * by the `FacebookServerSideEvent` class.
-     */
-    public static function readFormData( $form ) {
         if ( empty( $form ) ) {
-            return array();
+            return null;
         }
 
         $form_tags = $form->scan_form_tags();
         $name      = self::getName( $form_tags );
 
-        return array(
-            'email'      => self::getEmail( $form_tags ),
-            'first_name' => $name[0],
-            'last_name'  => $name[1],
-            'phone'      => self::getPhone( $form_tags ),
+        return $this->event_builder->build(
+            array(
+                'email'      => self::getEmail( $form_tags ),
+                'first_name' => is_array( $name ) ? $name[0] : null,
+                'last_name'  => is_array( $name ) ? $name[1] : null,
+                'phone'      => self::getPhone( $form_tags ),
+            )
         );
     }
 


### PR DESCRIPTION
## Summary
Reference per-integration conversion. Contact Form 7 moves to the instance + `Signals` model and no longer knows about CAPI/Pixel or where the browser code goes.

- `inject_pixel_code()` (instance) declares the event once:
  `$this->signals->on('wpcf7_submit', 'Lead', [$this,'read_form_data'], new AjaxFilterDelivery('wpcf7_feedback_response','fb_pxl_code'), self::TRACKING_NAME, 10, 2)` and registers the front-end listener.
- `read_form_data()` is a pure provider returning `EventData` (via the injected `EventDataBuilder`) or `null` to skip.
- The split `trackServerEvent`/`injectLeadEvent` methods are removed — `Signals` + `AjaxFilterDelivery` own server-vs-browser + placement.
- Test injects a **mock `Signals`** and asserts the registered event + extracted `EventData` — the mockability that motivated this refactor.

## Series
1. dispatch foundation (#158)
2. instance wiring (#159)
3. **convert Contact Form 7 ← this PR**
4. WPForms → Ninja → Formidable → Caldera → WooCommerce → EDD → WP-eComm → Mailchimp
5. remove the singleton

## Test plan
- `phpunit __tests__` → 250 passing; `phpcs` clean.