### PR TITLE
Signals refactor (3/3): convert remaining integrations + entry-point rename

### DIFF
--- a/__tests__/core/FacebookWordpressPixelInjectionTest.php
+++ b/__tests__/core/FacebookWordpressPixelInjectionTest.php
@@ -68,8 +68,8 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
    * inject_pixel_code and inject_pixel_noscript_code methods. Also verifies
    * that the sendServerEvents method is not added as an action.
    *
-   * Checks that each integration injects the correct Pixel code by verifying
-   * that the inject_pixel_code method is called on each integration class.
+   * Checks that each integration sets up its tracking by verifying that the
+   * set_up_tracking method is called on each integration class.
    *
    * @return void
    */
@@ -85,13 +85,13 @@ final class FacebookWordpressPixelInjectionTest extends FacebookWordpressTestBas
       array( $injection_obj, 'inject_pixel_noscript_code' )
     );
 
-    // Integrations are now instantiated and inject_pixel_code() is called on
+    // Integrations are now instantiated and set_up_tracking() is called on
     // the instance, so overload each class and expect the instance call.
     foreach ( self::$integrations as $index => $integration ) {
       $mock = \Mockery::mock(
         'overload:FacebookPixelPlugin\\Integration\\' . $integration
       );
-      $mock->shouldReceive( 'inject_pixel_code' )->once();
+      $mock->shouldReceive( 'set_up_tracking' )->once();
     }
 
     \WP_Mock::expectActionNotAdded(

--- a/__tests__/integration/FacebookWordpressCalderaFormTest.php
+++ b/__tests__/integration/FacebookWordpressCalderaFormTest.php
@@ -2,15 +2,7 @@
 /**
  * Facebook Pixel Plugin FacebookWordpressCalderaFormTest class.
  *
- * This file contains the main logic for FacebookWordpressCalderaFormTest.
- *
  * @package FacebookPixelPlugin
- */
-
-/**
- * Define FacebookWordpressCalderaFormTest class.
- *
- * @return void
  */
 
 /*
@@ -27,380 +19,131 @@
 
 namespace FacebookPixelPlugin\Tests\Integration;
 
+use FacebookPixelPlugin\Core\Signals;
+use FacebookPixelPlugin\Core\EventData;
+use FacebookPixelPlugin\Core\EventDataBuilder;
+use FacebookPixelPlugin\Core\AjaxHtmlDelivery;
 use FacebookPixelPlugin\Integration\FacebookWordpressCalderaForm;
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
-use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
-use FacebookPixelPlugin\FacebookAds\Object\ServerSide\UserData;
 
 /**
  * FacebookWordpressCalderaFormTest class.
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
- *
- * All tests in this test class should be run in separate PHP process to
- * make sure tests are isolated.
- * Stop preserving global state from the parent process.
  */
 final class FacebookWordpressCalderaFormTest extends FacebookWordpressTestBase {
+
   /**
-   * Tests that the inject_pixel_code method adds the
-   * correct hooks to WordPress
-   * and that no events are tracked after calling the method.
+   * Builds a Caldera integration with a mock Signals + real builder.
    *
-   * @return void
+   * @return array [ FacebookWordpressCalderaForm, Signals mock ]
    */
-  public function testInjectPixelCode() {
-    \WP_Mock::expectActionAdded(
-      'caldera_forms_ajax_return',
-      array( FacebookWordpressCalderaForm::class, 'injectLeadEvent' ),
-      10,
-      2
+  private function makeIntegration() {
+    $signals     = $this->createMock( Signals::class );
+    $integration = new FacebookWordpressCalderaForm(
+      $signals,
+      new EventDataBuilder()
     );
-
-    FacebookWordpressCalderaForm::inject_pixel_code();
-    $this->assertHooksAdded();
-
-    $this->assertCount(
-      0,
-      FacebookServerSideEvent::get_instance()->get_tracked_events()
-    );
+    return array( $integration, $signals );
   }
 
   /**
-   * Tests the injectLeadEvent method for a non-internal user
-   * when the form submission is complete.
+   * A Caldera form fixture whose fields map to $_POST values.
    *
-   * This test checks that the Pixel code is correctly
-   * appended to the HTML output
-   * when the form submission status is 'complete' and the
-   * user is not an internal user.
-   * It verifies that the output HTML contains the
-   * expected Pixel code pattern.
-   *
-   * @return void
+   * @return array
    */
-  public function testInjectLeadEventWithoutInternalUserAndSubmitted() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-    $mock_out = array(
-      'status' => 'complete',
-      'html'   => 'successful submitted',
-    );
-
-        \WP_Mock::userFunction(
-            'sanitize_text_field',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-        \WP_Mock::userFunction(
-            'wp_json_encode',
-            array(
-        'args'   => array(
-          \Mockery::type( 'array' ),
-          \Mockery::type( 'int' ),
-        ),
-        'return' => function ( $data, $options ) {
-          return json_encode( $data );
-        },
-            )
-        );
-
-    $out = FacebookWordpressCalderaForm::injectLeadEvent( $mock_out, null );
-
-    $this->assertArrayHasKey( 'html', $out );
-    $code = $out['html'];
-    $this->assertMatchesRegularExpression(
-      '/caldera-forms[\s\S]+End Meta Pixel Event Code/',
-      $code
-    );
-  }
-
-  /**
-   * Tests the injectLeadEvent method for a non-internal user
-     * when the form submission is not complete.
-   *
-   * This test checks that the Pixel code is not appended to the HTML output
-   * when the form submission status is not 'complete'
-     * and the user is not an internal user.
-   * It verifies that the output HTML is not modified
-     * and the server-side event tracking list is empty.
-   *
-   * @return void
-   */
-  public function testInjectLeadEventWithoutInternalUserAndNotSubmitted() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-    $mock_out  = array(
-      'status' => 'preprocess',
-      'html'   => 'fail to submit form',
-    );
-    $mock_form = array();
-
-    $out = FacebookWordpressCalderaForm::injectLeadEvent(
-            $mock_out,
-            $mock_form
-        );
-
-    $this->assertArrayHasKey( 'html', $out );
-    $code = $out['html'];
-    $this->assertEquals( 'fail to submit form', $code );
-
-    $this->assertCount(
-      0,
-      FacebookServerSideEvent::get_instance()->get_tracked_events()
-    );
-  }
-
-  /**
-   * Tests the injectLeadEvent method for an internal
-     * user when the form submission is complete.
-   *
-   * This test verifies that no Pixel code is
-     * appended to the HTML output
-   * when the user is an internal user, even if the form
-     * submission status is 'complete'.
-   * It asserts that the output HTML
-     * remains unchanged and that no events are tracked.
-   *
-   * @return void
-   */
-  public function testInjectLeadEventWithInternalUser() {
-    self::mockIsInternalUser( true );
-    self::mockFacebookWordpressOptions();
-    $mock_out  = array(
-      'status' => 'complete',
-      'html'   => 'successful submitted',
-    );
-    $mock_form = array();
-
-    $out = FacebookWordpressCalderaForm::injectLeadEvent(
-            $mock_out,
-            $mock_form
-        );
-
-    $this->assertArrayHasKey( 'html', $out );
-    $code = $out['html'];
-    $this->assertEquals( 'successful submitted', $code );
-
-    $this->assertCount(
-      0,
-      FacebookServerSideEvent::get_instance()->get_tracked_events()
-    );
-  }
-
-  /**
-   * Tests the injectLeadEvent method when the form submission
-     * is complete and the user is not an internal user.
-   *
-   * This test verifies that the Pixel code is appended to the HTML output
-   * and that the server-side event is tracked with the correct parameters.
-   */
-  public function testSendLeadEventViaServerAPISuccessWithoutInternalUser() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-    $mock_out                = array(
-      'status' => 'complete',
-      'html'   => 'successful submitted',
-    );
-    $mock_form               = self::createMockForm();
-    $_SERVER['HTTP_REFERER'] = 'TEST_REFERER';
-
-        \WP_Mock::userFunction(
-            'sanitize_text_field',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-        \WP_Mock::userFunction(
-            'wp_unslash',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-        \WP_Mock::userFunction(
-            'wp_json_encode',
-            array(
-        'args'   => array(
-          \Mockery::type( 'array' ),
-          \Mockery::type( 'int' ),
-        ),
-        'return' => function ( $data, $options ) {
-          return json_encode( $data );
-        },
-            )
-        );
-
-    $out = FacebookWordpressCalderaForm::injectLeadEvent(
-            $mock_out,
-            $mock_form
-        );
-
-    $this->assertArrayHasKey( 'html', $out );
-    $code = $out['html'];
-    $this->assertMatchesRegularExpression(
-      '/caldera-forms[\s\S]+End Meta Pixel Event Code/',
-      $code
-    );
-
-    $tracked_events =
-    FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-    $this->assertCount( 1, $tracked_events );
-
-    $event = $tracked_events[0];
-    $this->assertEquals( 'Lead', $event->getEventName() );
-    $this->assertNotNull( $event->getEventTime() );
-    $this->assertEquals(
-            'pika.chu@s2s.com',
-            $event->getUserData()->getEmail()
-        );
-    $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
-    $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
-    $this->assertEquals( '2061234567', $event->getUserData()->getPhone() );
-    $this->assertEquals( 'wa', $event->getUserData()->getState() );
-    $this->assertEquals(
-      'caldera-forms',
-      $event->getCustomData()->getCustomProperty(
-                'fb_integration_tracking'
-            )
-    );
-    $this->assertEquals( 'TEST_REFERER', $event->getEventSourceUrl() );
-  }
-
-  /**
-   * Tests the injectLeadEvent method when the form submission
-     * is not complete and the user is not an internal user.
-   *
-   * This test verifies that no Pixel code is appended to the HTML output and
-   * that no server-side event is tracked when the
-     * form submission status is not 'complete'
-   * and the user is not an internal user.
-   *
-   * @return void
-   */
-  public function testSendLeadEventViaServerAPIFailureWithoutInternalUser() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-    $mock_out  = array(
-      'status' => 'preprocess',
-      'html'   => 'fail to submit form',
-    );
-    $mock_form = array();
-
-    $out = FacebookWordpressCalderaForm::injectLeadEvent(
-            $mock_out,
-            $mock_form
-        );
-
-    $this->assertArrayHasKey( 'html', $out );
-    $code = $out['html'];
-    $this->assertEquals( 'fail to submit form', $code );
-
-    $this->assertCount(
-      0,
-      FacebookServerSideEvent::get_instance()->get_tracked_events()
-    );
-  }
-
-  /**
-   * Tests the injectLeadEvent method when the form
-     * submission is complete and the user is an internal user.
-   *
-   * This test verifies that no Pixel code is appended to the HTML output and
-   * that no server-side event is tracked when the
-     * form submission status is 'complete'
-   * and the user is an internal user.
-   *
-   * @return void
-   */
-  public function testSendLeadEventViaServerAPIFailureWithInternalUser() {
-    self::mockIsInternalUser( true );
-    self::mockFacebookWordpressOptions();
-    $mock_out  = array(
-      'status' => 'complete',
-      'html'   => 'successful submitted',
-    );
-    $mock_form = array();
-
-    $s2s_spy = \Mockery::spy( FacebookServerSideEvent::class );
-
-    $out = FacebookWordpressCalderaForm::injectLeadEvent(
-            $mock_out,
-            $mock_form
-        );
-
-    $this->assertArrayHasKey( 'html', $out );
-    $code = $out['html'];
-    $this->assertEquals( 'successful submitted', $code );
-
-    $this->assertCount(
-      0,
-      FacebookServerSideEvent::get_instance()->get_tracked_events()
-    );
-  }
-
-  /**
-   * Creates a mock form data array with email, first name,
-     * last name, phone, and state fields populated.
-   *
-   * @return array a mock form data array
-   */
-  private static function createMockForm() {
-    $email_field = array(
-      'ID'   => 'fld_1',
-      'type' => 'email',
-    );
-
-    $first_name_field = array(
-      'ID'   => 'fld_2',
-      'slug' => 'first_name',
-    );
-
-    $last_name_field = array(
-      'ID'   => 'fld_3',
-      'slug' => 'last_name',
-    );
-
-    $phone = array(
-      'ID'   => 'fld_4',
-      'type' => 'phone',
-    );
-
-    $state_field = array(
-      'ID'   => 'fld_5',
-      'type' => 'states',
-    );
-
-    $_POST['fld_1'] = 'pika.chu@s2s.com';
-    $_POST['fld_2'] = 'Pika';
-    $_POST['fld_3'] = 'Chu';
-    $_POST['fld_4'] = '(206)123-4567';
-    $_POST['fld_5'] = 'WA';
-
+  private function form() {
+    $_POST['fld1'] = 'pika.chu@s2s.com';
+    $_POST['fld2'] = 'Pika';
+    $_POST['fld3'] = 'Chu';
+    $_POST['fld4'] = '123456';
+    $_POST['fld5'] = 'Ohio';
     return array(
+      'ID'     => 'cf1',
       'fields' => array(
-        $email_field,
-        $first_name_field,
-        $last_name_field,
-        $phone,
-        $state_field,
+        array( 'ID' => 'fld1', 'type' => 'email' ),
+        array( 'ID' => 'fld2', 'slug' => 'first_name' ),
+        array( 'ID' => 'fld3', 'slug' => 'last_name' ),
+        array( 'ID' => 'fld4', 'type' => 'phone' ),
+        array( 'ID' => 'fld5', 'type' => 'states' ),
       ),
+    );
+  }
+
+  /**
+   * inject_pixel_code registers the Lead event with an AjaxHtmlDelivery.
+   *
+   * @return void
+   */
+  public function testInjectPixelCodeRegistersEvent() {
+    list( $integration, $signals ) = $this->makeIntegration();
+
+    $signals->expects( $this->once() )
+      ->method( 'on' )
+      ->with(
+        'caldera_forms_ajax_return',
+        'Lead',
+        $this->isType( 'callable' ),
+        $this->isInstanceOf( AjaxHtmlDelivery::class ),
+        'caldera-forms',
+        10,
+        2
+      );
+
+    $integration->inject_pixel_code();
+
+    $this->assertConditionsMet();
+  }
+
+  /**
+   * read_form_data extracts $_POST values for a completed submission.
+   *
+   * @return void
+   */
+  public function testReadFormDataReturnsEventData() {
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+
+    list( $integration ) = $this->makeIntegration();
+
+    $data = $integration->read_form_data(
+      array( 'status' => 'complete' ),
+      $this->form()
+    );
+
+    $this->assertInstanceOf( EventData::class, $data );
+    $this->assertEquals(
+      array(
+        'email'      => 'pika.chu@s2s.com',
+        'first_name' => 'Pika',
+        'last_name'  => 'Chu',
+        'phone'      => '123456',
+        'state'      => 'Ohio',
+      ),
+      $data->to_array()
+    );
+  }
+
+  /**
+   * read_form_data returns null when the submission is not complete.
+   *
+   * @return void
+   */
+  public function testReadFormDataSkipsWhenNotComplete() {
+    list( $integration ) = $this->makeIntegration();
+
+    $this->assertNull(
+      $integration->read_form_data(
+        array( 'status' => 'preprocess' ),
+        $this->form()
+      )
     );
   }
 }

--- a/__tests__/integration/FacebookWordpressCalderaFormTest.php
+++ b/__tests__/integration/FacebookWordpressCalderaFormTest.php
@@ -20,14 +20,20 @@
 namespace FacebookPixelPlugin\Tests\Integration;
 
 use FacebookPixelPlugin\Core\Signals;
-use FacebookPixelPlugin\Core\EventData;
 use FacebookPixelPlugin\Core\EventDataBuilder;
 use FacebookPixelPlugin\Core\AjaxHtmlDelivery;
+use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 use FacebookPixelPlugin\Integration\FacebookWordpressCalderaForm;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 
 /**
  * FacebookWordpressCalderaFormTest class.
+ *
+ * These tests assert the same observable behavior as before the Signals
+ * refactor: a completed Caldera submission tracks a Lead server-side event
+ * carrying the correct user data. The only change is the entry point — the
+ * read_form_data data provider plus the real Signals dispatch path instead of
+ * the old injectLeadEvent static method.
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
@@ -35,12 +41,13 @@ use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 final class FacebookWordpressCalderaFormTest extends FacebookWordpressTestBase {
 
   /**
-   * Builds a Caldera integration with a mock Signals + real builder.
+   * Builds a Caldera integration wired to a real Signals dispatcher, so a
+   * dispatched event actually tracks through FacebookServerSideEvent.
    *
-   * @return array [ FacebookWordpressCalderaForm, Signals mock ]
+   * @return array [ FacebookWordpressCalderaForm, Signals ]
    */
   private function makeIntegration() {
-    $signals     = $this->createMock( Signals::class );
+    $signals     = new Signals();
     $integration = new FacebookWordpressCalderaForm(
       $signals,
       new EventDataBuilder()
@@ -49,101 +56,207 @@ final class FacebookWordpressCalderaFormTest extends FacebookWordpressTestBase {
   }
 
   /**
-   * A Caldera form fixture whose fields map to $_POST values.
-   *
-   * @return array
-   */
-  private function form() {
-    $_POST['fld1'] = 'pika.chu@s2s.com';
-    $_POST['fld2'] = 'Pika';
-    $_POST['fld3'] = 'Chu';
-    $_POST['fld4'] = '123456';
-    $_POST['fld5'] = 'Ohio';
-    return array(
-      'ID'     => 'cf1',
-      'fields' => array(
-        array( 'ID' => 'fld1', 'type' => 'email' ),
-        array( 'ID' => 'fld2', 'slug' => 'first_name' ),
-        array( 'ID' => 'fld3', 'slug' => 'last_name' ),
-        array( 'ID' => 'fld4', 'type' => 'phone' ),
-        array( 'ID' => 'fld5', 'type' => 'states' ),
-      ),
-    );
-  }
-
-  /**
-   * set_up_tracking registers the Lead event with an AjaxHtmlDelivery.
+   * Stubs the JSON/sanitize helpers the dispatch/read path relies on.
    *
    * @return void
    */
-  public function testInjectPixelCodeRegistersEvent() {
-    list( $integration, $signals ) = $this->makeIntegration();
-
-    $signals->expects( $this->once() )
-      ->method( 'on' )
-      ->with(
-        'caldera_forms_ajax_return',
-        'Lead',
-        $this->isType( 'callable' ),
-        $this->isInstanceOf( AjaxHtmlDelivery::class ),
-        'caldera-forms',
-        10,
-        2
-      );
-
-    $integration->set_up_tracking();
-
-    $this->assertConditionsMet();
-  }
-
-  /**
-   * read_form_data extracts $_POST values for a completed submission.
-   *
-   * @return void
-   */
-  public function testReadFormDataReturnsEventData() {
+  private function mockRenderHelpers() {
     \WP_Mock::userFunction(
       'sanitize_text_field',
       array(
+        'args'   => array( \Mockery::any() ),
         'return' => function ( $input ) {
           return $input;
         },
       )
     );
-
-    list( $integration ) = $this->makeIntegration();
-
-    $data = $integration->read_form_data(
-      array( 'status' => 'complete' ),
-      $this->form()
-    );
-
-    $this->assertInstanceOf( EventData::class, $data );
-    $this->assertEquals(
+    \WP_Mock::userFunction(
+      'wp_json_encode',
       array(
-        'email'      => 'pika.chu@s2s.com',
-        'first_name' => 'Pika',
-        'last_name'  => 'Chu',
-        'phone'      => '123456',
-        'state'      => 'Ohio',
-      ),
-      $data->to_array()
+        'args'   => array( \Mockery::type( 'array' ), \Mockery::type( 'int' ) ),
+        'return' => function ( $data, $options ) {
+          return json_encode( $data );
+        },
+      )
     );
   }
 
   /**
-   * read_form_data returns null when the submission is not complete.
+   * Builds a mock Caldera form definition and populates the matching $_POST
+   * field values, mirroring a completed submission.
+   *
+   * @return array The Caldera form data array.
+   */
+  private static function createMockForm() {
+    $email_field = array(
+      'ID'   => 'fld_1',
+      'type' => 'email',
+    );
+
+    $first_name_field = array(
+      'ID'   => 'fld_2',
+      'slug' => 'first_name',
+    );
+
+    $last_name_field = array(
+      'ID'   => 'fld_3',
+      'slug' => 'last_name',
+    );
+
+    $phone = array(
+      'ID'   => 'fld_4',
+      'type' => 'phone',
+    );
+
+    $state_field = array(
+      'ID'   => 'fld_5',
+      'type' => 'states',
+    );
+
+    $_POST['fld_1'] = 'pika.chu@s2s.com';
+    $_POST['fld_2'] = 'Pika';
+    $_POST['fld_3'] = 'Chu';
+    $_POST['fld_4'] = '(206)123-4567';
+    $_POST['fld_5'] = 'WA';
+
+    return array(
+      'fields' => array(
+        $email_field,
+        $first_name_field,
+        $last_name_field,
+        $phone,
+        $state_field,
+      ),
+    );
+  }
+
+  /**
+   * set_up_tracking registers the Lead Signals event on the Caldera AJAX
+   * return hook, using the AJAX HTML delivery.
    *
    * @return void
    */
-  public function testReadFormDataSkipsWhenNotComplete() {
+  public function testSetUpTrackingRegistersLeadSignal() {
+    $signals     = $this->createMock( Signals::class );
+    $integration = new FacebookWordpressCalderaForm(
+      $signals,
+      new EventDataBuilder()
+    );
+
+    $delivery = null;
+    $signals->expects( $this->once() )
+      ->method( 'on' )
+      ->willReturnCallback(
+        function ( $hook, $event, $provider, $del ) use ( &$delivery ) {
+          $this->assertEquals( 'caldera_forms_ajax_return', $hook );
+          $this->assertEquals( 'Lead', $event );
+          $delivery = $del;
+        }
+      );
+
+    $integration->set_up_tracking();
+
+    $this->assertInstanceOf( AjaxHtmlDelivery::class, $delivery );
+  }
+
+  /**
+   * A completed submission tracks a Lead server event with the submitter's
+   * user data, dispatched through the real Signals path.
+   *
+   * @return void
+   */
+  public function testLeadEventWithoutInternalUser() {
+    self::mockIsInternalUser( false );
+    self::mockFacebookWordpressOptions();
+    $this->mockRenderHelpers();
+
+    $_SERVER['HTTP_REFERER'] = 'TEST_REFERER';
+
+    $out  = array(
+      'status' => 'complete',
+      'html'   => 'successful submitted',
+    );
+    $form = self::createMockForm();
+
+    list( $integration, $signals ) = $this->makeIntegration();
+
+    $data = $integration->read_form_data( $out, $form );
+    $signals->dispatch(
+      'Lead',
+      $data,
+      FacebookWordpressCalderaForm::TRACKING_NAME
+    );
+
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 1, $tracked_events );
+
+    $event = $tracked_events[0];
+    $this->assertEquals( 'Lead', $event->getEventName() );
+    $this->assertNotNull( $event->getEventTime() );
+
+    $user_data = $event->getUserData();
+    $this->assertEquals( 'pika.chu@s2s.com', $user_data->getEmail() );
+    $this->assertEquals( 'pika', $user_data->getFirstName() );
+    $this->assertEquals( 'chu', $user_data->getLastName() );
+    $this->assertEquals( '2061234567', $user_data->getPhone() );
+    $this->assertEquals( 'wa', $user_data->getState() );
+
+    $this->assertEquals(
+      'caldera-forms',
+      $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
+    );
+    $this->assertEquals( 'TEST_REFERER', $event->getEventSourceUrl() );
+  }
+
+  /**
+   * read_form_data returns null (nothing to dispatch) when the submission is
+   * not complete, so no server event is tracked.
+   *
+   * @return void
+   */
+  public function testReadFormDataReturnsNullWhenNotComplete() {
+    self::mockIsInternalUser( false );
+    self::mockFacebookWordpressOptions();
+
+    $out  = array(
+      'status' => 'preprocess',
+      'html'   => 'fail to submit form',
+    );
+    $form = self::createMockForm();
+
     list( $integration ) = $this->makeIntegration();
 
-    $this->assertNull(
-      $integration->read_form_data(
-        array( 'status' => 'preprocess' ),
-        $this->form()
-      )
+    $this->assertNull( $integration->read_form_data( $out, $form ) );
+
+    $this->assertCount(
+      0,
+      FacebookServerSideEvent::get_instance()->get_tracked_events()
+    );
+  }
+
+  /**
+   * read_form_data returns null when the form data is empty, even for a
+   * completed submission.
+   *
+   * @return void
+   */
+  public function testReadFormDataReturnsNullWhenFormEmpty() {
+    self::mockIsInternalUser( false );
+    self::mockFacebookWordpressOptions();
+
+    $out = array(
+      'status' => 'complete',
+      'html'   => 'successful submitted',
+    );
+
+    list( $integration ) = $this->makeIntegration();
+
+    $this->assertNull( $integration->read_form_data( $out, array() ) );
+
+    $this->assertCount(
+      0,
+      FacebookServerSideEvent::get_instance()->get_tracked_events()
     );
   }
 }

--- a/__tests__/integration/FacebookWordpressCalderaFormTest.php
+++ b/__tests__/integration/FacebookWordpressCalderaFormTest.php
@@ -72,7 +72,7 @@ final class FacebookWordpressCalderaFormTest extends FacebookWordpressTestBase {
   }
 
   /**
-   * inject_pixel_code registers the Lead event with an AjaxHtmlDelivery.
+   * set_up_tracking registers the Lead event with an AjaxHtmlDelivery.
    *
    * @return void
    */
@@ -91,7 +91,7 @@ final class FacebookWordpressCalderaFormTest extends FacebookWordpressTestBase {
         2
       );
 
-    $integration->inject_pixel_code();
+    $integration->set_up_tracking();
 
     $this->assertConditionsMet();
   }

--- a/__tests__/integration/FacebookWordpressContactForm7Test.php
+++ b/__tests__/integration/FacebookWordpressContactForm7Test.php
@@ -83,7 +83,7 @@ final class FacebookWordpressContactForm7Test extends FacebookWordpressTestBase 
   }
 
   /**
-   * inject_pixel_code registers the Lead event on Signals (with the AJAX
+   * set_up_tracking registers the Lead event on Signals (with the AJAX
    * delivery) and the front-end mail-sent listener.
    *
    * @return void
@@ -114,7 +114,7 @@ final class FacebookWordpressContactForm7Test extends FacebookWordpressTestBase 
       2
     );
 
-    $integration->inject_pixel_code();
+    $integration->set_up_tracking();
 
     $this->assertConditionsMet();
   }

--- a/__tests__/integration/FacebookWordpressEasyDigitalDownloadsTest.php
+++ b/__tests__/integration/FacebookWordpressEasyDigitalDownloadsTest.php
@@ -20,13 +20,19 @@
 namespace FacebookPixelPlugin\Tests\Integration;
 
 use FacebookPixelPlugin\Core\Signals;
-use FacebookPixelPlugin\Core\EventData;
 use FacebookPixelPlugin\Core\EventDataBuilder;
+use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 use FacebookPixelPlugin\Integration\FacebookWordpressEasyDigitalDownloads;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 
 /**
  * FacebookWordpressEasyDigitalDownloadsTest class.
+ *
+ * These tests assert the same observable behavior as before the Signals
+ * refactor: driving an event through the integration tracks a server-side
+ * event with the correct user/custom data (and the shared event id for the
+ * AJAX add-to-cart). The only change is the entry point — the data provider
+ * plus the real Signals dispatch path.
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
@@ -34,12 +40,12 @@ use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 final class FacebookWordpressEasyDigitalDownloadsTest extends FacebookWordpressTestBase {
 
   /**
-   * Builds an EDD integration with a mock Signals + real builder.
+   * Builds an EDD integration wired to a real Signals dispatcher.
    *
-   * @return array [ FacebookWordpressEasyDigitalDownloads, Signals mock ]
+   * @return array [ FacebookWordpressEasyDigitalDownloads, Signals ]
    */
   private function makeIntegration() {
-    $signals     = $this->createMock( Signals::class );
+    $signals     = new Signals();
     $integration = new FacebookWordpressEasyDigitalDownloads(
       $signals,
       new EventDataBuilder()
@@ -48,29 +54,65 @@ final class FacebookWordpressEasyDigitalDownloadsTest extends FacebookWordpressT
   }
 
   /**
-   * Alias-mocks the plugin utils + EDD helpers used by the create* builders,
-   * and stubs the WordPress functions the AddToCart/ViewContent path needs.
+   * Mocks the current user, plugin options, and the JSON/sanitize helpers the
+   * dispatch/render path relies on. Adds the logged-in user PII used by the
+   * cart/product event builders.
    *
    * @return void
    */
-  private function setupProductMocks() {
-    $utils = \Mockery::mock(
-      'alias:FacebookPixelPlugin\Core\FacebookPluginUtils'
-    );
-    $utils->shouldReceive( 'get_logged_in_user_info' )->andReturn(
+  private function setupUserAndOptions() {
+    self::mockIsInternalUser( false );
+    self::mockFacebookWordpressOptions();
+
+    $this->mocked_fbpixel->shouldReceive( 'get_logged_in_user_info' )
+      ->andReturn(
+        array(
+          'email'      => 'pika.chu@s2s.com',
+          'first_name' => 'Pika',
+          'last_name'  => 'Chu',
+        )
+      );
+
+    \WP_Mock::userFunction(
+      'wp_json_encode',
       array(
-        'email'      => 'pika.chu@s2s.com',
-        'first_name' => 'Pika',
-        'last_name'  => 'Chu',
+        'args'   => array( \Mockery::type( 'array' ), \Mockery::type( 'int' ) ),
+        'return' => function ( $data, $options ) {
+          return json_encode( $data );
+        },
       )
     );
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+  }
 
+  /**
+   * Alias-mocks EDDUtils currency + cart-total helpers.
+   *
+   * @return void
+   */
+  private function setupEddUtils() {
     $edd_utils = \Mockery::mock(
       'alias:FacebookPixelPlugin\Integration\EDDUtils'
     );
     $edd_utils->shouldReceive( 'get_currency' )->andReturn( 'USD' );
     $edd_utils->shouldReceive( 'get_cart_total' )->andReturn( 300 );
+  }
 
+  /**
+   * Mocks the download product lookups used by the AddToCart/ViewContent
+   * builders.
+   *
+   * @return void
+   */
+  private function setupProduct() {
     $download             = new \stdClass();
     $download->post_title = 'Encarta';
     \WP_Mock::userFunction(
@@ -89,7 +131,11 @@ final class FacebookWordpressEasyDigitalDownloadsTest extends FacebookWordpressT
    * @return void
    */
   public function testInjectPixelCodeRegistersFiveSignalEvents() {
-    list( $integration, $signals ) = $this->makeIntegration();
+    $signals     = $this->createMock( Signals::class );
+    $integration = new FacebookWordpressEasyDigitalDownloads(
+      $signals,
+      new EventDataBuilder()
+    );
 
     $signals->expects( $this->exactly( 5 ) )->method( 'on' );
 
@@ -104,42 +150,53 @@ final class FacebookWordpressEasyDigitalDownloadsTest extends FacebookWordpressT
   }
 
   /**
-   * read_initiate_checkout builds an InitiateCheckout EventData.
+   * A dispatched InitiateCheckout tracks the event with cart totals.
    *
    * @return void
    */
-  public function testReadInitiateCheckoutReturnsEventData() {
+  public function testInitiateCheckoutEventWithoutInternalUser() {
+    $this->setupUserAndOptions();
+    $this->setupEddUtils();
     \WP_Mock::userFunction( 'EDD' );
-    $this->setupProductMocks();
 
-    list( $integration ) = $this->makeIntegration();
+    list( $integration, $signals ) = $this->makeIntegration();
 
     $data = $integration->read_initiate_checkout();
+    $signals->dispatch(
+      'InitiateCheckout',
+      $data,
+      FacebookWordpressEasyDigitalDownloads::TRACKING_NAME
+    );
 
-    $this->assertInstanceOf( EventData::class, $data );
-    $fields = $data->to_array();
-    $this->assertEquals( 'pika.chu@s2s.com', $fields['email'] );
-    $this->assertEquals( 'USD', $fields['currency'] );
-    $this->assertEquals( 300, $fields['value'] );
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 1, $tracked_events );
+
+    $event = $tracked_events[0];
+    $this->assertEquals( 'InitiateCheckout', $event->getEventName() );
+    $this->assertNotNull( $event->getEventTime() );
+    $this->assertEquals(
+      'pika.chu@s2s.com',
+      $event->getUserData()->getEmail()
+    );
+    $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
+    $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
+    $this->assertEquals( 'USD', $event->getCustomData()->getCurrency() );
+    $this->assertEquals( '300', $event->getCustomData()->getValue() );
+    $this->assertEquals(
+      'easy-digital-downloads',
+      $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
+    );
   }
 
   /**
-   * read_initiate_checkout returns null when EDD is not loaded.
+   * A dispatched Purchase tracks the event with order data.
    *
    * @return void
    */
-  public function testReadInitiateCheckoutSkipsWithoutEdd() {
-    list( $integration ) = $this->makeIntegration();
+  public function testPurchaseEventWithoutInternalUser() {
+    $this->setupUserAndOptions();
 
-    $this->assertNull( $integration->read_initiate_checkout() );
-  }
-
-  /**
-   * read_purchase builds a Purchase EventData from the payment meta.
-   *
-   * @return void
-   */
-  public function testReadPurchaseReturnsEventData() {
     \WP_Mock::userFunction(
       'edd_get_payment_meta',
       array(
@@ -164,135 +221,142 @@ final class FacebookWordpressEasyDigitalDownloadsTest extends FacebookWordpressT
       )
     );
 
-    list( $integration ) = $this->makeIntegration();
+    list( $integration, $signals ) = $this->makeIntegration();
 
     $payment     = new \stdClass();
     $payment->ID = 1;
 
     $data = $integration->read_purchase( $payment, null );
+    $signals->dispatch(
+      'Purchase',
+      $data,
+      FacebookWordpressEasyDigitalDownloads::TRACKING_NAME
+    );
 
-    $this->assertInstanceOf( EventData::class, $data );
-    $fields = $data->to_array();
-    $this->assertEquals( 'pika.chu@s2s.com', $fields['email'] );
-    $this->assertEquals( 700, $fields['value'] );
-    $this->assertEquals( 'USD', $fields['currency'] );
-    $this->assertEquals( array( 99, 999 ), $fields['content_ids'] );
-    $this->assertEquals( 'product', $fields['content_type'] );
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 1, $tracked_events );
+
+    $event = $tracked_events[0];
+    $this->assertEquals( 'Purchase', $event->getEventName() );
+    $this->assertNotNull( $event->getEventTime() );
+    $this->assertEquals(
+      'pika.chu@s2s.com',
+      $event->getUserData()->getEmail()
+    );
+    $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
+    $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
+    $this->assertEquals( 'USD', $event->getCustomData()->getCurrency() );
+    $this->assertEquals( 700, $event->getCustomData()->getValue() );
+    $this->assertEquals( 'product', $event->getCustomData()->getContentType() );
+    $this->assertEquals(
+      array( 99, 999 ),
+      $event->getCustomData()->getContentIds()
+    );
+    $this->assertEquals(
+      'easy-digital-downloads',
+      $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
+    );
   }
 
   /**
-   * read_purchase returns null when the payment has no ID.
+   * A dispatched ViewContent tracks the event with product data.
    *
    * @return void
    */
-  public function testReadPurchaseSkipsWithoutPaymentId() {
-    list( $integration ) = $this->makeIntegration();
+  public function testViewContentEventWithoutInternalUser() {
+    $this->setupUserAndOptions();
+    $this->setupEddUtils();
+    $this->setupProduct();
 
-    $payment     = new \stdClass();
-    $payment->ID = 0;
-
-    $this->assertNull( $integration->read_purchase( $payment, null ) );
-  }
-
-  /**
-   * read_view_content builds a ViewContent EventData for a download.
-   *
-   * @return void
-   */
-  public function testReadViewContentReturnsEventData() {
-    $this->setupProductMocks();
-
-    list( $integration ) = $this->makeIntegration();
+    list( $integration, $signals ) = $this->makeIntegration();
 
     $data = $integration->read_view_content( 1234 );
+    $signals->dispatch(
+      'ViewContent',
+      $data,
+      FacebookWordpressEasyDigitalDownloads::TRACKING_NAME
+    );
 
-    $this->assertInstanceOf( EventData::class, $data );
-    $fields = $data->to_array();
-    $this->assertEquals( array( '1234' ), $fields['content_ids'] );
-    $this->assertEquals( 'product', $fields['content_type'] );
-    $this->assertEquals( 'USD', $fields['currency'] );
-    $this->assertEquals( 'Encarta', $fields['content_name'] );
-    $this->assertEquals( 50, $fields['value'] );
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 1, $tracked_events );
+
+    $event       = $tracked_events[0];
+    $custom_data = $event->getCustomData();
+    $user_data   = $event->getUserData();
+
+    $this->assertEquals( 'ViewContent', $event->getEventName() );
+    $this->assertNotNull( $event->getEventTime() );
+    $this->assertEquals( 'pika.chu@s2s.com', $user_data->getEmail() );
+    $this->assertEquals( 'pika', $user_data->getFirstName() );
+    $this->assertEquals( 'chu', $user_data->getLastName() );
+    $this->assertEquals( array( '1234' ), $custom_data->getContentIds() );
+    $this->assertEquals( 'product', $custom_data->getContentType() );
+    $this->assertEquals( 'USD', $custom_data->getCurrency() );
+    $this->assertEquals( 'Encarta', $custom_data->getContentName() );
+    $this->assertEquals( 50, $custom_data->getValue() );
   }
 
   /**
-   * read_view_content returns null without a download id.
+   * A dispatched AJAX AddToCart tracks the event with the shared event id and
+   * product data.
    *
    * @return void
    */
-  public function testReadViewContentSkipsWithoutDownloadId() {
-    list( $integration ) = $this->makeIntegration();
-
-    $this->assertNull( $integration->read_view_content( 0 ) );
-  }
-
-  /**
-   * read_add_to_cart verifies the nonce, builds the EventData, and reuses the
-   * shared event id from the posted form data.
-   *
-   * @return void
-   */
-  public function testReadAddToCartReturnsEventDataWithSharedId() {
-    $this->setupProductMocks();
+  public function testAddToCartEventAjaxWithoutInternalUser() {
+    $this->setupUserAndOptions();
+    $this->setupEddUtils();
+    $this->setupProduct();
 
     $_POST['nonce']       = '54321';
     $_POST['download_id'] = '1234';
     $_POST['post_data']   = 'facebook_event_id=abc-123';
 
-    \WP_Mock::userFunction(
-      'absint',
-      array( 'return' => 1234 )
-    );
-    \WP_Mock::userFunction(
-      'sanitize_text_field',
-      array(
-        'return' => function ( $input ) {
-          return $input;
-        },
-      )
-    );
-    \WP_Mock::userFunction(
-      'wp_verify_nonce',
-      array( 'return' => true )
-    );
+    \WP_Mock::userFunction( 'absint', array( 'return' => 1234 ) );
+    \WP_Mock::userFunction( 'wp_verify_nonce', array( 'return' => true ) );
 
-    list( $integration ) = $this->makeIntegration();
+    list( $integration, $signals ) = $this->makeIntegration();
 
     $data = $integration->read_add_to_cart();
+    $signals->dispatch(
+      'AddToCart',
+      $data,
+      FacebookWordpressEasyDigitalDownloads::TRACKING_NAME
+    );
 
-    $this->assertInstanceOf( EventData::class, $data );
-    $this->assertEquals( 'abc-123', $data->get_event_id() );
-    $fields = $data->to_array();
-    $this->assertEquals( array( '1234' ), $fields['content_ids'] );
-    $this->assertEquals( 'product', $fields['content_type'] );
-    $this->assertEquals( 'Encarta', $fields['content_name'] );
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 1, $tracked_events );
+
+    $event       = $tracked_events[0];
+    $custom_data = $event->getCustomData();
+
+    $this->assertEquals( 'AddToCart', $event->getEventName() );
+    $this->assertEquals( 'abc-123', $event->getEventId() );
+    $this->assertNotNull( $event->getEventTime() );
+    $this->assertEquals(
+      'pika.chu@s2s.com',
+      $event->getUserData()->getEmail()
+    );
+    $this->assertEquals( array( '1234' ), $custom_data->getContentIds() );
+    $this->assertEquals( 'product', $custom_data->getContentType() );
+    $this->assertEquals( 'USD', $custom_data->getCurrency() );
+    $this->assertEquals( 'Encarta', $custom_data->getContentName() );
+    $this->assertEquals( 50, $custom_data->getValue() );
   }
 
   /**
-   * read_add_to_cart returns null when the AJAX payload is incomplete.
+   * read_add_to_cart returns null (nothing dispatched) when the nonce fails.
    *
    * @return void
    */
-  public function testReadAddToCartSkipsWithoutPost() {
-    list( $integration ) = $this->makeIntegration();
-
-    $this->assertNull( $integration->read_add_to_cart() );
-  }
-
-  /**
-   * read_add_to_cart returns null when the nonce fails verification.
-   *
-   * @return void
-   */
-  public function testReadAddToCartSkipsOnBadNonce() {
+  public function testAddToCartSkipsOnBadNonce() {
     $_POST['nonce']       = 'bad';
     $_POST['download_id'] = '1234';
     $_POST['post_data']   = 'facebook_event_id=abc-123';
 
-    \WP_Mock::userFunction(
-      'absint',
-      array( 'return' => 1234 )
-    );
+    \WP_Mock::userFunction( 'absint', array( 'return' => 1234 ) );
     \WP_Mock::userFunction(
       'sanitize_text_field',
       array(
@@ -301,10 +365,7 @@ final class FacebookWordpressEasyDigitalDownloadsTest extends FacebookWordpressT
         },
       )
     );
-    \WP_Mock::userFunction(
-      'wp_verify_nonce',
-      array( 'return' => false )
-    );
+    \WP_Mock::userFunction( 'wp_verify_nonce', array( 'return' => false ) );
 
     list( $integration ) = $this->makeIntegration();
 
@@ -312,8 +373,7 @@ final class FacebookWordpressEasyDigitalDownloadsTest extends FacebookWordpressT
   }
 
   /**
-   * inject_add_to_cart_event_id prints the hidden shared-id field for a
-   * non-internal user.
+   * The hidden shared-id field is printed for a non-internal user.
    *
    * @return void
    */
@@ -338,7 +398,7 @@ final class FacebookWordpressEasyDigitalDownloadsTest extends FacebookWordpressT
   }
 
   /**
-   * inject_add_to_cart_event_id prints nothing for an internal user.
+   * The hidden shared-id field is not printed for an internal user.
    *
    * @return void
    */
@@ -353,7 +413,7 @@ final class FacebookWordpressEasyDigitalDownloadsTest extends FacebookWordpressT
   }
 
   /**
-   * inject_add_to_cart_listener enqueues nothing for an internal user.
+   * The AddToCart listener enqueues nothing for an internal user.
    *
    * @return void
    */

--- a/__tests__/integration/FacebookWordpressEasyDigitalDownloadsTest.php
+++ b/__tests__/integration/FacebookWordpressEasyDigitalDownloadsTest.php
@@ -2,16 +2,7 @@
 /**
  * Facebook Pixel Plugin FacebookWordpressEasyDigitalDownloadsTest class.
  *
- * This file contains the main logic
- * for FacebookWordpressEasyDigitalDownloadsTest.
- *
  * @package FacebookPixelPlugin
- */
-
-/**
- * Define FacebookWordpressEasyDigitalDownloadsTest class.
- *
- * @return void
  */
 
 /*
@@ -28,416 +19,45 @@
 
 namespace FacebookPixelPlugin\Tests\Integration;
 
+use FacebookPixelPlugin\Core\Signals;
+use FacebookPixelPlugin\Core\EventData;
+use FacebookPixelPlugin\Core\EventDataBuilder;
 use FacebookPixelPlugin\Integration\FacebookWordpressEasyDigitalDownloads;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 
 /**
  * FacebookWordpressEasyDigitalDownloadsTest class.
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
- *
- * All tests in this test class should be run in separate PHP process to
- * make sure tests are isolated.
- * Stop preserving global state from the parent process.
  */
 final class FacebookWordpressEasyDigitalDownloadsTest extends FacebookWordpressTestBase {
 
   /**
-   * Tests that the inject_pixel_code method correctly sets up the
-   * necessary WordPress hooks for the Facebook Pixel events in
-   * the Easy Digital Downloads integration.
+   * Builds an EDD integration with a mock Signals + real builder.
    *
-   * This test verifies that the appropriate hooks are added for
-   * the 'injectInitiateCheckoutEvent' event with the expected
-   * hook name 'edd_after_checkout_cart'.
-   *
-   * Utilizes the Mockery library to mock the base integration class
-   * and validate that the add_pixel_fire_for_hook method is called with
-   * the correct parameters.
+   * @return array [ FacebookWordpressEasyDigitalDownloads, Signals mock ]
    */
-  public function testInjectPixelCode() {
-    $event_hook_map = array(
-      'injectInitiateCheckoutEvent' => 'edd_after_checkout_cart',
+  private function makeIntegration() {
+    $signals     = $this->createMock( Signals::class );
+    $integration = new FacebookWordpressEasyDigitalDownloads(
+      $signals,
+      new EventDataBuilder()
     );
+    return array( $integration, $signals );
+  }
 
-    $mocked_base = \Mockery::mock(
-      'alias:FacebookPixelPlugin\Integration\FacebookWordpressIntegrationBase'
+  /**
+   * Alias-mocks the plugin utils + EDD helpers used by the create* builders,
+   * and stubs the WordPress functions the AddToCart/ViewContent path needs.
+   *
+   * @return void
+   */
+  private function setupProductMocks() {
+    $utils = \Mockery::mock(
+      'alias:FacebookPixelPlugin\Core\FacebookPluginUtils'
     );
-    foreach ( $event_hook_map as $event => $hook ) {
-      $mocked_base->shouldReceive( 'add_pixel_fire_for_hook' )
-      ->with(
-        array(
-          'hook_name'       => $hook,
-          'classname'       =>
-                    FacebookWordpressEasyDigitalDownloads::class,
-          'inject_function' => $event,
-        )
-      )
-      ->once();
-    }
-
-    FacebookWordpressEasyDigitalDownloads::inject_pixel_code();
-  }
-
-  /**
-   * Tests that the injectAddToCartEventId method injects the correct
-   * hidden input field when the user is not an internal user.
-   *
-   * This test verifies that the hidden input field is correctly injected
-   * into the HTML output when the user is not an internal user
-   * and the injectAddToCartEventId method is called.
-   */
-  public function testInjectAddToCartEventIdWithoutInternalUser() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-    FacebookWordpressEasyDigitalDownloads::injectAddToCartEventId();
-    $this->expectOutputRegex(
-      '/input type="hidden" name="facebook_event_id"/'
-    );
-  }
-
-  /**
-   * Tests that the injectInitiateCheckoutEvent method correctly injects
-   * the Pixel code for the 'InitiateCheckout' event when the user is
-   * not an internal user.
-   *
-   * This test verifies that the output contains the expected Meta Pixel
-   * Event Code for Easy Digital Downloads and that the server-side event
-   * tracking records the 'InitiateCheckout' event with the correct user
-   * and custom data attributes.
-   */
-  public function testInitiateCheckoutEventWithoutInternalUser() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-    $this->setupEDDMocks();
-
-        \WP_Mock::userFunction(
-            'wp_json_encode',
-            array(
-        'args'   => array(
-                    \Mockery::type( 'array' ),
-          \Mockery::type( 'int' ),
-        ),
-        'return' => function ( $data, $options ) {
-          return json_encode( $data );
-        },
-            )
-        );
-
-    FacebookWordpressEasyDigitalDownloads::injectInitiateCheckoutEvent();
-
-    $this->expectOutputRegex(
-      '/easy-digital-downloads[\s\S]+End Meta Pixel Event Code/'
-    );
-
-    $tracked_events =
-    FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-    $this->assertCount( 1, $tracked_events );
-
-    $event = $tracked_events[0];
-    $this->assertEquals( 'InitiateCheckout', $event->getEventName() );
-    $this->assertNotNull( $event->getEventTime() );
-    $this->assertEquals(
-            'pika.chu@s2s.com',
-            $event->getUserData()->getEmail()
-        );
-    $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
-    $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
-    $this->assertEquals( 'USD', $event->getCustomData()->getCurrency() );
-    $this->assertEquals( '300', $event->getCustomData()->getValue() );
-    $this->assertEquals(
-      'easy-digital-downloads',
-      $event->getCustomData()->getCustomProperty(
-                'fb_integration_tracking'
-            )
-    );
-  }
-
-  /**
-   * Tests that the trackPurchaseEvent method correctly injects the Pixel code
-   * for the 'Purchase' event when the user is not an internal user.
-   *
-   * This test verifies that the server-side event tracking records the
-   * 'Purchase' event with the correct user and custom data attributes.
-   */
-  public function testPurchaseEventWithoutInternalUser() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-    $this->setupEDDMocks();
-
-    $payment = new class() {
-      /**
-       * Unique ID
-       *
-       * @var integer
-       */
-      public $ID = 1;
-    };
-
-    \WP_Mock::expectActionAdded(
-      'wp_footer',
-      array(
-        'FacebookPixelPlugin\\Integration\\FacebookWordpressEasyDigitalDownloads',
-        'injectPurchaseEvent',
-      ),
-      20
-    );
-
-    FacebookWordpressEasyDigitalDownloads::trackPurchaseEvent(
-            $payment,
-            null
-        );
-
-    $tracked_events =
-    FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-    $this->assertCount( 1, $tracked_events );
-
-    $event = $tracked_events[0];
-    $this->assertEquals( 'Purchase', $event->getEventName() );
-    $this->assertNotNull( $event->getEventTime() );
-    $this->assertEquals(
-            'pika.chu@s2s.com',
-            $event->getUserData()->getEmail()
-        );
-    $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
-    $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
-    $this->assertEquals( 'USD', $event->getCustomData()->getCurrency() );
-    $this->assertEquals( 700, $event->getCustomData()->getValue() );
-    $this->assertEquals(
-            'product',
-            $event->getCustomData()->getContentType()
-        );
-    $this->assertEquals(
-            array( 99, 999 ),
-            $event->getCustomData()->getContentIds()
-        );
-    $this->assertEquals(
-      'easy-digital-downloads',
-      $event->getCustomData()->getCustomProperty(
-                'fb_integration_tracking'
-            )
-    );
-  }
-
-  /**
-   * Tests that the injectAddToCartListener method does not inject
-   * any Pixel code when the user is an internal user.
-   *
-   * This test verifies that the output does not contain any Meta Pixel
-   * Event Code when the injectAddToCartListener method is called by an
-   * internal user.
-   */
-  public function testInjectAddToCartEventListenerWithInternalUser() {
-    self::mockIsInternalUser( true );
-
-    $download_id = '1234';
-    FacebookWordpressEasyDigitalDownloads::injectAddToCartListener(
-      $download_id
-    );
-    $this->expectOutputString( '' );
-  }
-
-  /**
-   * Tests that the injectAddToCartEventId method does not inject
-   * any Pixel code when the user is an internal user.
-   *
-   * This test verifies that the output does not contain any Meta Pixel
-   * Event Code when the injectAddToCartEventId method is called by an
-   * internal user.
-   */
-  public function testInjectAddToCartEventIdWithInternalUser() {
-    self::mockIsInternalUser( true );
-
-    FacebookWordpressEasyDigitalDownloads::injectAddToCartEventId();
-    $this->expectOutputString( '' );
-  }
-
-  /**
-   * Tests that the injectInitiateCheckoutEvent method does not inject
-   * any Pixel code when the user is an internal user.
-   *
-   * This test verifies that the output does not contain any Meta Pixel
-   * Event Code when the injectInitiateCheckoutEvent method is called by an
-   * internal user.
-   */
-  public function testInjectInitiateCheckoutEventWithInternalUser() {
-    self::mockIsInternalUser( true );
-
-    FacebookWordpressEasyDigitalDownloads::injectInitiateCheckoutEvent();
-    $this->expectOutputString( '' );
-  }
-
-  /**
-   * Tests that the trackPurchaseEvent method does not inject any Pixel code
-   * when the user is an internal user.
-   *
-   * This test verifies that the output does not contain any Meta Pixel
-   * Event Code when the trackPurchaseEvent method is called by an
-   * internal user.
-   */
-  public function testInjectPurchaseEventWithInternalUser() {
-    self::mockIsInternalUser( true );
-    $payment = array( 'ID' => '1234' );
-    FacebookWordpressEasyDigitalDownloads::trackPurchaseEvent(
-            $payment,
-            null
-        );
-    $this->expectOutputString( '' );
-  }
-
-  /**
-   * Tests that the injectViewContentEvent method does not inject
-   * any Pixel code when the user is an internal user.
-   *
-   * This test verifies that the output does not contain any Meta Pixel
-   * Event Code when the injectViewContentEvent method is called by an
-   * internal user.
-   */
-  public function testInjectViewContentEventWithInternalUser() {
-    self::mockIsInternalUser( true );
-
-    $download_id = 1234;
-    FacebookWordpressEasyDigitalDownloads::injectViewContentEvent(
-            $download_id
-        );
-    $this->expectOutputString( '' );
-  }
-
-  /**
-   * Tests that the injectViewContentEvent method
-     * correctly injects the Pixel code
-   * for the 'ViewContent' event when the user is not an internal user.
-   *
-   * This test verifies that the output contains the expected Meta Pixel
-   * Event Code for Easy Digital Downloads and that the server-side event
-   * tracking records the 'ViewContent' event with the correct user and
-   * custom data attributes, such as content IDs, content type, currency,
-   * content name, and value.
-   */
-  public function testInjectViewContentEventWithoutInternalUser() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-    $this->setupEDDMocks();
-
-        \WP_Mock::userFunction(
-            'wp_json_encode',
-            array(
-        'args'   => array(
-                    \Mockery::type( 'array' ),
-          \Mockery::type( 'int' ),
-        ),
-        'return' => function ( $data, $options ) {
-          return json_encode( $data );
-        },
-            )
-        );
-
-    FacebookWordpressEasyDigitalDownloads::injectViewContentEvent( 1234 );
-    $this->expectOutputRegex(
-      '/easy-digital-downloads[\s\S]+End Meta Pixel Event Code/'
-    );
-    $tracked_events =
-    FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-    $this->assertCount( 1, $tracked_events );
-
-    $event       = $tracked_events[0];
-    $custom_data = $event->getCustomData();
-    $user_data   = $event->getUserData();
-
-    $this->assertEquals( 'pika.chu@s2s.com', $user_data->getEmail() );
-    $this->assertEquals( 'pika', $user_data->getFirstName() );
-    $this->assertEquals( 'chu', $user_data->getLastName() );
-    $this->assertEquals( 'ViewContent', $event->getEventName() );
-    $this->assertEquals( array( '1234' ), $custom_data->getContentIds() );
-    $this->assertEquals( 'product', $custom_data->getContentType() );
-    $this->assertEquals( 'USD', $custom_data->getCurrency() );
-    $this->assertEquals( 'Encarta', $custom_data->getContentName() );
-    $this->assertEquals( 50, $custom_data->getValue() );
-    $this->assertNotNull( $event->getEventTime() );
-  }
-
-  /**
-   * Tests that the injectAddToCartEventAjax method correctly injects
-   * the Pixel code for the 'AddToCart' event when the user is not an
-   * internal user.
-   *
-   * This test verifies that the output contains the expected Meta Pixel
-   * Event Code for Easy Digital Downloads and that the server-side event
-   * tracking records the 'AddToCart' event with the correct user and
-   * custom data attributes, such as content IDs, content type, currency,
-   * content name, and value.
-   */
-  public function testInjectAddToCartEventAjax() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-    $this->setupEDDMocks();
-
-        \WP_Mock::userFunction(
-            'wp_unslash',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-    FacebookWordpressEasyDigitalDownloads::injectAddToCartEventAjax();
-
-    $tracked_events =
-    FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-    $this->assertCount( 2, $tracked_events );
-
-    $event       = $tracked_events[0];
-    $custom_data = $event->getCustomData();
-    $user_data   = $event->getUserData();
-
-    $this->assertEquals( 'abc-123', $event->getEventId() );
-    $this->assertEquals( 'pika.chu@s2s.com', $user_data->getEmail() );
-    $this->assertEquals( 'pika', $user_data->getFirstName() );
-    $this->assertEquals( 'chu', $user_data->getLastName() );
-    $this->assertEquals( 'AddToCart', $event->getEventName() );
-    $this->assertEquals( array( '1234' ), $custom_data->getContentIds() );
-    $this->assertEquals( 'product', $custom_data->getContentType() );
-    $this->assertEquals( 'USD', $custom_data->getCurrency() );
-    $this->assertEquals( 'Encarta', $custom_data->getContentName() );
-    $this->assertEquals( 50, $custom_data->getValue() );
-    $this->assertNotNull( $event->getEventTime() );
-  }
-
-  /**
-   * Sets up the necessary mocks for Easy Digital Downloads integration tests.
-   *
-   * This method mocks various functions and methods
-     * related to Easy Digital Downloads
-   * to simulate the environment for testing purposes.
-     * It configures the expected
-   * return values for functions like currency retrieval,
-     * cart total calculation,
-   * payment metadata, and download object information. It also sets up mock
-   * POST data and ensures nonce verification functions behave as expected.
-   */
-  private function setupEDDMocks() {
-    \WP_Mock::userFunction( 'EDD' );
-    $mock_edd_utils = \Mockery::mock(
-      'alias:FacebookPixelPlugin\Integration\EDDUtils'
-    );
-    $mock_edd_utils->shouldReceive( 'get_currency' )->andReturn( 'USD' );
-    $mock_edd_utils->shouldReceive( 'get_cart_total' )->andReturn( 300 );
-
-    $this->mocked_fbpixel->shouldReceive( 'get_logged_in_user_info' )
-    ->andReturn(
+    $utils->shouldReceive( 'get_logged_in_user_info' )->andReturn(
       array(
         'email'      => 'pika.chu@s2s.com',
         'first_name' => 'Pika',
@@ -445,10 +65,84 @@ final class FacebookWordpressEasyDigitalDownloadsTest extends FacebookWordpressT
       )
     );
 
+    $edd_utils = \Mockery::mock(
+      'alias:FacebookPixelPlugin\Integration\EDDUtils'
+    );
+    $edd_utils->shouldReceive( 'get_currency' )->andReturn( 'USD' );
+    $edd_utils->shouldReceive( 'get_cart_total' )->andReturn( 300 );
+
+    $download             = new \stdClass();
+    $download->post_title = 'Encarta';
+    \WP_Mock::userFunction(
+      'edd_get_download',
+      array( 'return' => $download )
+    );
+    \WP_Mock::userFunction(
+      'get_post_meta',
+      array( 'return' => array( array( 'amount' => 50 ) ) )
+    );
+  }
+
+  /**
+   * inject_pixel_code registers the five Signals-routed EDD events.
+   *
+   * @return void
+   */
+  public function testInjectPixelCodeRegistersFiveSignalEvents() {
+    list( $integration, $signals ) = $this->makeIntegration();
+
+    $signals->expects( $this->exactly( 5 ) )->method( 'on' );
+
+    \WP_Mock::expectActionAdded(
+      'edd_purchase_link_top',
+      array( $integration, 'inject_add_to_cart_event_id' )
+    );
+
+    $integration->inject_pixel_code();
+
+    $this->assertConditionsMet();
+  }
+
+  /**
+   * read_initiate_checkout builds an InitiateCheckout EventData.
+   *
+   * @return void
+   */
+  public function testReadInitiateCheckoutReturnsEventData() {
+    \WP_Mock::userFunction( 'EDD' );
+    $this->setupProductMocks();
+
+    list( $integration ) = $this->makeIntegration();
+
+    $data = $integration->read_initiate_checkout();
+
+    $this->assertInstanceOf( EventData::class, $data );
+    $fields = $data->to_array();
+    $this->assertEquals( 'pika.chu@s2s.com', $fields['email'] );
+    $this->assertEquals( 'USD', $fields['currency'] );
+    $this->assertEquals( 300, $fields['value'] );
+  }
+
+  /**
+   * read_initiate_checkout returns null when EDD is not loaded.
+   *
+   * @return void
+   */
+  public function testReadInitiateCheckoutSkipsWithoutEdd() {
+    list( $integration ) = $this->makeIntegration();
+
+    $this->assertNull( $integration->read_initiate_checkout() );
+  }
+
+  /**
+   * read_purchase builds a Purchase EventData from the payment meta.
+   *
+   * @return void
+   */
+  public function testReadPurchaseReturnsEventData() {
     \WP_Mock::userFunction(
       'edd_get_payment_meta',
       array(
-        'args'   => 1,
         'return' => array(
           'email'        => 'pika.chu@s2s.com',
           'user_info'    => array(
@@ -470,30 +164,76 @@ final class FacebookWordpressEasyDigitalDownloadsTest extends FacebookWordpressT
       )
     );
 
-    \WP_Mock::userFunction(
-      'get_post_meta',
-      array(
-        'args'   => array(
-          1234,
-          \WP_Mock\Functions::type( 'string' ),
-          true,
-        ),
-        'return' => array(
-          array(
-            'amount' => 50,
-          ),
-        ),
-      )
-    );
-    $download_object             = new \stdClass();
-    $download_object->post_title = 'Encarta';
-    \WP_Mock::userFunction(
-      'edd_get_download',
-      array(
-        'args'   => array( \WP_Mock\Functions::type( 'int' ) ),
-        'return' => $download_object,
-      )
-    );
+    list( $integration ) = $this->makeIntegration();
+
+    $payment     = new \stdClass();
+    $payment->ID = 1;
+
+    $data = $integration->read_purchase( $payment, null );
+
+    $this->assertInstanceOf( EventData::class, $data );
+    $fields = $data->to_array();
+    $this->assertEquals( 'pika.chu@s2s.com', $fields['email'] );
+    $this->assertEquals( 700, $fields['value'] );
+    $this->assertEquals( 'USD', $fields['currency'] );
+    $this->assertEquals( array( 99, 999 ), $fields['content_ids'] );
+    $this->assertEquals( 'product', $fields['content_type'] );
+  }
+
+  /**
+   * read_purchase returns null when the payment has no ID.
+   *
+   * @return void
+   */
+  public function testReadPurchaseSkipsWithoutPaymentId() {
+    list( $integration ) = $this->makeIntegration();
+
+    $payment     = new \stdClass();
+    $payment->ID = 0;
+
+    $this->assertNull( $integration->read_purchase( $payment, null ) );
+  }
+
+  /**
+   * read_view_content builds a ViewContent EventData for a download.
+   *
+   * @return void
+   */
+  public function testReadViewContentReturnsEventData() {
+    $this->setupProductMocks();
+
+    list( $integration ) = $this->makeIntegration();
+
+    $data = $integration->read_view_content( 1234 );
+
+    $this->assertInstanceOf( EventData::class, $data );
+    $fields = $data->to_array();
+    $this->assertEquals( array( '1234' ), $fields['content_ids'] );
+    $this->assertEquals( 'product', $fields['content_type'] );
+    $this->assertEquals( 'USD', $fields['currency'] );
+    $this->assertEquals( 'Encarta', $fields['content_name'] );
+    $this->assertEquals( 50, $fields['value'] );
+  }
+
+  /**
+   * read_view_content returns null without a download id.
+   *
+   * @return void
+   */
+  public function testReadViewContentSkipsWithoutDownloadId() {
+    list( $integration ) = $this->makeIntegration();
+
+    $this->assertNull( $integration->read_view_content( 0 ) );
+  }
+
+  /**
+   * read_add_to_cart verifies the nonce, builds the EventData, and reuses the
+   * shared event id from the posted form data.
+   *
+   * @return void
+   */
+  public function testReadAddToCartReturnsEventDataWithSharedId() {
+    $this->setupProductMocks();
 
     $_POST['nonce']       = '54321';
     $_POST['download_id'] = '1234';
@@ -501,29 +241,129 @@ final class FacebookWordpressEasyDigitalDownloadsTest extends FacebookWordpressT
 
     \WP_Mock::userFunction(
       'absint',
-      array(
-        'args'   => array( \WP_Mock\Functions::type( 'string' ) ),
-        'return' => 1234,
-      )
+      array( 'return' => 1234 )
     );
-
     \WP_Mock::userFunction(
       'sanitize_text_field',
       array(
-        'args'   => array( \WP_Mock\Functions::type( 'string' ) ),
-        'return' => '54321',
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_verify_nonce',
+      array( 'return' => true )
+    );
+
+    list( $integration ) = $this->makeIntegration();
+
+    $data = $integration->read_add_to_cart();
+
+    $this->assertInstanceOf( EventData::class, $data );
+    $this->assertEquals( 'abc-123', $data->get_event_id() );
+    $fields = $data->to_array();
+    $this->assertEquals( array( '1234' ), $fields['content_ids'] );
+    $this->assertEquals( 'product', $fields['content_type'] );
+    $this->assertEquals( 'Encarta', $fields['content_name'] );
+  }
+
+  /**
+   * read_add_to_cart returns null when the AJAX payload is incomplete.
+   *
+   * @return void
+   */
+  public function testReadAddToCartSkipsWithoutPost() {
+    list( $integration ) = $this->makeIntegration();
+
+    $this->assertNull( $integration->read_add_to_cart() );
+  }
+
+  /**
+   * read_add_to_cart returns null when the nonce fails verification.
+   *
+   * @return void
+   */
+  public function testReadAddToCartSkipsOnBadNonce() {
+    $_POST['nonce']       = 'bad';
+    $_POST['download_id'] = '1234';
+    $_POST['post_data']   = 'facebook_event_id=abc-123';
+
+    \WP_Mock::userFunction(
+      'absint',
+      array( 'return' => 1234 )
+    );
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_verify_nonce',
+      array( 'return' => false )
+    );
+
+    list( $integration ) = $this->makeIntegration();
+
+    $this->assertNull( $integration->read_add_to_cart() );
+  }
+
+  /**
+   * inject_add_to_cart_event_id prints the hidden shared-id field for a
+   * non-internal user.
+   *
+   * @return void
+   */
+  public function testInjectAddToCartEventIdOutputsHiddenField() {
+    self::mockIsInternalUser( false );
+    \WP_Mock::userFunction(
+      'esc_attr',
+      array(
+        'return' => function ( $input ) {
+          return $input;
+        },
       )
     );
 
-    \WP_Mock::userFunction(
-      'wp_verify_nonce',
-      array(
-        'args'   => array(
-          \WP_Mock\Functions::type( 'string' ),
-          \WP_Mock\Functions::type( 'string' ),
-        ),
-        'return' => true,
-      )
+    list( $integration ) = $this->makeIntegration();
+
+    $integration->inject_add_to_cart_event_id();
+
+    $this->expectOutputRegex(
+      '/input type="hidden" name="facebook_event_id"/'
     );
+  }
+
+  /**
+   * inject_add_to_cart_event_id prints nothing for an internal user.
+   *
+   * @return void
+   */
+  public function testInjectAddToCartEventIdSkipsInternalUser() {
+    self::mockIsInternalUser( true );
+
+    list( $integration ) = $this->makeIntegration();
+
+    $integration->inject_add_to_cart_event_id();
+
+    $this->expectOutputString( '' );
+  }
+
+  /**
+   * inject_add_to_cart_listener enqueues nothing for an internal user.
+   *
+   * @return void
+   */
+  public function testInjectAddToCartListenerSkipsInternalUser() {
+    self::mockIsInternalUser( true );
+
+    list( $integration ) = $this->makeIntegration();
+
+    $integration->inject_add_to_cart_listener( 1234 );
+
+    $this->expectOutputString( '' );
   }
 }

--- a/__tests__/integration/FacebookWordpressEasyDigitalDownloadsTest.php
+++ b/__tests__/integration/FacebookWordpressEasyDigitalDownloadsTest.php
@@ -126,7 +126,7 @@ final class FacebookWordpressEasyDigitalDownloadsTest extends FacebookWordpressT
   }
 
   /**
-   * inject_pixel_code registers the five Signals-routed EDD events.
+   * set_up_tracking registers the five Signals-routed EDD events.
    *
    * @return void
    */
@@ -144,7 +144,7 @@ final class FacebookWordpressEasyDigitalDownloadsTest extends FacebookWordpressT
       array( $integration, 'inject_add_to_cart_event_id' )
     );
 
-    $integration->inject_pixel_code();
+    $integration->set_up_tracking();
 
     $this->assertConditionsMet();
   }

--- a/__tests__/integration/FacebookWordpressFormidableFormTest.php
+++ b/__tests__/integration/FacebookWordpressFormidableFormTest.php
@@ -20,31 +20,42 @@
 namespace FacebookPixelPlugin\Tests\Integration;
 
 use FacebookPixelPlugin\Core\Signals;
-use FacebookPixelPlugin\Core\EventData;
 use FacebookPixelPlugin\Core\EventDataBuilder;
 use FacebookPixelPlugin\Core\FooterDelivery;
+use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 use FacebookPixelPlugin\Integration\FacebookWordpressFormidableForm;
-use FacebookPixelPlugin\Tests\Mocks\MockFormidableFormEntryValues;
-use FacebookPixelPlugin\Tests\Mocks\MockFormidableFormFieldValue;
-use FacebookPixelPlugin\Tests\Mocks\MockFormidableFormField;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
+use FacebookPixelPlugin\Tests\Mocks\MockFormidableFormField;
+use FacebookPixelPlugin\Tests\Mocks\MockFormidableFormFieldValue;
+use FacebookPixelPlugin\Tests\Mocks\MockFormidableFormEntryValues;
 
 /**
  * FacebookWordpressFormidableFormTest class.
  *
+ * These tests assert the same observable behavior as before the Signals
+ * refactor: a Formidable entry submission ends up tracking a Lead server-side
+ * event carrying the correct user data. The only change is the entry point —
+ * read_form_data plus the real Signals dispatch path instead of the old
+ * trackServerEvent static method.
+ *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
+ *
+ * All tests in this test class should be run in separate PHP process to
+ * make sure tests are isolated.
+ * Stop preserving global state from the parent process.
  */
 final class FacebookWordpressFormidableFormTest
   extends FacebookWordpressTestBase {
 
   /**
-   * Builds a Formidable integration with a mock Signals + real builder.
+   * Builds a Formidable integration wired to a real Signals dispatcher, so a
+   * dispatched event actually tracks through FacebookServerSideEvent.
    *
-   * @return array [ FacebookWordpressFormidableForm, Signals mock ]
+   * @return array [ FacebookWordpressFormidableForm, Signals ]
    */
   private function makeIntegration() {
-    $signals     = $this->createMock( Signals::class );
+    $signals     = new Signals();
     $integration = new FacebookWordpressFormidableForm(
       $signals,
       new EventDataBuilder()
@@ -53,12 +64,43 @@ final class FacebookWordpressFormidableFormTest
   }
 
   /**
-   * set_up_tracking registers the Lead event with a footer delivery.
+   * Stubs the JSON/sanitize helpers the dispatch/render path relies on.
    *
    * @return void
    */
-  public function testInjectPixelCodeRegistersEvent() {
-    list( $integration, $signals ) = $this->makeIntegration();
+  private function mockRenderHelpers() {
+    \WP_Mock::userFunction(
+      'wp_json_encode',
+      array(
+        'args'   => array( \Mockery::type( 'array' ), \Mockery::type( 'int' ) ),
+        'return' => function ( $data, $options ) {
+          return json_encode( $data );
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+  }
+
+  /**
+   * set_up_tracking registers the Lead event on Signals with the footer
+   * delivery.
+   *
+   * @return void
+   */
+  public function testSetUpTrackingRegistersLeadEvent() {
+    $signals     = $this->createMock( Signals::class );
+    $integration = new FacebookWordpressFormidableForm(
+      $signals,
+      new EventDataBuilder()
+    );
 
     $signals->expects( $this->once() )
       ->method( 'on' )
@@ -67,7 +109,7 @@ final class FacebookWordpressFormidableFormTest
         'Lead',
         $this->isType( 'callable' ),
         $this->isInstanceOf( FooterDelivery::class ),
-        'formidable-lite',
+        FacebookWordpressFormidableForm::TRACKING_NAME,
         20,
         2
       );
@@ -78,65 +120,128 @@ final class FacebookWordpressFormidableFormTest
   }
 
   /**
-   * read_form_data extracts the entry field values into an EventData.
+   * A dispatched Lead tracks a Lead server event carrying the submitter's user
+   * data and the formidable-lite tracking property — the same outcome the old
+   * trackServerEvent path asserted.
    *
    * @return void
    */
-  public function testReadFormDataReturnsEventData() {
-    self::setupMockFormidableForm( 1 );
-    list( $integration ) = $this->makeIntegration();
+  public function testTrackEventWithoutInternalUser() {
+    self::mockIsInternalUser( false );
+    self::mockFacebookWordpressOptions();
+    $this->mockRenderHelpers();
 
-    $data = $integration->read_form_data( 1, 1 );
+    $mock_entry_id = 1;
+    $mock_form_id  = 1;
 
-    $this->assertInstanceOf( EventData::class, $data );
-    $this->assertEquals(
-      array(
-        'email'      => 'pika.chu@s2s.com',
-        'first_name' => 'Pika',
-        'last_name'  => 'Chu',
-        'phone'      => '123456',
-        'city'       => 'Springfield',
-        'state'      => 'Ohio',
-        'zip'        => '45501',
-      ),
-      $data->to_array()
+    self::setupMockFormidableForm( $mock_entry_id );
+    $_SERVER['HTTP_REFERER'] = 'TEST_REFERER';
+
+    list( $integration, $signals ) = $this->makeIntegration();
+
+    $data = $integration->read_form_data( $mock_entry_id, $mock_form_id );
+    $signals->dispatch(
+      'Lead',
+      $data,
+      FacebookWordpressFormidableForm::TRACKING_NAME
     );
+
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 1, $tracked_events );
+
+    $event = $tracked_events[0];
+    $this->assertEquals( 'Lead', $event->getEventName() );
+    $this->assertNotNull( $event->getEventTime() );
+    $this->assertEquals(
+      'pika.chu@s2s.com',
+      $event->getUserData()->getEmail()
+    );
+    $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
+    $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
+    $this->assertEquals( '123456', $event->getUserData()->getPhone() );
+    $this->assertEquals( 'springfield', $event->getUserData()->getCity() );
+    $this->assertEquals( 'ohio', $event->getUserData()->getState() );
+    $this->assertEquals( '45501', $event->getUserData()->getZipCode() );
+    $this->assertNull( $event->getUserData()->getCountryCode() );
+    $this->assertEquals(
+      'formidable-lite',
+      $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
+    );
+    $this->assertEquals( 'TEST_REFERER', $event->getEventSourceUrl() );
   }
 
   /**
-   * read_form_data returns null for an empty entry id.
+   * read_form_data returns null (nothing dispatched) when the entry id is
+   * empty.
    *
    * @return void
    */
-  public function testReadFormDataSkipsWhenNoEntry() {
+  public function testReadFormDataSkipsWhenEntryIdEmpty() {
     list( $integration ) = $this->makeIntegration();
-    $this->assertNull( $integration->read_form_data( 0 ) );
+
+    $this->assertNull( $integration->read_form_data( 0, 1 ) );
+
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 0, $tracked_events );
   }
 
   /**
-   * Aliases IntegrationUtils to return a fixture entry with sample fields.
+   * read_form_data returns null (nothing dispatched) when the entry carries no
+   * field values.
    *
-   * @param int $entry_id The entry id.
+   * @return void
+   */
+  public function testReadFormDataSkipsWhenNoFieldValues() {
+    $mock_entry_id = 1;
+
+    $entry_values = new MockFormidableFormEntryValues( array() );
+    $mock_utils   = \Mockery::mock(
+      'alias:FacebookPixelPlugin\Integration\IntegrationUtils'
+    );
+    $mock_utils->shouldReceive( 'get_formidable_forms_entry_values' )
+      ->with( $mock_entry_id )
+      ->andReturn( $entry_values );
+
+    list( $integration ) = $this->makeIntegration();
+
+    $this->assertNull( $integration->read_form_data( $mock_entry_id, 1 ) );
+
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 0, $tracked_events );
+  }
+
+  /**
+   * Alias-mocks the Formidable entry values with sample email/name/phone/
+   * address fields.
+   *
+   * @param int $entry_id The mocked entry id.
    * @return void
    */
   private static function setupMockFormidableForm( $entry_id ) {
-    $email      = new MockFormidableFormFieldValue(
+    $email = new MockFormidableFormFieldValue(
       new MockFormidableFormField( 'email', null, null ),
       'pika.chu@s2s.com'
     );
+
     $first_name = new MockFormidableFormFieldValue(
       new MockFormidableFormField( 'text', 'Name', 'First' ),
       'Pika'
     );
-    $last_name  = new MockFormidableFormFieldValue(
+
+    $last_name = new MockFormidableFormFieldValue(
       new MockFormidableFormField( 'text', 'Last', 'Last' ),
       'Chu'
     );
-    $phone      = new MockFormidableFormFieldValue(
+
+    $phone = new MockFormidableFormFieldValue(
       new MockFormidableFormField( 'phone', null, null ),
       '123456'
     );
-    $address    = new MockFormidableFormFieldValue(
+
+    $address = new MockFormidableFormFieldValue(
       new MockFormidableFormField( 'address', null, null ),
       array(
         'city'    => 'Springfield',

--- a/__tests__/integration/FacebookWordpressFormidableFormTest.php
+++ b/__tests__/integration/FacebookWordpressFormidableFormTest.php
@@ -53,7 +53,7 @@ final class FacebookWordpressFormidableFormTest
   }
 
   /**
-   * inject_pixel_code registers the Lead event with a footer delivery.
+   * set_up_tracking registers the Lead event with a footer delivery.
    *
    * @return void
    */
@@ -72,7 +72,7 @@ final class FacebookWordpressFormidableFormTest
         2
       );
 
-    $integration->inject_pixel_code();
+    $integration->set_up_tracking();
 
     $this->assertConditionsMet();
   }

--- a/__tests__/integration/FacebookWordpressFormidableFormTest.php
+++ b/__tests__/integration/FacebookWordpressFormidableFormTest.php
@@ -13,8 +13,10 @@
 
 namespace FacebookPixelPlugin\Tests\Integration;
 
-use FacebookPixelPlugin\Core\ServerEventFactory;
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
+use FacebookPixelPlugin\Core\Signals;
+use FacebookPixelPlugin\Core\EventData;
+use FacebookPixelPlugin\Core\EventDataBuilder;
+use FacebookPixelPlugin\Core\FooterDelivery;
 use FacebookPixelPlugin\Integration\FacebookWordpressFormidableForm;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 use FacebookPixelPlugin\Tests\Mocks\MockFormidableFormField;
@@ -24,184 +26,132 @@ use FacebookPixelPlugin\Tests\Mocks\MockFormidableFormEntryValues;
 /**
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
- *
- * All tests in this test class should be run in separate PHP process to
- * make sure tests are isolated.
- * Stop preserving global state from the parent process.
  */
 final class FacebookWordpressFormidableFormTest
   extends FacebookWordpressTestBase {
 
-  public function testInjectLeadEventWithoutInternalUser() {
-    self::mockIsInternalUser(false);
-    self::mockFacebookWordpressOptions();
+  /**
+   * Builds a Formidable integration with a mock Signals and a real builder.
+   *
+   * @return array [ FacebookWordpressFormidableForm, Signals mock ]
+   */
+  private function makeIntegration() {
+    $signals     = $this->createMock( Signals::class );
+    $integration = new FacebookWordpressFormidableForm(
+      $signals,
+      new EventDataBuilder()
+    );
+    return array( $integration, $signals );
+  }
 
-    \WP_Mock::userFunction(
-      'sanitize_text_field',
+  /**
+   * inject_pixel_code registers the Lead event with footer delivery.
+   *
+   * @return void
+   */
+  public function testInjectPixelCodeRegistersEvent() {
+    list( $integration, $signals ) = $this->makeIntegration();
+
+    $signals->expects( $this->once() )
+      ->method( 'on' )
+      ->with(
+        'frm_after_create_entry',
+        'Lead',
+        $this->isType( 'callable' ),
+        $this->isInstanceOf( FooterDelivery::class ),
+        'formidable-lite',
+        20,
+        2
+      );
+
+    $integration->inject_pixel_code();
+
+    $this->assertConditionsMet();
+  }
+
+  /**
+   * read_form_data extracts the entry's fields into an EventData.
+   *
+   * @return void
+   */
+  public function testReadFormDataReturnsEventData() {
+    self::setupMockFormidableForm( 1 );
+    list( $integration ) = $this->makeIntegration();
+
+    $data = $integration->read_form_data( 1, 1 );
+
+    $this->assertInstanceOf( EventData::class, $data );
+    $this->assertEquals(
       array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-      )
-    );
-
-    $event = ServerEventFactory::new_event('Lead');
-
-    \WP_Mock::userFunction(
-        'wp_json_encode',
-        array(
-            'args'   => array(
-        \Mockery::type( 'array' ),
-        \Mockery::type( 'int' ),
+        'email'      => 'pika.chu@s2s.com',
+        'first_name' => 'Pika',
+        'last_name'  => 'Chu',
+        'phone'      => '123456',
+        'city'       => 'Springfield',
+        'state'      => 'Ohio',
+        'zip'        => '45501',
       ),
-            'return' => function ( $data, $options ) {
-                return json_encode( $data );
-            },
-        )
+      $data->to_array()
     );
-
-    FacebookServerSideEvent::get_instance()->track($event);
-
-    FacebookWordpressFormidableForm::injectLeadEvent();
-
-    $this->expectOutputRegex('/script[\s\S]+formidable-lite/');
   }
 
-  public function testInjectLeadEventWithInternalUser() {
-    self::mockIsInternalUser(true);
-    self::mockFacebookWordpressOptions();
+  /**
+   * read_form_data returns null for an empty entry id.
+   *
+   * @return void
+   */
+  public function testReadFormDataSkipsWhenNoEntry() {
+    list( $integration ) = $this->makeIntegration();
 
-    FacebookWordpressFormidableForm::injectLeadEvent();
-
-    $this->expectOutputString("");
+    $this->assertNull( $integration->read_form_data( 0, 1 ) );
   }
 
-  public function testTrackEventWithoutInternalUser() {
-    self::mockIsInternalUser(false);
-    self::mockFacebookWordpressOptions();
-
-    \WP_Mock::userFunction(
-        'sanitize_text_field',
-        array(
-            'args'   => array( \Mockery::any() ),
-            'return' => function ( $input ) {
-                return $input;
-            },
-        )
-    );
-
-    $mock_entry_id = 1;
-    $mock_form_id = 1;
-
-    self::setupMockFormidableForm($mock_entry_id);
-    $_SERVER['HTTP_REFERER'] = 'TEST_REFERER';
-
-    \WP_Mock::expectActionAdded(
-      'wp_footer',
-      array(
-        'FacebookPixelPlugin\\Integration\\FacebookWordpressFormidableForm',
-        'injectLeadEvent'
-      ),
-      20
-    );
-
-    FacebookWordpressFormidableForm::trackServerEvent(
-      $mock_entry_id, $mock_form_id);
-
-    $tracked_events =
-      FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-    $this->assertCount(1, $tracked_events);
-
-    $event = $tracked_events[0];
-    $this->assertEquals('Lead', $event->getEventName());
-    $this->assertNotNull($event->getEventTime());
-    $this->assertEquals('pika.chu@s2s.com', $event->getUserData()->getEmail());
-    $this->assertEquals('pika', $event->getUserData()->getFirstName());
-    $this->assertEquals('chu', $event->getUserData()->getLastName());
-    $this->assertEquals('123456', $event->getUserData()->getPhone());
-    $this->assertEquals('springfield', $event->getUserData()->getCity());
-    $this->assertEquals('ohio', $event->getUserData()->getState());
-    $this->assertEquals('45501', $event->getUserData()->getZipCode());
-    $this->assertNull($event->getUserData()->getCountryCode());
-    $this->assertEquals('formidable-lite',
-      $event->getCustomData()->getCustomProperty('fb_integration_tracking'));
-    $this->assertEquals('TEST_REFERER', $event->getEventSourceUrl());
-  }
-
-  public function testTrackEventWithoutInternalUserErrorReadingForm() {
-    self::mockIsInternalUser(false);
-    self::mockFacebookWordpressOptions();
-
-    $mock_entry_id = 1;
-    $mock_form_id = 1;
-
-    $this->markTestSkipped('Skipping test temporarily while we update error handling.');
-
-    self::setupErrorForm($mock_entry_id);
-
-    FacebookWordpressFormidableForm::trackServerEvent(
-      $mock_entry_id,
-      $mock_form_id
-    );
-
-    $tracked_events =
-      FacebookServerSideEvent::getInstance()->getTrackedEvents();
-
-    $this->assertCount(1, $tracked_events);
-
-    $event = $tracked_events[0];
-    $this->assertEquals('Lead', $event->getEventName());
-    $this->assertNotNull($event->getEventTime());
-  }
-
-  private static function setupErrorForm($entry_id) {
-    $entry_values = new MockFormidableFormEntryValues(array());
-    $entry_values->set_throw(true);
-
-    $mock_utils = \Mockery::mock(
-      'alias:FacebookPixelPlugin\Integration\IntegrationUtils');
-    $mock_utils->shouldReceive('get_formidable_forms_entry_values')->with($entry_id)->andReturn($entry_values);
-  }
-
-  private static function setupMockFormidableForm($entry_id) {
+  /**
+   * Sets up an IntegrationUtils alias mock returning a mock entry with fields.
+   *
+   * @param int $entry_id The entry id.
+   * @return void
+   */
+  private static function setupMockFormidableForm( $entry_id ) {
     $email = new MockFormidableFormFieldValue(
-      new MockFormidableFormField('email', null, null),
+      new MockFormidableFormField( 'email', null, null ),
       'pika.chu@s2s.com'
     );
 
     $first_name = new MockFormidableFormFieldValue(
-      new MockFormidableFormField('text', 'Name', 'First'),
+      new MockFormidableFormField( 'text', 'Name', 'First' ),
       'Pika'
     );
 
     $last_name = new MockFormidableFormFieldValue(
-      new MockFormidableFormField('text', 'Last', 'Last'),
+      new MockFormidableFormField( 'text', 'Last', 'Last' ),
       'Chu'
     );
 
     $phone = new MockFormidableFormFieldValue(
-      new MockFormidableFormField('phone', null, null),
+      new MockFormidableFormField( 'phone', null, null ),
       '123456'
     );
 
     $address = new MockFormidableFormFieldValue(
-      new MockFormidableFormField('address', null, null),
+      new MockFormidableFormField( 'address', null, null ),
       array(
-        'city' => 'Springfield',
-        'state' => 'Ohio',
-        'zip' => '45501',
-        'country' => 'United States'
+        'city'    => 'Springfield',
+        'state'   => 'Ohio',
+        'zip'     => '45501',
+        'country' => 'United States',
       )
     );
 
     $entry_values = new MockFormidableFormEntryValues(
-      array($email, $first_name, $last_name, $phone, $address)
+      array( $email, $first_name, $last_name, $phone, $address )
     );
 
     $mock_utils = \Mockery::mock(
-      'alias:FacebookPixelPlugin\Integration\IntegrationUtils');
-    $mock_utils->shouldReceive('get_formidable_forms_entry_values')->with($entry_id)->andReturn($entry_values);
+      'alias:FacebookPixelPlugin\Integration\IntegrationUtils'
+    );
+    $mock_utils->shouldReceive( 'get_formidable_forms_entry_values' )
+      ->with( $entry_id )
+      ->andReturn( $entry_values );
   }
 }

--- a/__tests__/integration/FacebookWordpressFormidableFormTest.php
+++ b/__tests__/integration/FacebookWordpressFormidableFormTest.php
@@ -1,15 +1,21 @@
 <?php
 /**
- * Copyright (C) 2017-present, Meta, Inc.
+ * Facebook Pixel Plugin FacebookWordpressFormidableFormTest class.
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; version 2 of the License.
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * @package FacebookPixelPlugin
  */
+
+/*
+* Copyright (C) 2017-present, Meta, Inc.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; version 2 of the License.
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*/
 
 namespace FacebookPixelPlugin\Tests\Integration;
 
@@ -18,12 +24,14 @@ use FacebookPixelPlugin\Core\EventData;
 use FacebookPixelPlugin\Core\EventDataBuilder;
 use FacebookPixelPlugin\Core\FooterDelivery;
 use FacebookPixelPlugin\Integration\FacebookWordpressFormidableForm;
-use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
-use FacebookPixelPlugin\Tests\Mocks\MockFormidableFormField;
-use FacebookPixelPlugin\Tests\Mocks\MockFormidableFormFieldValue;
 use FacebookPixelPlugin\Tests\Mocks\MockFormidableFormEntryValues;
+use FacebookPixelPlugin\Tests\Mocks\MockFormidableFormFieldValue;
+use FacebookPixelPlugin\Tests\Mocks\MockFormidableFormField;
+use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 
 /**
+ * FacebookWordpressFormidableFormTest class.
+ *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
@@ -31,7 +39,7 @@ final class FacebookWordpressFormidableFormTest
   extends FacebookWordpressTestBase {
 
   /**
-   * Builds a Formidable integration with a mock Signals and a real builder.
+   * Builds a Formidable integration with a mock Signals + real builder.
    *
    * @return array [ FacebookWordpressFormidableForm, Signals mock ]
    */
@@ -45,7 +53,7 @@ final class FacebookWordpressFormidableFormTest
   }
 
   /**
-   * inject_pixel_code registers the Lead event with footer delivery.
+   * inject_pixel_code registers the Lead event with a footer delivery.
    *
    * @return void
    */
@@ -70,7 +78,7 @@ final class FacebookWordpressFormidableFormTest
   }
 
   /**
-   * read_form_data extracts the entry's fields into an EventData.
+   * read_form_data extracts the entry field values into an EventData.
    *
    * @return void
    */
@@ -102,38 +110,33 @@ final class FacebookWordpressFormidableFormTest
    */
   public function testReadFormDataSkipsWhenNoEntry() {
     list( $integration ) = $this->makeIntegration();
-
-    $this->assertNull( $integration->read_form_data( 0, 1 ) );
+    $this->assertNull( $integration->read_form_data( 0 ) );
   }
 
   /**
-   * Sets up an IntegrationUtils alias mock returning a mock entry with fields.
+   * Aliases IntegrationUtils to return a fixture entry with sample fields.
    *
    * @param int $entry_id The entry id.
    * @return void
    */
   private static function setupMockFormidableForm( $entry_id ) {
-    $email = new MockFormidableFormFieldValue(
+    $email      = new MockFormidableFormFieldValue(
       new MockFormidableFormField( 'email', null, null ),
       'pika.chu@s2s.com'
     );
-
     $first_name = new MockFormidableFormFieldValue(
       new MockFormidableFormField( 'text', 'Name', 'First' ),
       'Pika'
     );
-
-    $last_name = new MockFormidableFormFieldValue(
+    $last_name  = new MockFormidableFormFieldValue(
       new MockFormidableFormField( 'text', 'Last', 'Last' ),
       'Chu'
     );
-
-    $phone = new MockFormidableFormFieldValue(
+    $phone      = new MockFormidableFormFieldValue(
       new MockFormidableFormField( 'phone', null, null ),
       '123456'
     );
-
-    $address = new MockFormidableFormFieldValue(
+    $address    = new MockFormidableFormFieldValue(
       new MockFormidableFormField( 'address', null, null ),
       array(
         'city'    => 'Springfield',

--- a/__tests__/integration/FacebookWordpressMailchimpForWpTest.php
+++ b/__tests__/integration/FacebookWordpressMailchimpForWpTest.php
@@ -2,15 +2,7 @@
 /**
  * Facebook Pixel Plugin FacebookWordpressMailchimpForWpTest class.
  *
- * This file contains the main logic for FacebookWordpressMailchimpForWpTest.
- *
  * @package FacebookPixelPlugin
- */
-
-/**
- * Define FacebookWordpressMailchimpForWpTest class.
- *
- * @return void
  */
 
 /*
@@ -27,161 +19,102 @@
 
 namespace FacebookPixelPlugin\Tests\Integration;
 
+use FacebookPixelPlugin\Core\Signals;
+use FacebookPixelPlugin\Core\EventData;
+use FacebookPixelPlugin\Core\EventDataBuilder;
+use FacebookPixelPlugin\Core\FooterDelivery;
 use FacebookPixelPlugin\Integration\FacebookWordpressMailchimpForWp;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 
 /**
  * FacebookWordpressMailchimpForWpTest class.
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
- *
- * All tests in this test class should be run in separate PHP process to
- * make sure tests are isolated.
- * Stop preserving global state from the parent process.
  */
-final class FacebookWordpressMailchimpForWpTest extends FacebookWordpressTestBase {
+final class FacebookWordpressMailchimpForWpTest
+  extends FacebookWordpressTestBase {
+
   /**
-   * Tests that the inject_pixel_code method correctly sets up the
-   * necessary WordPress hooks for the Facebook Pixel events in
-   * the MailChimp for WP integration.
+   * Builds a Mailchimp integration with a mock Signals + real builder.
    *
-   * This test verifies that the add_pixel_fire_for_hook method is called
-   * with the correct parameters, ensuring that the 'mc4wp_form_subscribed'
-   * hook is added to trigger the 'injectLeadEvent' method.
+   * @return array [ FacebookWordpressMailchimpForWp, Signals mock ]
    */
-  public function testInjectPixelCode() {
-    $mocked_base = \Mockery::mock(
-      'alias:FacebookPixelPlugin\Integration\FacebookWordpressIntegrationBase'
+  private function makeIntegration() {
+    $signals     = $this->createMock( Signals::class );
+    $integration = new FacebookWordpressMailchimpForWp(
+      $signals,
+      new EventDataBuilder()
     );
-    $mocked_base->shouldReceive( 'add_pixel_fire_for_hook' )
-    ->with(
+    return array( $integration, $signals );
+  }
+
+  /**
+   * inject_pixel_code registers the Lead event with a footer delivery.
+   *
+   * @return void
+   */
+  public function testInjectPixelCodeRegistersEvent() {
+    list( $integration, $signals ) = $this->makeIntegration();
+
+    $signals->expects( $this->once() )
+      ->method( 'on' )
+      ->with(
+        'mc4wp_form_subscribed',
+        'Lead',
+        $this->isType( 'callable' ),
+        $this->isInstanceOf( FooterDelivery::class ),
+        'mailchimp-for-wp',
+        10,
+        1
+      );
+
+    $integration->inject_pixel_code();
+
+    $this->assertConditionsMet();
+  }
+
+  /**
+   * read_form_data extracts the $_POST subscribe fields into an EventData.
+   *
+   * @return void
+   */
+  public function testReadFormDataReturnsEventData() {
+    \WP_Mock::userFunction(
+      'sanitize_email',
       array(
-        'hook_name'       => 'mc4wp_form_subscribed',
-        'classname'       => FacebookWordpressMailchimpForWp::class,
-        'inject_function' => 'injectLeadEvent',
+        'return' => function ( $input ) {
+          return $input;
+        },
       )
-    )
-    ->once();
-    FacebookWordpressMailchimpForWp::inject_pixel_code();
-  }
-
-  /**
-   * Tests the injectLeadEvent method when the user is not an internal user.
-   *
-   * This test verifies that the Pixel code is correctly
-     * appended to the HTML output
-   * and that the server-side event is tracked with the correct parameters.
-   * It ensures that the 'Lead' event is recorded with the expected user data
-   * and custom properties when the MailChimp for WP integration is triggered.
-   *
-   * @return void
-   */
-  public function testInjectLeadEventWithoutInternalUser() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-    $_POST['EMAIL']          = 'pika.chu@s2s.com';
-    $_POST['FNAME']          = 'Pika';
-    $_POST['LNAME']          = 'Chu';
-    $_POST['PHONE']          = '123456';
-    $_POST['ADDRESS']        = array(
-      'city'    => 'Springfield',
-      'state'   => 'Ohio',
-      'zip'     => '54321',
-      'country' => 'US',
     );
-    $_SERVER['HTTP_REFERER'] = 'TEST_REFERER';
-
-        \WP_Mock::userFunction(
-            'sanitize_text_field',
-            array(
-              'args'   => array( \Mockery::any() ),
-              'return' => function ( $input ) {
-                  return $input;
-              },
-            )
-        );
-
-        \WP_Mock::userFunction(
-            'sanitize_email',
-            array(
-        'args'   => array( \Mockery::any() ),
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
         'return' => function ( $input ) {
           return $input;
         },
-            )
-        );
-
-        \WP_Mock::userFunction(
-            'wp_unslash',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-        \WP_Mock::userFunction(
-            'wp_json_encode',
-            array(
-        'args'   => array(
-                    \Mockery::type( 'array' ),
-          \Mockery::type( 'int' ),
-        ),
-        'return' => function ( $data, $options ) {
-          return json_encode( $data );
-        },
-            )
-        );
-
-    FacebookWordpressMailchimpForWp::injectLeadEvent();
-    $this->expectOutputRegex(
-      '/mailchimp-for-wp[\s\S]+End Meta Pixel Event Code/'
+      )
     );
 
-    $tracked_events =
-    FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $_POST['EMAIL'] = 'pika.chu@s2s.com';
+    $_POST['FNAME'] = 'Pika';
+    $_POST['LNAME'] = 'Chu';
+    $_POST['PHONE'] = '123456';
 
-    $this->assertCount( 1, $tracked_events );
+    list( $integration ) = $this->makeIntegration();
 
-    $event = $tracked_events[0];
-    $this->assertEquals( 'Lead', $event->getEventName() );
-    $this->assertNotNull( $event->getEventTime() );
+    $data = $integration->read_form_data();
+
+    $this->assertInstanceOf( EventData::class, $data );
     $this->assertEquals(
-            'pika.chu@s2s.com',
-            $event->getUserData()->getEmail()
-        );
-    $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
-    $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
-    $this->assertEquals( '123456', $event->getUserData()->getPhone() );
-    $this->assertEquals( 'springfield', $event->getUserData()->getCity() );
-    $this->assertEquals( 'ohio', $event->getUserData()->getState() );
-    $this->assertEquals( '54321', $event->getUserData()->getZipCode() );
-    $this->assertEquals( 'us', $event->getUserData()->getCountryCode() );
-    $this->assertEquals(
-      'mailchimp-for-wp',
-      $event->getCustomData()
-            ->getCustomProperty( 'fb_integration_tracking' )
+      array(
+        'email'      => 'pika.chu@s2s.com',
+        'first_name' => 'Pika',
+        'last_name'  => 'Chu',
+        'phone'      => '123456',
+      ),
+      $data->to_array()
     );
-    $this->assertEquals( 'TEST_REFERER', $event->getEventSourceUrl() );
-  }
-
-  /**
-   * Tests the injectLeadEvent method when the user is an internal user.
-   *
-   * This test verifies that no Pixel code is appended to the HTML output
-   * when the user is an internal user. It
-     * asserts that the output HTML remains
-   * unchanged and that no events are tracked.
-   *
-   * @return void
-   */
-  public function testInjectLeadEventWithInternalUser() {
-    self::mockIsInternalUser( true );
-    FacebookWordpressMailchimpForWp::injectLeadEvent();
-    $this->expectOutputString( '' );
   }
 }

--- a/__tests__/integration/FacebookWordpressMailchimpForWpTest.php
+++ b/__tests__/integration/FacebookWordpressMailchimpForWpTest.php
@@ -20,14 +20,20 @@
 namespace FacebookPixelPlugin\Tests\Integration;
 
 use FacebookPixelPlugin\Core\Signals;
-use FacebookPixelPlugin\Core\EventData;
 use FacebookPixelPlugin\Core\EventDataBuilder;
 use FacebookPixelPlugin\Core\FooterDelivery;
+use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 use FacebookPixelPlugin\Integration\FacebookWordpressMailchimpForWp;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 
 /**
  * FacebookWordpressMailchimpForWpTest class.
+ *
+ * These tests assert the same observable behavior as before the Signals
+ * refactor: a Mailchimp subscribe tracks a Lead server-side event carrying the
+ * correct user data. The only change is the entry point — read_form_data plus
+ * the real Signals dispatch path instead of the old static injectLeadEvent
+ * method.
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
@@ -36,12 +42,13 @@ final class FacebookWordpressMailchimpForWpTest
   extends FacebookWordpressTestBase {
 
   /**
-   * Builds a Mailchimp integration with a mock Signals + real builder.
+   * Builds a Mailchimp integration wired to a real Signals dispatcher, so a
+   * dispatched event actually tracks through FacebookServerSideEvent.
    *
-   * @return array [ FacebookWordpressMailchimpForWp, Signals mock ]
+   * @return array [ FacebookWordpressMailchimpForWp, Signals ]
    */
   private function makeIntegration() {
-    $signals     = $this->createMock( Signals::class );
+    $signals     = new Signals();
     $integration = new FacebookWordpressMailchimpForWp(
       $signals,
       new EventDataBuilder()
@@ -50,12 +57,51 @@ final class FacebookWordpressMailchimpForWpTest
   }
 
   /**
+   * Stubs the sanitize/JSON helpers the read/dispatch path relies on.
+   *
+   * @return void
+   */
+  private function mockRenderHelpers() {
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'sanitize_email',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'wp_json_encode',
+      array(
+        'args'   => array( \Mockery::type( 'array' ), \Mockery::type( 'int' ) ),
+        'return' => function ( $data, $options ) {
+          return json_encode( $data );
+        },
+      )
+    );
+  }
+
+  /**
    * set_up_tracking registers the Lead event with a footer delivery.
    *
    * @return void
    */
   public function testInjectPixelCodeRegistersEvent() {
-    list( $integration, $signals ) = $this->makeIntegration();
+    $signals     = $this->createMock( Signals::class );
+    $integration = new FacebookWordpressMailchimpForWp(
+      $signals,
+      new EventDataBuilder()
+    );
 
     $signals->expects( $this->once() )
       ->method( 'on' )
@@ -75,46 +121,57 @@ final class FacebookWordpressMailchimpForWpTest
   }
 
   /**
-   * read_form_data extracts the $_POST subscribe fields into an EventData.
+   * A dispatched Lead tracks a Lead server event with the subscribe user data.
    *
    * @return void
    */
-  public function testReadFormDataReturnsEventData() {
-    \WP_Mock::userFunction(
-      'sanitize_email',
-      array(
-        'return' => function ( $input ) {
-          return $input;
-        },
-      )
-    );
-    \WP_Mock::userFunction(
-      'sanitize_text_field',
-      array(
-        'return' => function ( $input ) {
-          return $input;
-        },
-      )
-    );
+  public function testLeadEventWithoutInternalUser() {
+    self::mockIsInternalUser( false );
+    self::mockFacebookWordpressOptions();
+    $this->mockRenderHelpers();
 
-    $_POST['EMAIL'] = 'pika.chu@s2s.com';
-    $_POST['FNAME'] = 'Pika';
-    $_POST['LNAME'] = 'Chu';
-    $_POST['PHONE'] = '123456';
+    $_POST['EMAIL']          = 'pika.chu@s2s.com';
+    $_POST['FNAME']          = 'Pika';
+    $_POST['LNAME']          = 'Chu';
+    $_POST['PHONE']          = '123456';
+    $_POST['ADDRESS']        = array(
+      'city'    => 'Springfield',
+      'state'   => 'Ohio',
+      'zip'     => '54321',
+      'country' => 'US',
+    );
+    $_SERVER['HTTP_REFERER'] = 'TEST_REFERER';
 
-    list( $integration ) = $this->makeIntegration();
+    list( $integration, $signals ) = $this->makeIntegration();
 
     $data = $integration->read_form_data();
+    $signals->dispatch(
+      'Lead',
+      $data,
+      FacebookWordpressMailchimpForWp::TRACKING_NAME
+    );
 
-    $this->assertInstanceOf( EventData::class, $data );
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 1, $tracked_events );
+
+    $event = $tracked_events[0];
+    $this->assertEquals( 'Lead', $event->getEventName() );
+    $this->assertNotNull( $event->getEventTime() );
+
+    $user_data = $event->getUserData();
+    $this->assertEquals( 'pika.chu@s2s.com', $user_data->getEmail() );
+    $this->assertEquals( 'pika', $user_data->getFirstName() );
+    $this->assertEquals( 'chu', $user_data->getLastName() );
+    $this->assertEquals( '123456', $user_data->getPhone() );
+    $this->assertEquals( 'springfield', $user_data->getCity() );
+    $this->assertEquals( 'ohio', $user_data->getState() );
+    $this->assertEquals( '54321', $user_data->getZipCode() );
+    $this->assertEquals( 'us', $user_data->getCountryCode() );
+
     $this->assertEquals(
-      array(
-        'email'      => 'pika.chu@s2s.com',
-        'first_name' => 'Pika',
-        'last_name'  => 'Chu',
-        'phone'      => '123456',
-      ),
-      $data->to_array()
+      'mailchimp-for-wp',
+      $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
     );
   }
 }

--- a/__tests__/integration/FacebookWordpressMailchimpForWpTest.php
+++ b/__tests__/integration/FacebookWordpressMailchimpForWpTest.php
@@ -50,7 +50,7 @@ final class FacebookWordpressMailchimpForWpTest
   }
 
   /**
-   * inject_pixel_code registers the Lead event with a footer delivery.
+   * set_up_tracking registers the Lead event with a footer delivery.
    *
    * @return void
    */
@@ -69,7 +69,7 @@ final class FacebookWordpressMailchimpForWpTest
         1
       );
 
-    $integration->inject_pixel_code();
+    $integration->set_up_tracking();
 
     $this->assertConditionsMet();
   }

--- a/__tests__/integration/FacebookWordpressNinjaFormsTest.php
+++ b/__tests__/integration/FacebookWordpressNinjaFormsTest.php
@@ -63,7 +63,7 @@ final class FacebookWordpressNinjaFormsTest extends FacebookWordpressTestBase {
   }
 
   /**
-   * inject_pixel_code registers the Lead event (AJAX delivery) + listener.
+   * set_up_tracking registers the Lead event (AJAX delivery) + listener.
    *
    * @return void
    */
@@ -88,7 +88,7 @@ final class FacebookWordpressNinjaFormsTest extends FacebookWordpressTestBase {
       9
     );
 
-    $integration->inject_pixel_code();
+    $integration->set_up_tracking();
 
     $this->assertConditionsMet();
   }

--- a/__tests__/integration/FacebookWordpressNinjaFormsTest.php
+++ b/__tests__/integration/FacebookWordpressNinjaFormsTest.php
@@ -20,14 +20,19 @@
 namespace FacebookPixelPlugin\Tests\Integration;
 
 use FacebookPixelPlugin\Core\Signals;
-use FacebookPixelPlugin\Core\EventData;
 use FacebookPixelPlugin\Core\EventDataBuilder;
-use FacebookPixelPlugin\Core\AjaxFilterDelivery;
+use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 use FacebookPixelPlugin\Integration\FacebookWordpressNinjaForms;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 
 /**
  * FacebookWordpressNinjaFormsTest class.
+ *
+ * These tests assert the same observable behavior as before the Signals
+ * refactor: a Ninja Forms submission that carries a success-message action
+ * tracks a Lead server-side event with the correct user data. The only change
+ * is the entry point — the read_form_data provider plus the real Signals
+ * dispatch path instead of the old injectLeadEvent static method.
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
@@ -35,12 +40,13 @@ use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 final class FacebookWordpressNinjaFormsTest extends FacebookWordpressTestBase {
 
   /**
-   * Builds a Ninja Forms integration with a mock Signals + real builder.
+   * Builds a Ninja Forms integration wired to a real Signals dispatcher, so a
+   * dispatched event actually tracks through FacebookServerSideEvent.
    *
-   * @return array [ FacebookWordpressNinjaForms, Signals mock ]
+   * @return array [ FacebookWordpressNinjaForms, Signals ]
    */
   private function makeIntegration() {
-    $signals     = $this->createMock( Signals::class );
+    $signals     = new Signals();
     $integration = new FacebookWordpressNinjaForms(
       $signals,
       new EventDataBuilder()
@@ -49,37 +55,151 @@ final class FacebookWordpressNinjaFormsTest extends FacebookWordpressTestBase {
   }
 
   /**
-   * A form_data fixture with name + email fields.
+   * Mocks the current user, plugin options, and the sanitize helper the
+   * dispatch path relies on.
    *
-   * @return array
+   * @return void
    */
-  private function formData() {
-    return array(
-      'fields' => array(
-        array( 'key' => 'name_1', 'value' => 'Pika Chu' ),
-        array( 'key' => 'email_1', 'value' => 'pika.chu@s2s.com' ),
-      ),
+  private function setupUserAndOptions() {
+    self::mockIsInternalUser( false );
+    self::mockFacebookWordpressOptions();
+
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
     );
   }
 
   /**
-   * set_up_tracking registers the Lead event (AJAX delivery) + listener.
+   * A submission with a success-message action feeds the form fields through
+   * read_form_data and dispatches a Lead event carrying all the user data —
+   * same observable outcome as the old injectLeadEvent path.
    *
    * @return void
    */
-  public function testInjectPixelCodeRegistersEventAndListener() {
+  public function testSubmissionTracksLeadEventWithoutInternalUser() {
+    $this->setupUserAndOptions();
+
+    $_SERVER['HTTP_REFERER'] = 'TEST_REFERER';
+
+    $actions = array(
+      array(
+        'id'       => 1,
+        'settings' => array(
+          'type'        => 'successmessage',
+          'success_msg' => 'successful',
+        ),
+      ),
+    );
+
     list( $integration, $signals ) = $this->makeIntegration();
+
+    $data = $integration->read_form_data(
+      $actions,
+      null,
+      $this->getMockFormData()
+    );
+    $this->assertNotNull( $data );
+
+    $signals->dispatch(
+      'Lead',
+      $data,
+      FacebookWordpressNinjaForms::TRACKING_NAME
+    );
+
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 1, $tracked_events );
+
+    $event     = $tracked_events[0];
+    $user_data = $event->getUserData();
+    $this->assertEquals( 'Lead', $event->getEventName() );
+    $this->assertNotNull( $event->getEventTime() );
+    $this->assertEquals( 'pika.chu@s2s.com', $user_data->getEmail() );
+    $this->assertEquals( 'pika', $user_data->getFirstName() );
+    $this->assertEquals( 'chu', $user_data->getLastName() );
+    $this->assertEquals( '12345', $user_data->getPhone() );
+    $this->assertEquals( 'oh', $user_data->getState() );
+    $this->assertEquals( 'springfield', $user_data->getCity() );
+    $this->assertEquals( 'us', $user_data->getCountryCode() );
+    $this->assertEquals( '4321', $user_data->getZipCode() );
+    $this->assertEquals( 'm', $user_data->getGender() );
+    $this->assertEquals(
+      'ninja-forms',
+      $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
+    );
+    $this->assertEquals( 'TEST_REFERER', $event->getEventSourceUrl() );
+  }
+
+  /**
+   * read_form_data returns null (nothing to dispatch) when the submission has
+   * no success-message action.
+   *
+   * @return void
+   */
+  public function testReadFormDataSkipsWithoutSuccessMessage() {
+    $this->setupUserAndOptions();
+
+    $actions = array(
+      array(
+        'id'       => 1,
+        'settings' => array( 'type' => 'email' ),
+      ),
+    );
+
+    list( $integration ) = $this->makeIntegration();
+
+    $this->assertNull(
+      $integration->read_form_data( $actions, null, $this->getMockFormData() )
+    );
+  }
+
+  /**
+   * read_form_data returns null when the submission carries no form data.
+   *
+   * @return void
+   */
+  public function testReadFormDataSkipsWithoutFormData() {
+    $this->setupUserAndOptions();
+
+    $actions = array(
+      array(
+        'id'       => 1,
+        'settings' => array( 'type' => 'successmessage' ),
+      ),
+    );
+
+    list( $integration ) = $this->makeIntegration();
+
+    $this->assertNull(
+      $integration->read_form_data( $actions, null, array() )
+    );
+  }
+
+  /**
+   * set_up_tracking registers the Lead event through Signals and adds the
+   * front-end AJAX listener hook.
+   *
+   * @return void
+   */
+  public function testSetUpTrackingRegistersLeadSignal() {
+    $signals     = $this->createMock( Signals::class );
+    $integration = new FacebookWordpressNinjaForms(
+      $signals,
+      new EventDataBuilder()
+    );
 
     $signals->expects( $this->once() )
       ->method( 'on' )
       ->with(
         'ninja_forms_submission_actions',
         'Lead',
-        $this->isType( 'callable' ),
-        $this->isInstanceOf( AjaxFilterDelivery::class ),
-        'ninja-forms',
-        10,
-        3
+        array( $integration, 'read_form_data' )
       );
 
     \WP_Mock::expectActionAdded(
@@ -94,40 +214,57 @@ final class FacebookWordpressNinjaFormsTest extends FacebookWordpressTestBase {
   }
 
   /**
-   * read_form_data extracts fields when a success-message action is present.
+   * The AJAX response listener script is printed on wp_footer.
    *
    * @return void
    */
-  public function testReadFormDataReturnsEventData() {
+  public function testInjectAjaxListenerOutputsScript() {
     list( $integration ) = $this->makeIntegration();
 
-    $actions = array( array( 'settings' => array( 'type' => 'successmessage' ) ) );
-
-    $data = $integration->read_form_data( $actions, array(), $this->formData() );
-
-    $this->assertInstanceOf( EventData::class, $data );
-    $this->assertEquals(
-      array(
-        'first_name' => 'Pika',
-        'last_name'  => 'Chu',
-        'email'      => 'pika.chu@s2s.com',
-      ),
-      $data->to_array()
-    );
+    $integration->inject_ajax_listener();
+    $this->expectOutputRegex( '/submit:response/' );
   }
 
   /**
-   * read_form_data returns null without a success-message action.
+   * Creates a mock Ninja Forms submission with some sample form fields.
    *
-   * @return void
+   * @return array
    */
-  public function testReadFormDataSkipsWithoutSuccessMessage() {
-    list( $integration ) = $this->makeIntegration();
-
-    $actions = array( array( 'settings' => array( 'type' => 'redirect' ) ) );
-
-    $this->assertNull(
-      $integration->read_form_data( $actions, array(), $this->formData() )
+  private function getMockFormData() {
+    $fields = array(
+      array(
+        'key'   => 'email',
+        'value' => 'pika.chu@s2s.com',
+      ),
+      array(
+        'key'   => 'name',
+        'value' => 'Pika Chu',
+      ),
+      array(
+        'key'   => 'phone',
+        'value' => '12345',
+      ),
+      array(
+        'key'   => 'city',
+        'value' => 'Springfield',
+      ),
+      array(
+        'key'   => 'liststate',
+        'value' => 'OH',
+      ),
+      array(
+        'key'   => 'listcountry',
+        'value' => 'US',
+      ),
+      array(
+        'key'   => 'zip',
+        'value' => '4321',
+      ),
+      array(
+        'key'   => 'gender',
+        'value' => 'M',
+      ),
     );
+    return array( 'fields' => $fields );
   }
 }

--- a/__tests__/integration/FacebookWordpressNinjaFormsTest.php
+++ b/__tests__/integration/FacebookWordpressNinjaFormsTest.php
@@ -2,15 +2,7 @@
 /**
  * Facebook Pixel Plugin FacebookWordpressNinjaFormsTest class.
  *
- * This file contains the main logic for FacebookWordpressNinjaFormsTest.
- *
  * @package FacebookPixelPlugin
- */
-
-/**
- * Define FacebookWordpressNinjaFormsTest class.
- *
- * @return void
  */
 
 /*
@@ -27,247 +19,141 @@
 
 namespace FacebookPixelPlugin\Tests\Integration;
 
+use FacebookPixelPlugin\Core\Signals;
+use FacebookPixelPlugin\Core\EventData;
+use FacebookPixelPlugin\Core\EventDataBuilder;
+use FacebookPixelPlugin\Core\AjaxFilterDelivery;
 use FacebookPixelPlugin\Integration\FacebookWordpressNinjaForms;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 
 /**
  * FacebookWordpressNinjaFormsTest class.
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
- *
- * All tests in this test class should be run in separate PHP process to
- * make sure tests are isolated.
- * Stop preserving global state from the parent process.
  */
 final class FacebookWordpressNinjaFormsTest extends FacebookWordpressTestBase {
-  /**
-   * Tests that the inject_pixel_code method adds
-     * the correct hooks to WordPress.
-   *
-   * @return void
-   */
-  public function testInjectPixelCode() {
-    \WP_Mock::expectActionAdded(
-      'ninja_forms_submission_actions',
-      array( FacebookWordpressNinjaForms::class, 'injectLeadEvent' ),
-      10,
-      3
-    );
-    \WP_Mock::expectFilterAdded(
-      'ninja_forms_post_run_action_type_successmessage',
-      array( FacebookWordpressNinjaForms::class, 'injectLeadEventResponse' )
-    );
-    \WP_Mock::expectActionAdded(
-      'wp_footer',
-      array( FacebookWordpressNinjaForms::class, 'injectAjaxListener' ),
-      9
-    );
 
-    FacebookWordpressNinjaForms::inject_pixel_code();
-    $this->assertHooksAdded();
+  /**
+   * Builds a Ninja Forms integration with a mock Signals and a real builder.
+   *
+   * @return array [ FacebookWordpressNinjaForms, Signals mock ]
+   */
+  private function makeIntegration() {
+    $signals     = $this->createMock( Signals::class );
+    $integration = new FacebookWordpressNinjaForms(
+      $signals,
+      new EventDataBuilder()
+    );
+    return array( $integration, $signals );
   }
 
   /**
-   * Tests the injectLeadEvent method when the user is not an internal user.
+   * A form_data with the given fields (each key => value).
    *
-   * This test verifies that the success message is left unchanged and that the
-   * server-side event is tracked with the correct parameters.
-   * It ensures that the 'Lead' event is recorded with the expected user data,
-   * including email, first name, last name, phone number,
-     * city, state, country,
-   * zip code, and gender when the Ninja Forms integration is triggered.
-   * It also checks that the event source URL is correctly set.
-   *
-   * @return void
+   * @param array $fields Map of field key => value.
+   * @return array
    */
-  public function testInjectLeadEventWithoutInternalUser() {
-    parent::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-    $mock_actions = array(
-      array(
-        'id'       => 1,
-        'settings' => array(
-          'type'        => 'successmessage',
-          'success_msg' => 'successful',
-        ),
-      ),
+  private function formData( $fields ) {
+    $out = array();
+    foreach ( $fields as $key => $value ) {
+      $out[] = array(
+        'key'   => $key,
+        'value' => $value,
+      );
+    }
+    return array(
+      'id'     => 1,
+      'fields' => $out,
     );
-
-    $mock_form_data          = $this->getMockFormData();
-    $_SERVER['HTTP_REFERER'] = 'TEST_REFERER';
-
-        \WP_Mock::userFunction(
-            'sanitize_text_field',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-    $result = FacebookWordpressNinjaForms::injectLeadEvent(
-      $mock_actions,
-      null,
-      $mock_form_data
-    );
-
-    $this->assertNotEmpty( $result );
-    $this->assertArrayHasKey( 'settings', $result[0] );
-    $this->assertArrayHasKey( 'success_msg', $result[0]['settings'] );
-    $this->assertEquals( 'successful', $result[0]['settings']['success_msg'] );
-
-    $tracked_events =
-    FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-    $this->assertCount( 1, $tracked_events );
-
-    $event = $tracked_events[0];
-    $this->assertEquals( 'Lead', $event->getEventName() );
-    $this->assertNotNull( $event->getEventTime() );
-    $this->assertEquals(
-            'pika.chu@s2s.com',
-            $event->getUserData()->getEmail()
-        );
-    $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
-    $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
-    $this->assertEquals( '12345', $event->getUserData()->getPhone() );
-    $this->assertEquals( 'oh', $event->getUserData()->getState() );
-    $this->assertEquals( 'springfield', $event->getUserData()->getCity() );
-    $this->assertEquals( 'us', $event->getUserData()->getCountryCode() );
-    $this->assertEquals( '4321', $event->getUserData()->getZipCode() );
-    $this->assertEquals( 'm', $event->getUserData()->getGender() );
-    $this->assertEquals(
-      'ninja-forms',
-      $event->getCustomData()->getCustomProperty(
-                'fb_integration_tracking'
-            )
-    );
-    $this->assertEquals( 'TEST_REFERER', $event->getEventSourceUrl() );
   }
 
   /**
-   * Tests the injectLeadEvent method when the user is an internal user.
-   *
-   * This test verifies that the output HTML remains
-     * unchanged and that no events are tracked.
-   *
-   * @return void
-   */
-  public function testInjectLeadEventWithInternalUser() {
-    parent::mockIsInternalUser( true );
-
-    $result = FacebookWordpressNinjaForms::injectLeadEvent(
-      'mock_actions',
-      'mock_form_cache',
-      'mock_form_data'
-    );
-
-    $this->assertEquals( 'mock_actions', $result );
-  }
-
-  /**
-   * Tests that the AJAX response is enriched with raw pixel code.
-   *
-   * @return void
-   */
-  public function testInjectLeadEventResponseAddsPixelCode() {
-    parent::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-        \WP_Mock::userFunction(
-            'sanitize_text_field',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-        \WP_Mock::userFunction(
-            'wp_json_encode',
-            array(
-        'args'   => array(
-                    \Mockery::type( 'array' ),
-          \Mockery::type( 'int' ),
-        ),
-        'return' => function ( $data, $options ) {
-          return json_encode( $data );
-        },
-            )
-        );
-
-    $event = \FacebookPixelPlugin\Core\ServerEventFactory::new_event( 'Lead' );
-    FacebookServerSideEvent::get_instance()->track( $event );
-
-    $response = FacebookWordpressNinjaForms::injectLeadEventResponse( array() );
-
-    $this->assertArrayHasKey( 'fb_pxl_code', $response );
-    $this->assertStringContainsString( "fbq('track'", $response['fb_pxl_code'] );
-  }
-
-  /**
-   * Tests that the AJAX response listener script is printed.
-   *
-   * @return void
-   */
-  public function testInjectAjaxListenerOutputsScript() {
-    FacebookWordpressNinjaForms::injectAjaxListener();
-    $this->expectOutputRegex( '/submit:response/' );
-  }
-
-  /**
-   * Creates a mock form data object with some sample form tags.
+   * A submission actions array with a success-message action.
    *
    * @return array
    */
-  private function getMockFormData() {
-    $email   = array(
-      'key'   => 'email',
-      'value' => 'pika.chu@s2s.com',
+  private function successActions() {
+    return array(
+      array( 'settings' => array( 'type' => 'successmessage' ) ),
     );
-    $name    = array(
-      'key'   => 'name',
-      'value' => 'Pika Chu',
+  }
+
+  /**
+   * inject_pixel_code registers the Lead event (AJAX delivery) and listener.
+   *
+   * @return void
+   */
+  public function testInjectPixelCodeRegistersEventAndListener() {
+    list( $integration, $signals ) = $this->makeIntegration();
+
+    $signals->expects( $this->once() )
+      ->method( 'on' )
+      ->with(
+        'ninja_forms_submission_actions',
+        'Lead',
+        $this->isType( 'callable' ),
+        $this->isInstanceOf( AjaxFilterDelivery::class ),
+        'ninja-forms',
+        10,
+        3
+      );
+
+    \WP_Mock::expectActionAdded(
+      'wp_footer',
+      array( $integration, 'inject_ajax_listener' ),
+      9
     );
-    $phone   = array(
-      'key'   => 'phone',
-      'value' => '12345',
+
+    $integration->inject_pixel_code();
+
+    $this->assertConditionsMet();
+  }
+
+  /**
+   * read_form_data extracts fields into an EventData on a success submission.
+   *
+   * @return void
+   */
+  public function testReadFormDataReturnsEventData() {
+    list( $integration ) = $this->makeIntegration();
+
+    $form_data = $this->formData(
+      array(
+        'name'  => 'Pika Chu',
+        'email' => 'pika.chu@s2s.com',
+      )
     );
-    $city    = array(
-      'key'   => 'city',
-      'value' => 'Springfield',
+
+    $data = $integration->read_form_data(
+      $this->successActions(),
+      array(),
+      $form_data
     );
-    $state   = array(
-      'key'   => 'liststate',
-      'value' => 'OH',
+
+    $this->assertInstanceOf( EventData::class, $data );
+    $this->assertEquals(
+      array(
+        'first_name' => 'Pika',
+        'last_name'  => 'Chu',
+        'email'      => 'pika.chu@s2s.com',
+      ),
+      $data->to_array()
     );
-    $country = array(
-      'key'   => 'listcountry',
-      'value' => 'US',
+  }
+
+  /**
+   * read_form_data returns null when there is no success-message action.
+   *
+   * @return void
+   */
+  public function testReadFormDataSkipsWithoutSuccessMessage() {
+    list( $integration ) = $this->makeIntegration();
+
+    $form_data = $this->formData( array( 'email' => 'pika.chu@s2s.com' ) );
+
+    $this->assertNull(
+      $integration->read_form_data( array(), array(), $form_data )
     );
-    $zip     = array(
-      'key'   => 'zip',
-      'value' => '4321',
-    );
-    $gender  = array(
-      'key'   => 'gender',
-      'value' => 'M',
-    );
-    $fields  = array(
-      $email,
-      $name,
-      $phone,
-      $city,
-      $state,
-      $country,
-      $zip,
-      $gender,
-    );
-    return array( 'fields' => $fields );
   }
 }

--- a/__tests__/integration/FacebookWordpressNinjaFormsTest.php
+++ b/__tests__/integration/FacebookWordpressNinjaFormsTest.php
@@ -35,7 +35,7 @@ use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 final class FacebookWordpressNinjaFormsTest extends FacebookWordpressTestBase {
 
   /**
-   * Builds a Ninja Forms integration with a mock Signals and a real builder.
+   * Builds a Ninja Forms integration with a mock Signals + real builder.
    *
    * @return array [ FacebookWordpressNinjaForms, Signals mock ]
    */
@@ -49,38 +49,21 @@ final class FacebookWordpressNinjaFormsTest extends FacebookWordpressTestBase {
   }
 
   /**
-   * A form_data with the given fields (each key => value).
+   * A form_data fixture with name + email fields.
    *
-   * @param array $fields Map of field key => value.
    * @return array
    */
-  private function formData( $fields ) {
-    $out = array();
-    foreach ( $fields as $key => $value ) {
-      $out[] = array(
-        'key'   => $key,
-        'value' => $value,
-      );
-    }
+  private function formData() {
     return array(
-      'id'     => 1,
-      'fields' => $out,
+      'fields' => array(
+        array( 'key' => 'name_1', 'value' => 'Pika Chu' ),
+        array( 'key' => 'email_1', 'value' => 'pika.chu@s2s.com' ),
+      ),
     );
   }
 
   /**
-   * A submission actions array with a success-message action.
-   *
-   * @return array
-   */
-  private function successActions() {
-    return array(
-      array( 'settings' => array( 'type' => 'successmessage' ) ),
-    );
-  }
-
-  /**
-   * inject_pixel_code registers the Lead event (AJAX delivery) and listener.
+   * inject_pixel_code registers the Lead event (AJAX delivery) + listener.
    *
    * @return void
    */
@@ -111,25 +94,16 @@ final class FacebookWordpressNinjaFormsTest extends FacebookWordpressTestBase {
   }
 
   /**
-   * read_form_data extracts fields into an EventData on a success submission.
+   * read_form_data extracts fields when a success-message action is present.
    *
    * @return void
    */
   public function testReadFormDataReturnsEventData() {
     list( $integration ) = $this->makeIntegration();
 
-    $form_data = $this->formData(
-      array(
-        'name'  => 'Pika Chu',
-        'email' => 'pika.chu@s2s.com',
-      )
-    );
+    $actions = array( array( 'settings' => array( 'type' => 'successmessage' ) ) );
 
-    $data = $integration->read_form_data(
-      $this->successActions(),
-      array(),
-      $form_data
-    );
+    $data = $integration->read_form_data( $actions, array(), $this->formData() );
 
     $this->assertInstanceOf( EventData::class, $data );
     $this->assertEquals(
@@ -143,17 +117,17 @@ final class FacebookWordpressNinjaFormsTest extends FacebookWordpressTestBase {
   }
 
   /**
-   * read_form_data returns null when there is no success-message action.
+   * read_form_data returns null without a success-message action.
    *
    * @return void
    */
   public function testReadFormDataSkipsWithoutSuccessMessage() {
     list( $integration ) = $this->makeIntegration();
 
-    $form_data = $this->formData( array( 'email' => 'pika.chu@s2s.com' ) );
+    $actions = array( array( 'settings' => array( 'type' => 'redirect' ) ) );
 
     $this->assertNull(
-      $integration->read_form_data( array(), array(), $form_data )
+      $integration->read_form_data( $actions, array(), $this->formData() )
     );
   }
 }

--- a/__tests__/integration/FacebookWordpressWPECommerceTest.php
+++ b/__tests__/integration/FacebookWordpressWPECommerceTest.php
@@ -48,7 +48,7 @@ final class FacebookWordpressWPECommerceTest extends FacebookWordpressTestBase {
   }
 
   /**
-   * inject_pixel_code registers the three WP eCommerce events.
+   * set_up_tracking registers the three WP eCommerce events.
    *
    * @return void
    */
@@ -57,7 +57,7 @@ final class FacebookWordpressWPECommerceTest extends FacebookWordpressTestBase {
 
     $signals->expects( $this->exactly( 3 ) )->method( 'on' );
 
-    $integration->inject_pixel_code();
+    $integration->set_up_tracking();
 
     $this->assertConditionsMet();
   }

--- a/__tests__/integration/FacebookWordpressWPECommerceTest.php
+++ b/__tests__/integration/FacebookWordpressWPECommerceTest.php
@@ -2,15 +2,7 @@
 /**
  * Facebook Pixel Plugin FacebookWordpressWPECommerceTest class.
  *
- * This file contains the main logic for FacebookWordpressWPECommerceTest.
- *
  * @package FacebookPixelPlugin
- */
-
-/**
- * Define FacebookWordpressWPECommerceTest class.
- *
- * @return void
  */
 
 /*
@@ -27,417 +19,97 @@
 
 namespace FacebookPixelPlugin\Tests\Integration;
 
+use FacebookPixelPlugin\Core\Signals;
+use FacebookPixelPlugin\Core\EventData;
+use FacebookPixelPlugin\Core\EventDataBuilder;
 use FacebookPixelPlugin\Integration\FacebookWordpressWPECommerce;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 
 /**
  * FacebookWordpressWPECommerceTest class.
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
- *
- * All tests in this test class should be run in separate PHP process to
- * make sure tests are isolated.
- * Stop preserving global state from the parent process.
  */
 final class FacebookWordpressWPECommerceTest extends FacebookWordpressTestBase {
+
   /**
-   * Tests that the inject_pixel_code method correctly sets up the
-   * necessary WordPress hooks for the Facebook Pixel events in
-   * the WP eCommerce integration.
+   * Builds a WP eCommerce integration with a mock Signals + real builder.
    *
-   * This test verifies that the appropriate hooks are added for
-   * the 'injectAddToCartEvent', 'injectInitiateCheckoutEvent', and
-   * 'injectPurchaseEvent' events with the expected hook names.
-   *
-   * Utilizes the Mockery library to mock the base integration class
-   * and validate that the add_pixel_fire_for_hook method is called with
-   * the correct parameters.
+   * @return array [ FacebookWordpressWPECommerce, Signals mock ]
    */
-  public function testInjectPixelCode() {
-    \WP_Mock::expectActionAdded(
-      'wpsc_add_to_cart_json_response',
-      array(
-                FacebookWordpressWPECommerce::class,
-        'injectAddToCartEvent',
-            ),
-      11
+  private function makeIntegration() {
+    $signals     = $this->createMock( Signals::class );
+    $integration = new FacebookWordpressWPECommerce(
+      $signals,
+      new EventDataBuilder()
     );
-
-    $mocked_base =
-        \Mockery::mock(
-            'alias:FacebookPixelPlugin\Integration\FacebookWordpressIntegrationBase'
-        );
-    $mocked_base->shouldReceive( 'add_pixel_fire_for_hook' )
-    ->with(
-      array(
-        'hook_name'       => 'wpsc_before_shopping_cart_page',
-        'classname'       => FacebookWordpressWPECommerce::class,
-        'inject_function' => 'injectInitiateCheckoutEvent',
-      )
-    )
-    ->once();
-    \WP_Mock::expectActionAdded(
-      'wpsc_transaction_results_shutdown',
-      array( FacebookWordpressWPECommerce::class, 'injectPurchaseEvent' ),
-      11,
-      3
-    );
-
-    FacebookWordpressWPECommerce::inject_pixel_code();
-
-    $this->assertHooksAdded();
+    return array( $integration, $signals );
   }
 
   /**
-   * Tests that the injectAddToCartEvent method injects the correct
-   * Pixel code when the user is not an internal user.
-   *
-   * This test verifies that the output contains the expected Meta Pixel
-   * Event Code for WP eCommerce and that the server-side event tracking
-   * records the 'AddToCart' event with the correct user and custom data
-   * attributes.
-   */
-  public function testInjectAddToCartEventWithoutInternalUser() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-    $parameter = array(
-      'product_id'    => 1,
-      'widget_output' => '',
-    );
-
-    $this->setupMocks();
-
-        \WP_Mock::userFunction(
-            'sanitize_text_field',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-        \WP_Mock::userFunction(
-            'wp_json_encode',
-            array(
-        'args'   => array(
-                    \Mockery::type( 'array' ),
-          \Mockery::type( 'int' ),
-        ),
-        'return' => function ( $data, $options ) {
-          return json_encode( $data );
-        },
-            )
-        );
-
-    $response =
-        FacebookWordpressWPECommerce::injectAddToCartEvent( $parameter );
-
-    $this->assertArrayHasKey( 'widget_output', $response );
-    $code = $response['widget_output'];
-    $this->assertMatchesRegularExpression(
-      '/wp-e-commerce[\s\S]+End Meta Pixel Event Code/',
-      $code
-    );
-
-    $tracked_events =
-    FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-    $this->assertCount( 1, $tracked_events );
-
-    $event = $tracked_events[0];
-    $this->assertEquals( 'AddToCart', $event->getEventName() );
-    $this->assertNotNull( $event->getEventTime() );
-    $this->assertEquals(
-            'pika.chu@s2s.com',
-            $event->getUserData()->getEmail()
-        );
-    $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
-    $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
-    $this->assertEquals( 'USD', $event->getCustomData()->getCurrency() );
-    $this->assertEquals( 999, $event->getCustomData()->getValue() );
-    $this->assertEquals(
-            'product',
-            $event->getCustomData()->getContentType()
-        );
-    $this->assertEquals(
-            array( 1 ),
-            $event->getCustomData()->getContentIds()
-        );
-    $this->assertEquals(
-      'wp-e-commerce',
-      $event->getCustomData()
-            ->getCustomProperty( 'fb_integration_tracking' )
-    );
-  }
-
-  /**
-   * Tests that the injectAddToCartEvent method does not inject any Pixel code
-   * when the user is an internal user.
-   *
-   * This test verifies that the output does not contain any Meta Pixel
-   * Event Code when the injectAddToCartEvent method is called by an
-   * internal user.
-   */
-  public function testInjectAddToCartEventWithInternalUser() {
-    self::mockIsInternalUser( true );
-    $parameter = array(
-      'product_id'    => 1,
-      'widget_output' => '',
-    );
-
-    $response =
-        FacebookWordpressWPECommerce::injectAddToCartEvent( $parameter );
-
-    $this->assertArrayHasKey( 'widget_output', $response );
-    $code = $response['widget_output'];
-    $this->assertEquals( '', $code );
-  }
-
-  /**
-   * Tests that the injectInitiateCheckoutEvent
-     * method correctly injects the Pixel code
-   * for the 'InitiateCheckout' event when the user is not an internal user.
-   *
-   * This test verifies that the output contains
-     * the expected Meta Pixel Event Code for
-   * WP e-Commerce and that the server-side event
-     * tracking records the 'InitiateCheckout'
-   * event with the correct user and custom data attributes.
-   */
-  public function testInitiateCheckoutEventWithoutInternalUser() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-    $this->setupMocks();
-
-        \WP_Mock::userFunction(
-            'wp_json_encode',
-            array(
-        'args'   => array(
-                    \Mockery::type( 'array' ),
-          \Mockery::type( 'int' ),
-        ),
-        'return' => function ( $data, $options ) {
-          return json_encode( $data );
-        },
-            )
-        );
-
-        \WP_Mock::userFunction(
-            'sanitize_text_field',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-    FacebookWordpressWPECommerce::injectInitiateCheckoutEvent();
-    $this->expectOutputRegex(
-      '/wp-e-commerce[\s\S]+End Meta Pixel Event Code/'
-    );
-
-    $tracked_events =
-    FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-    $this->assertCount( 1, $tracked_events );
-
-    $event = $tracked_events[0];
-    $this->assertEquals( 'InitiateCheckout', $event->getEventName() );
-    $this->assertNotNull( $event->getEventTime() );
-    $this->assertEquals(
-            'pika.chu@s2s.com',
-            $event->getUserData()->getEmail()
-        );
-    $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
-    $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
-    $this->assertEquals( 'USD', $event->getCustomData()->getCurrency() );
-    $this->assertEquals( 999, $event->getCustomData()->getValue() );
-    $this->assertEquals(
-      'wp-e-commerce',
-      $event->getCustomData()
-            ->getCustomProperty( 'fb_integration_tracking' )
-    );
-  }
-
-  /**
-   * Tests that the injectInitiateCheckoutEvent method does not inject
-   * any Pixel code when the user is an internal user.
-   *
-   * This test verifies that the output does not contain any Meta Pixel
-   * Event Code when the injectInitiateCheckoutEvent method is called by an
-   * internal user.
-   */
-  public function testInitiateCheckoutEventWithInternalUser() {
-    self::mockIsInternalUser( true );
-
-    FacebookWordpressWPECommerce::injectInitiateCheckoutEvent();
-    $this->expectOutputString( '' );
-  }
-
-  /**
-   * Tests that the injectPurchaseEvent method
-     * correctly injects the Pixel code
-   * for the 'Purchase' event when the user is not an internal user.
-   *
-   * This test verifies that the output contains
-     * the expected Meta Pixel Event Code
-   * for WP e-Commerce and that the server-side
-     * event tracking records the 'Purchase'
-   * event with the correct user and custom data attributes.
-   */
-  public function testInjectPurchaseEventWithoutInternalUser() {
-    self::mockIsInternalUser( false );
-    self::mockFacebookWordpressOptions();
-
-    $this->setupMocks();
-
-    $mock_purchase_log_object = \Mockery::mock();
-    $purchase_log_object      = $mock_purchase_log_object;
-    $session_id               = null;
-    $display_to_screen        = true;
-
-        \WP_Mock::userFunction(
-            'wp_json_encode',
-            array(
-        'args'   => array(
-                    \Mockery::type( 'array' ),
-          \Mockery::type( 'int' ),
-        ),
-        'return' => function ( $data, $options ) {
-          return json_encode( $data );
-        },
-            )
-        );
-
-        \WP_Mock::userFunction(
-            'sanitize_text_field',
-            array(
-        'args'   => array( \Mockery::any() ),
-        'return' => function ( $input ) {
-          return $input;
-        },
-            )
-        );
-
-    $mock_purchase_log_object->shouldReceive( 'get_items' )
-    ->andReturn( array( 0 => (object) array( 'prodid' => '1' ) ) );
-    $mock_purchase_log_object->shouldReceive( 'get_total' )
-    ->andReturn( 999 );
-
-    FacebookWordpressWPECommerce::injectPurchaseEvent(
-      $purchase_log_object,
-      $session_id,
-      $display_to_screen
-    );
-
-    $this->expectOutputRegex(
-      '/wp-e-commerce[\s\S]+End Meta Pixel Event Code/'
-    );
-
-    $tracked_events =
-    FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-    $this->assertCount( 1, $tracked_events );
-
-    $event = $tracked_events[0];
-    $this->assertEquals( 'Purchase', $event->getEventName() );
-    $this->assertNotNull( $event->getEventTime() );
-    $this->assertEquals(
-            'pika.chu@s2s.com',
-            $event->getUserData()->getEmail()
-        );
-    $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
-    $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
-    $this->assertEquals( 'USD', $event->getCustomData()->getCurrency() );
-    $this->assertEquals( 999, $event->getCustomData()->getValue() );
-    $this->assertEquals(
-      'wp-e-commerce',
-      $event->getCustomData()
-            ->getCustomProperty( 'fb_integration_tracking' )
-    );
-  }
-
-  /**
-   * Tests that the injectPurchaseEvent method does not inject any Pixel code
-   * when the user is an internal user.
-   *
-   * This test verifies that the output does not contain any Meta Pixel
-   * Event Code when the injectPurchaseEvent method is called by an
-   * internal user, even if the display_to_screen flag is true.
-   */
-  public function testInjectPurchaseEventWithInternalUser() {
-    self::mockIsInternalUser( true );
-
-    $mock_purchase_log_object = \Mockery::mock();
-    $purchase_log_object      = $mock_purchase_log_object;
-    $session_id               = null;
-    $display_to_screen        = true;
-
-    $mock_purchase_log_object->shouldReceive( 'get_items' )
-    ->andReturn( array( 0 => (object) array( 'prodid' => '1' ) ) );
-    $mock_purchase_log_object->shouldReceive( 'get_total' )
-    ->andReturn( 999 );
-
-    FacebookWordpressWPECommerce::injectPurchaseEvent(
-      $purchase_log_object,
-      $session_id,
-      $display_to_screen
-    );
-    $this->expectOutputString( '' );
-  }
-
-  /**
-   * Sets up various mock objects and functions for
-     * the WP e-Commerce integration tests.
-   *
-   * This method uses Mockery to create a mock cart and
-     * define the behavior of the
-   * get_items method to return a predefined set of cart
-     * items. It also sets up a global
-   * variable for the cart and mocks the getLoggedInUserInfo
-     * method to return specific
-   * user details. Additionally, it mocks the
-     * wpsc_get_currency_code function to return
-   * a fixed currency code. These mocks are used to
-     * simulate the environment and behavior
-   * required for testing the Facebook Pixel integration with WP e-Commerce.
+   * inject_pixel_code registers the three WP eCommerce events.
    *
    * @return void
    */
-  private function setupMocks() {
-    $mock_cart = \Mockery::mock();
-    $mock_cart->shouldReceive( 'get_items' )
-    ->andReturn(
-      array(
-        '1' => (object) array(
-          'product_id' => 1,
-          'unit_price' => 999,
-        ),
-      )
-    );
+  public function testInjectPixelCodeRegistersThreeEvents() {
+    list( $integration, $signals ) = $this->makeIntegration();
 
-    $GLOBALS['wpsc_cart'] = $mock_cart;
+    $signals->expects( $this->exactly( 3 ) )->method( 'on' );
 
-    $this->mocked_fbpixel->shouldReceive( 'get_logged_in_user_info' )
-    ->andReturn(
-      array(
-        'email'      => 'pika.chu@s2s.com',
-        'first_name' => 'Pika',
-        'last_name'  => 'Chu',
-      )
-    );
+    $integration->inject_pixel_code();
 
-    \WP_Mock::userFunction(
-      'wpsc_get_currency_code',
-      array(
-        'return' => 'USD',
-      )
+    $this->assertConditionsMet();
+  }
+
+  /**
+   * read_purchase builds a Purchase EventData from the purchase log.
+   *
+   * @return void
+   */
+  public function testReadPurchaseReturnsEventData() {
+    $utils = \Mockery::mock(
+      'alias:FacebookPixelPlugin\Core\FacebookPluginUtils'
     );
+    $utils->shouldReceive( 'get_logged_in_user_info' )->andReturn( array() );
+
+    $item        = new \stdClass();
+    $item->prodid = 7;
+    $log          = \Mockery::mock();
+    $log->shouldReceive( 'get_items' )->andReturn( array( $item ) );
+    $log->shouldReceive( 'get_total' )->andReturn( 42.0 );
+
+    list( $integration ) = $this->makeIntegration();
+
+    $data = $integration->read_purchase( $log, null, true );
+
+    $this->assertInstanceOf( EventData::class, $data );
+    $fields = $data->to_array();
+    $this->assertEquals( array( 7 ), $fields['content_ids'] );
+    $this->assertEquals( 'product', $fields['content_type'] );
+    $this->assertEquals( 42.0, $fields['value'] );
+  }
+
+  /**
+   * read_purchase returns null when results are not displayed.
+   *
+   * @return void
+   */
+  public function testReadPurchaseSkipsWhenNotDisplayed() {
+    list( $integration ) = $this->makeIntegration();
+    $log                 = \Mockery::mock();
+
+    $this->assertNull( $integration->read_purchase( $log, null, false ) );
+  }
+
+  /**
+   * read_add_to_cart returns null when the response has no product id.
+   *
+   * @return void
+   */
+  public function testReadAddToCartSkipsWithoutProductId() {
+    list( $integration ) = $this->makeIntegration();
+
+    $this->assertNull( $integration->read_add_to_cart( array() ) );
   }
 }

--- a/__tests__/integration/FacebookWordpressWPECommerceTest.php
+++ b/__tests__/integration/FacebookWordpressWPECommerceTest.php
@@ -20,13 +20,19 @@
 namespace FacebookPixelPlugin\Tests\Integration;
 
 use FacebookPixelPlugin\Core\Signals;
-use FacebookPixelPlugin\Core\EventData;
 use FacebookPixelPlugin\Core\EventDataBuilder;
+use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 use FacebookPixelPlugin\Integration\FacebookWordpressWPECommerce;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 
 /**
  * FacebookWordpressWPECommerceTest class.
+ *
+ * These tests assert the same observable behavior as before the Signals
+ * refactor: driving an event through the integration tracks a server-side
+ * event carrying the correct user/custom data. The only change is the entry
+ * point — the read_* data provider plus the real Signals dispatch path
+ * instead of the old inject/track static methods.
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
@@ -34,12 +40,13 @@ use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 final class FacebookWordpressWPECommerceTest extends FacebookWordpressTestBase {
 
   /**
-   * Builds a WP eCommerce integration with a mock Signals + real builder.
+   * Builds a WP eCommerce integration wired to a real Signals dispatcher, so a
+   * dispatched event actually tracks through FacebookServerSideEvent.
    *
-   * @return array [ FacebookWordpressWPECommerce, Signals mock ]
+   * @return array [ FacebookWordpressWPECommerce, Signals ]
    */
   private function makeIntegration() {
-    $signals     = $this->createMock( Signals::class );
+    $signals     = new Signals();
     $integration = new FacebookWordpressWPECommerce(
       $signals,
       new EventDataBuilder()
@@ -48,12 +55,88 @@ final class FacebookWordpressWPECommerceTest extends FacebookWordpressTestBase {
   }
 
   /**
+   * Mocks the current user, plugin options, and logged-in user PII used by the
+   * create* event builders.
+   *
+   * @return void
+   */
+  private function setupUserAndOptions() {
+    self::mockIsInternalUser( false );
+    self::mockFacebookWordpressOptions();
+
+    $this->mocked_fbpixel->shouldReceive( 'get_logged_in_user_info' )
+      ->andReturn(
+        array(
+          'email'      => 'pika.chu@s2s.com',
+          'first_name' => 'Pika',
+          'last_name'  => 'Chu',
+        )
+      );
+  }
+
+  /**
+   * Stubs the JSON/sanitize helpers the dispatch/render path relies on.
+   *
+   * @return void
+   */
+  private function mockRenderHelpers() {
+    \WP_Mock::userFunction(
+      'wp_json_encode',
+      array(
+        'args'   => array( \Mockery::type( 'array' ), \Mockery::type( 'int' ) ),
+        'return' => function ( $data, $options ) {
+          return json_encode( $data );
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+  }
+
+  /**
+   * Sets up the WP eCommerce cart global and currency helper used by the
+   * AddToCart/InitiateCheckout builders.
+   *
+   * @return void
+   */
+  private function setupCart() {
+    $mock_cart = \Mockery::mock();
+    $mock_cart->shouldReceive( 'get_items' )
+      ->andReturn(
+        array(
+          '1' => (object) array(
+            'product_id' => 1,
+            'unit_price' => 999,
+          ),
+        )
+      );
+
+    $GLOBALS['wpsc_cart'] = $mock_cart;
+
+    \WP_Mock::userFunction(
+      'wpsc_get_currency_code',
+      array( 'return' => 'USD' )
+    );
+  }
+
+  /**
    * set_up_tracking registers the three WP eCommerce events.
    *
    * @return void
    */
   public function testInjectPixelCodeRegistersThreeEvents() {
-    list( $integration, $signals ) = $this->makeIntegration();
+    $signals     = $this->createMock( Signals::class );
+    $integration = new FacebookWordpressWPECommerce(
+      $signals,
+      new EventDataBuilder()
+    );
 
     $signals->expects( $this->exactly( 3 ) )->method( 'on' );
 
@@ -63,31 +146,169 @@ final class FacebookWordpressWPECommerceTest extends FacebookWordpressTestBase {
   }
 
   /**
-   * read_purchase builds a Purchase EventData from the purchase log.
+   * A dispatched AddToCart tracks an AddToCart server event with cart data.
    *
    * @return void
    */
-  public function testReadPurchaseReturnsEventData() {
-    $utils = \Mockery::mock(
-      'alias:FacebookPixelPlugin\Core\FacebookPluginUtils'
+  public function testAddToCartEventWithoutInternalUser() {
+    $this->setupUserAndOptions();
+    $this->setupCart();
+    $this->mockRenderHelpers();
+
+    list( $integration, $signals ) = $this->makeIntegration();
+
+    $data = $integration->read_add_to_cart(
+      array(
+        'product_id'    => 1,
+        'widget_output' => '',
+      )
     );
-    $utils->shouldReceive( 'get_logged_in_user_info' )->andReturn( array() );
+    $signals->dispatch(
+      'AddToCart',
+      $data,
+      FacebookWordpressWPECommerce::TRACKING_NAME
+    );
 
-    $item        = new \stdClass();
-    $item->prodid = 7;
-    $log          = \Mockery::mock();
-    $log->shouldReceive( 'get_items' )->andReturn( array( $item ) );
-    $log->shouldReceive( 'get_total' )->andReturn( 42.0 );
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 1, $tracked_events );
 
-    list( $integration ) = $this->makeIntegration();
+    $event = $tracked_events[0];
+    $this->assertEquals( 'AddToCart', $event->getEventName() );
+    $this->assertNotNull( $event->getEventTime() );
+    $this->assertEquals(
+      'pika.chu@s2s.com',
+      $event->getUserData()->getEmail()
+    );
+    $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
+    $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
+    $this->assertEquals( 'USD', $event->getCustomData()->getCurrency() );
+    $this->assertEquals( 999, $event->getCustomData()->getValue() );
+    $this->assertEquals(
+      'product',
+      $event->getCustomData()->getContentType()
+    );
+    $this->assertEquals(
+      array( 1 ),
+      $event->getCustomData()->getContentIds()
+    );
+    $this->assertEquals(
+      'wp-e-commerce',
+      $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
+    );
+  }
+
+  /**
+   * A dispatched InitiateCheckout tracks an InitiateCheckout server event with
+   * the cart data.
+   *
+   * @return void
+   */
+  public function testInitiateCheckoutEventWithoutInternalUser() {
+    $this->setupUserAndOptions();
+    $this->setupCart();
+    $this->mockRenderHelpers();
+
+    list( $integration, $signals ) = $this->makeIntegration();
+
+    $data = $integration->read_initiate_checkout();
+    $signals->dispatch(
+      'InitiateCheckout',
+      $data,
+      FacebookWordpressWPECommerce::TRACKING_NAME
+    );
+
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 1, $tracked_events );
+
+    $event = $tracked_events[0];
+    $this->assertEquals( 'InitiateCheckout', $event->getEventName() );
+    $this->assertNotNull( $event->getEventTime() );
+    $this->assertEquals(
+      'pika.chu@s2s.com',
+      $event->getUserData()->getEmail()
+    );
+    $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
+    $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
+    $this->assertEquals( 'USD', $event->getCustomData()->getCurrency() );
+    $this->assertEquals( 999, $event->getCustomData()->getValue() );
+    $this->assertEquals(
+      array( 1 ),
+      $event->getCustomData()->getContentIds()
+    );
+    $this->assertEquals(
+      'wp-e-commerce',
+      $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
+    );
+  }
+
+  /**
+   * A dispatched Purchase tracks a Purchase server event with order data.
+   *
+   * @return void
+   */
+  public function testPurchaseEventWithoutInternalUser() {
+    $this->setupUserAndOptions();
+    $this->mockRenderHelpers();
+
+    \WP_Mock::userFunction(
+      'wpsc_get_currency_code',
+      array( 'return' => 'USD' )
+    );
+
+    $log = \Mockery::mock();
+    $log->shouldReceive( 'get_items' )
+      ->andReturn( array( 0 => (object) array( 'prodid' => '1' ) ) );
+    $log->shouldReceive( 'get_total' )->andReturn( 999 );
+
+    list( $integration, $signals ) = $this->makeIntegration();
 
     $data = $integration->read_purchase( $log, null, true );
+    $signals->dispatch(
+      'Purchase',
+      $data,
+      FacebookWordpressWPECommerce::TRACKING_NAME
+    );
 
-    $this->assertInstanceOf( EventData::class, $data );
-    $fields = $data->to_array();
-    $this->assertEquals( array( 7 ), $fields['content_ids'] );
-    $this->assertEquals( 'product', $fields['content_type'] );
-    $this->assertEquals( 42.0, $fields['value'] );
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 1, $tracked_events );
+
+    $event = $tracked_events[0];
+    $this->assertEquals( 'Purchase', $event->getEventName() );
+    $this->assertNotNull( $event->getEventTime() );
+    $this->assertEquals(
+      'pika.chu@s2s.com',
+      $event->getUserData()->getEmail()
+    );
+    $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
+    $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
+    $this->assertEquals( 'USD', $event->getCustomData()->getCurrency() );
+    $this->assertEquals( 999, $event->getCustomData()->getValue() );
+    $this->assertEquals(
+      'product',
+      $event->getCustomData()->getContentType()
+    );
+    $this->assertEquals(
+      array( '1' ),
+      $event->getCustomData()->getContentIds()
+    );
+    $this->assertEquals(
+      'wp-e-commerce',
+      $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
+    );
+  }
+
+  /**
+   * read_add_to_cart returns null when the response has no product id.
+   *
+   * @return void
+   */
+  public function testReadAddToCartSkipsWithoutProductId() {
+    list( $integration ) = $this->makeIntegration();
+
+    $this->assertNull( $integration->read_add_to_cart( array() ) );
   }
 
   /**
@@ -100,16 +321,5 @@ final class FacebookWordpressWPECommerceTest extends FacebookWordpressTestBase {
     $log                 = \Mockery::mock();
 
     $this->assertNull( $integration->read_purchase( $log, null, false ) );
-  }
-
-  /**
-   * read_add_to_cart returns null when the response has no product id.
-   *
-   * @return void
-   */
-  public function testReadAddToCartSkipsWithoutProductId() {
-    list( $integration ) = $this->makeIntegration();
-
-    $this->assertNull( $integration->read_add_to_cart( array() ) );
   }
 }

--- a/__tests__/integration/FacebookWordpressWPFormsTest.php
+++ b/__tests__/integration/FacebookWordpressWPFormsTest.php
@@ -49,7 +49,7 @@ final class FacebookWordpressWPFormsTest extends FacebookWordpressTestBase {
   }
 
   /**
-   * inject_pixel_code registers the Lead event (with a composite footer+AJAX
+   * set_up_tracking registers the Lead event (with a composite footer+AJAX
    * delivery) and the front-end AJAX listener.
    *
    * @return void
@@ -75,7 +75,7 @@ final class FacebookWordpressWPFormsTest extends FacebookWordpressTestBase {
       9
     );
 
-    $integration->inject_pixel_code();
+    $integration->set_up_tracking();
 
     $this->assertConditionsMet();
   }

--- a/__tests__/integration/FacebookWordpressWPFormsTest.php
+++ b/__tests__/integration/FacebookWordpressWPFormsTest.php
@@ -20,14 +20,20 @@
 namespace FacebookPixelPlugin\Tests\Integration;
 
 use FacebookPixelPlugin\Core\Signals;
-use FacebookPixelPlugin\Core\EventData;
 use FacebookPixelPlugin\Core\EventDataBuilder;
 use FacebookPixelPlugin\Core\CompositeDelivery;
+use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 use FacebookPixelPlugin\Integration\FacebookWordpressWPForms;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 
 /**
  * FacebookWordpressWPFormsTest class.
+ *
+ * These tests assert the same observable behavior as before the Signals
+ * refactor: submitting a WPForms form ends up tracking a server-side Lead
+ * event carrying the correct user/custom data. The only change is the entry
+ * point — the data provider (read_form_data) plus the real Signals dispatch
+ * path instead of the old trackEvent static method.
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
@@ -35,12 +41,13 @@ use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 final class FacebookWordpressWPFormsTest extends FacebookWordpressTestBase {
 
   /**
-   * Builds a WPForms integration with a mock Signals and a real builder.
+   * Builds a WPForms integration wired to a real Signals dispatcher, so a
+   * dispatched event actually tracks through FacebookServerSideEvent.
    *
-   * @return array [ FacebookWordpressWPForms, Signals mock ]
+   * @return array [ FacebookWordpressWPForms, Signals ]
    */
   private function makeIntegration() {
-    $signals     = $this->createMock( Signals::class );
+    $signals     = new Signals();
     $integration = new FacebookWordpressWPForms(
       $signals,
       new EventDataBuilder()
@@ -49,24 +56,76 @@ final class FacebookWordpressWPFormsTest extends FacebookWordpressTestBase {
   }
 
   /**
-   * set_up_tracking registers the Lead event (with a composite footer+AJAX
-   * delivery) and the front-end AJAX listener.
+   * Mocks the current user, plugin options, and the JSON/sanitize helpers the
+   * dispatch/render path relies on.
    *
    * @return void
    */
-  public function testInjectPixelCodeRegistersEventAndListener() {
-    list( $integration, $signals ) = $this->makeIntegration();
+  private function setupUserAndOptions() {
+    self::mockIsInternalUser( false );
+    self::mockFacebookWordpressOptions();
 
+    $this->mocked_fbpixel->shouldReceive( 'get_logged_in_user_info' )
+      ->andReturn( array() );
+
+    \WP_Mock::userFunction(
+      'wp_json_encode',
+      array(
+        'args'   => array( \Mockery::type( 'array' ), \Mockery::type( 'int' ) ),
+        'return' => function ( $data, $options ) {
+          return json_encode( $data );
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
+    );
+  }
+
+  /**
+   * Asserts the shared user data carried on the tracked Lead event.
+   *
+   * @param object $event The tracked server event.
+   * @return void
+   */
+  private function assertLeadUserData( $event ) {
+    $user_data = $event->getUserData();
+    $this->assertEquals( 'pika.chu@s2s.com', $user_data->getEmail() );
+    $this->assertEquals( 'pika', $user_data->getFirstName() );
+    $this->assertEquals( 'chu', $user_data->getLastName() );
+    $this->assertEquals( '1234567', $user_data->getPhone() );
+    $this->assertEquals( 'us', $user_data->getCountryCode() );
+    $this->assertEquals( 'springfield', $user_data->getCity() );
+    $this->assertEquals( 'ohio', $user_data->getState() );
+    $this->assertEquals( '45401', $user_data->getZipCode() );
+  }
+
+  /**
+   * set_up_tracking registers the Lead Signals event using a composite
+   * delivery (footer + AJAX filters).
+   *
+   * @return void
+   */
+  public function testSetUpTrackingRegistersLeadSignalEvent() {
+    $signals     = $this->createMock( Signals::class );
+    $integration = new FacebookWordpressWPForms(
+      $signals,
+      new EventDataBuilder()
+    );
+
+    $deliveries = array();
     $signals->expects( $this->once() )
       ->method( 'on' )
-      ->with(
-        'wpforms_process_before',
-        'Lead',
-        $this->isType( 'callable' ),
-        $this->isInstanceOf( CompositeDelivery::class ),
-        'wpforms-lite',
-        20,
-        2
+      ->willReturnCallback(
+        function ( $hook, $event, $provider, $delivery ) use ( &$deliveries ) {
+          $deliveries[ $event ] = $delivery;
+        }
       );
 
     \WP_Mock::expectActionAdded(
@@ -77,58 +136,173 @@ final class FacebookWordpressWPFormsTest extends FacebookWordpressTestBase {
 
     $integration->set_up_tracking();
 
+    $this->assertInstanceOf(
+      CompositeDelivery::class,
+      $deliveries['Lead']
+    );
     $this->assertConditionsMet();
   }
 
   /**
-   * read_form_data extracts the standard fields into an EventData.
+   * A dispatched Lead tracks a Lead server event with the submission's user
+   * data (first-last name format).
    *
    * @return void
    */
-  public function testReadFormDataReturnsEventData() {
-    list( $integration ) = $this->makeIntegration();
+  public function testLeadEventWithoutInternalUser() {
+    $this->setupUserAndOptions();
 
-    $form_data = array(
-      'fields' => array(
-        array(
-          'type'   => 'name',
-          'format' => 'simple',
-          'id'     => 0,
-        ),
-        array(
-          'type' => 'email',
-          'id'   => 1,
-        ),
-      ),
+    list( $integration, $signals ) = $this->makeIntegration();
+
+    $data = $integration->read_form_data(
+      $this->createMockEntry(),
+      $this->createMockFormData()
     );
-    $entry     = array(
-      'fields' => array(
-        0 => 'Pika Chu',
-        1 => 'pika.chu@s2s.com',
-      ),
+    $signals->dispatch(
+      'Lead',
+      $data,
+      FacebookWordpressWPForms::TRACKING_NAME
     );
 
-    $data = $integration->read_form_data( $entry, $form_data );
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 1, $tracked_events );
 
-    $this->assertInstanceOf( EventData::class, $data );
+    $event = $tracked_events[0];
+    $this->assertEquals( 'Lead', $event->getEventName() );
+    $this->assertNotNull( $event->getEventTime() );
+    $this->assertLeadUserData( $event );
     $this->assertEquals(
-      array(
-        'email'      => 'pika.chu@s2s.com',
-        'first_name' => 'Pika',
-        'last_name'  => 'Chu',
-      ),
-      $data->to_array()
+      'wpforms-lite',
+      $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
     );
   }
 
   /**
-   * read_form_data returns null when the entry or form data is empty.
+   * A dispatched Lead tracks a Lead server event with the submission's user
+   * data (simple name format), and prefers the referrer for the event source
+   * URL.
    *
    * @return void
    */
-  public function testReadFormDataSkipsWhenEmpty() {
+  public function testLeadEventWithoutInternalUserSimpleFormat() {
+    $this->setupUserAndOptions();
+    $_SERVER['HTTP_REFERER'] = 'TEST_REFERER';
+
+    list( $integration, $signals ) = $this->makeIntegration();
+
+    $data = $integration->read_form_data(
+      $this->createMockEntry( true ),
+      $this->createMockFormData( true )
+    );
+    $signals->dispatch(
+      'Lead',
+      $data,
+      FacebookWordpressWPForms::TRACKING_NAME
+    );
+
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 1, $tracked_events );
+
+    $event = $tracked_events[0];
+    $this->assertEquals( 'Lead', $event->getEventName() );
+    $this->assertNotNull( $event->getEventTime() );
+    $this->assertLeadUserData( $event );
+    $this->assertEquals( 'TEST_REFERER', $event->getEventSourceUrl() );
+    $this->assertEquals(
+      'wpforms-lite',
+      $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
+    );
+  }
+
+  /**
+   * read_form_data returns null (nothing to dispatch) when the entry is empty.
+   *
+   * @return void
+   */
+  public function testReadFormDataReturnsNullForEmptyEntry() {
     list( $integration ) = $this->makeIntegration();
 
-    $this->assertNull( $integration->read_form_data( array(), array() ) );
+    $this->assertNull(
+      $integration->read_form_data(
+        array(),
+        $this->createMockFormData()
+      )
+    );
+  }
+
+  /**
+   * read_form_data returns null (nothing to dispatch) when the form schema is
+   * empty.
+   *
+   * @return void
+   */
+  public function testReadFormDataReturnsNullForEmptyFormData() {
+    list( $integration ) = $this->makeIntegration();
+
+    $this->assertNull(
+      $integration->read_form_data(
+        $this->createMockEntry(),
+        array()
+      )
+    );
+  }
+
+  /**
+   * Creates a mock entry with predefined field values.
+   *
+   * @param bool $simple_format Whether to use the simple format for the name
+   *                            field.
+   * @return array The mock entry with predefined field values.
+   */
+  private function createMockEntry( $simple_format = false ) {
+    return array(
+      'fields' => array(
+        '0' => $simple_format ? 'Pika Chu' : array(
+          'first' => 'Pika',
+          'last'  => 'Chu',
+        ),
+        '1' => 'pika.chu@s2s.com',
+        '2' => '1234567',
+        '3' => array(
+          'country' => 'US',
+          'postal'  => '45401',
+          'state'   => 'Ohio',
+          'city'    => 'Springfield',
+        ),
+      ),
+    );
+  }
+
+  /**
+   * Creates a mock form data object with predefined field values.
+   *
+   * @param bool $simple_format Whether to use the simple format for the name
+   *                            field.
+   * @return array The mock form data object with predefined field values.
+   */
+  private function createMockFormData( $simple_format = false ) {
+    return array(
+      'fields' => array(
+        array(
+          'type'   => 'name',
+          'id'     => '0',
+          'format' => $simple_format ? 'simple' : 'first-last',
+        ),
+        array(
+          'type' => 'email',
+          'id'   => '1',
+        ),
+        array(
+          'type' => 'phone',
+          'id'   => '2',
+        ),
+        array(
+          'type' => 'address',
+          'id'   => '3',
+        ),
+      ),
+    );
   }
 }

--- a/__tests__/integration/FacebookWordpressWPFormsTest.php
+++ b/__tests__/integration/FacebookWordpressWPFormsTest.php
@@ -2,15 +2,7 @@
 /**
  * Facebook Pixel Plugin FacebookWordpressWPFormsTest class.
  *
- * This file contains the main logic for FacebookWordpressWPFormsTest.
- *
  * @package FacebookPixelPlugin
- */
-
-/**
- * Define FacebookWordpressWPFormsTest class.
- *
- * @return void
  */
 
 /*
@@ -27,391 +19,116 @@
 
 namespace FacebookPixelPlugin\Tests\Integration;
 
+use FacebookPixelPlugin\Core\Signals;
+use FacebookPixelPlugin\Core\EventData;
+use FacebookPixelPlugin\Core\EventDataBuilder;
+use FacebookPixelPlugin\Core\CompositeDelivery;
 use FacebookPixelPlugin\Integration\FacebookWordpressWPForms;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
-use FacebookPixelPlugin\Core\ServerEventFactory;
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 
 /**
  * FacebookWordpressWPFormsTest class.
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
- *
- * All tests in this test class should be run in separate PHP process to
- * make sure tests are isolated.
- * Stop preserving global state from the parent process.
  */
 final class FacebookWordpressWPFormsTest extends FacebookWordpressTestBase {
-    /**
-     * Tests that the inject_pixel_code method adds the correct WordPress hook.
-     *
-     * This test verifies that the 'wpforms_process_before' action hook is added
-     * to trigger the 'trackEvent' method of the FacebookWordpressWPForms class.
-     *
-     * @return void
-     */
-    public function testInjectPixelCode() {
-    \WP_Mock::expectActionAdded(
+
+  /**
+   * Builds a WPForms integration with a mock Signals and a real builder.
+   *
+   * @return array [ FacebookWordpressWPForms, Signals mock ]
+   */
+  private function makeIntegration() {
+    $signals     = $this->createMock( Signals::class );
+    $integration = new FacebookWordpressWPForms(
+      $signals,
+      new EventDataBuilder()
+    );
+    return array( $integration, $signals );
+  }
+
+  /**
+   * inject_pixel_code registers the Lead event (with a composite footer+AJAX
+   * delivery) and the front-end AJAX listener.
+   *
+   * @return void
+   */
+  public function testInjectPixelCodeRegistersEventAndListener() {
+    list( $integration, $signals ) = $this->makeIntegration();
+
+    $signals->expects( $this->once() )
+      ->method( 'on' )
+      ->with(
         'wpforms_process_before',
-        array( FacebookWordpressWPForms::class, 'trackEvent' ),
+        'Lead',
+        $this->isType( 'callable' ),
+        $this->isInstanceOf( CompositeDelivery::class ),
+        'wpforms-lite',
         20,
         2
-    );
-    \WP_Mock::expectFilterAdded(
-        'wpforms_ajax_submit_success_response',
-        array( FacebookWordpressWPForms::class, 'injectLeadEventAjax' ),
-        20,
-        3
-    );
-    \WP_Mock::expectFilterAdded(
-        'wpforms_ajax_submit_redirect',
-        array( FacebookWordpressWPForms::class, 'injectLeadEventAjax' ),
-        20,
-        3
-    );
-    \WP_Mock::expectActionAdded(
-        'wp_footer',
-        array( FacebookWordpressWPForms::class, 'injectAjaxListener' ),
-        9
-    );
-
-        FacebookWordpressWPForms::inject_pixel_code();
-        $this->assertHooksAdded();
-    }
-
-    /**
-     * Tests the injectLeadEvent method when the user is not an internal user.
-     *
-     * This test verifies that the Pixel code is correctly
-     * appended to the HTML output
-     * when the user is not an internal user. It ensures that the output matches
-     * the expected pattern for the "wpforms-lite" event.
-     *
-     * @return void
-     */
-    public function testInjectLeadEventWithoutInternalUser() {
-        parent::mockIsInternalUser( false );
-        self::mockFacebookWordpressOptions();
-
-    \WP_Mock::userFunction(
-        'sanitize_text_field',
-        array(
-            'args'   => array( \Mockery::any() ),
-            'return' => function ( $input ) {
-                return $input;
-            },
-        )
-    );
-
-        $event = ServerEventFactory::new_event( 'Lead' );
-        FacebookServerSideEvent::get_instance()->track( $event );
-
-    \WP_Mock::userFunction(
-        'wp_json_encode',
-        array(
-            'args'   => array(
-                \Mockery::type( 'array' ),
-        \Mockery::type( 'int' ),
-      ),
-            'return' => function ( $data, $options ) {
-                return json_encode( $data );
-            },
-        )
-    );
-
-        FacebookWordpressWPForms::injectLeadEvent();
-    $this->expectOutputRegex(
-        '/wpforms-lite[\s\S]+End Meta Pixel Event Code/'
-    );
-    }
-
-    /**
-     * Tests the injectLeadEvent method when the user is an internal user.
-     *
-     * This test verifies that no Pixel code is appended to the HTML output
-     * when the user is an internal user. It
-     * asserts that the output HTML remains
-     * unchanged and that no events are tracked.
-     *
-     * @return void
-     */
-    public function testInjectLeadEventWithInternalUser() {
-        parent::mockIsInternalUser( true );
-        self::mockFacebookWordpressOptions();
-
-        FacebookWordpressWPForms::injectLeadEvent( 'mock_form_data' );
-        $this->expectOutputString( '' );
-    }
-
-    /**
-     * Tests the trackEvent method for a non-internal user.
-     *
-     * This test verifies that the Pixel code is correctly
-     * injected into the HTML
-     * output and that the server-side event is tracked
-     * with the correct parameters
-     * when the user is not an internal user. It asserts
-     * that the output HTML matches
-     * the expected pattern for the "wpforms-lite" event.
-     *
-     * @return void
-     */
-    public function testTrackEventWithoutInternalUser() {
-        self::mockIsInternalUser( false );
-        self::mockFacebookWordpressOptions();
-
-        $mock_entry     = $this->createMockEntry();
-        $mock_form_data = $this->createMockFormData();
-
-    \WP_Mock::userFunction(
-        'sanitize_text_field',
-        array(
-            'args'   => array( \Mockery::any() ),
-            'return' => function ( $input ) {
-                return $input;
-            },
-        )
-    );
+      );
 
     \WP_Mock::expectActionAdded(
-        'wp_footer',
+      'wp_footer',
+      array( $integration, 'inject_ajax_listener' ),
+      9
+    );
+
+    $integration->inject_pixel_code();
+
+    $this->assertConditionsMet();
+  }
+
+  /**
+   * read_form_data extracts the standard fields into an EventData.
+   *
+   * @return void
+   */
+  public function testReadFormDataReturnsEventData() {
+    list( $integration ) = $this->makeIntegration();
+
+    $form_data = array(
+      'fields' => array(
         array(
-            FacebookWordpressWPForms::class,
-            'injectLeadEvent',
+          'type'   => 'name',
+          'format' => 'simple',
+          'id'     => 0,
         ),
-        20
+        array(
+          'type' => 'email',
+          'id'   => 1,
+        ),
+      ),
+    );
+    $entry     = array(
+      'fields' => array(
+        0 => 'Pika Chu',
+        1 => 'pika.chu@s2s.com',
+      ),
     );
 
-    FacebookWordpressWPForms::trackEvent(
-        $mock_entry,
-        $mock_form_data
-    );
+    $data = $integration->read_form_data( $entry, $form_data );
 
-        $tracked_events =
-        FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-        $this->assertCount( 1, $tracked_events );
-
-        $event = $tracked_events[0];
-        $this->assertEquals( 'Lead', $event->getEventName() );
-        $this->assertNotNull( $event->getEventTime() );
-        $this->assertEquals(
-            'pika.chu@s2s.com',
-            $event->getUserData()->getEmail()
-        );
-        $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
-        $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
-        $this->assertEquals( '1234567', $event->getUserData()->getPhone() );
-        $this->assertEquals( 'us', $event->getUserData()->getCountryCode() );
-        $this->assertEquals( 'springfield', $event->getUserData()->getCity() );
-        $this->assertEquals( 'ohio', $event->getUserData()->getState() );
-        $this->assertEquals( '45401', $event->getUserData()->getZipCode() );
+    $this->assertInstanceOf( EventData::class, $data );
     $this->assertEquals(
-        'wpforms-lite',
-        $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
-    );
-    }
-
-    /**
-     * Tests the trackEvent method when the user is not an internal user,
-     * and the form data is provided in the simple format.
-     *
-     * This test verifies that the server-side event is tracked with the correct
-     * parameters when the user is not an internal user and the form data is
-     * provided in the simple format. It
-     * ensures that the output HTML matches the
-     * expected pattern for the "wpforms-lite" event.
-     *
-     * @return void
-     */
-    public function testTrackEventWithoutInternalUserSimpleFormat() {
-        self::mockIsInternalUser( false );
-        self::mockFacebookWordpressOptions();
-
-        $mock_entry              = $this->createMockEntry( true );
-        $mock_form_data          = $this->createMockFormData( true );
-        $_SERVER['HTTP_REFERER'] = 'TEST_REFERER';
-
-    \WP_Mock::expectActionAdded(
-        'wp_footer',
-        array(
-            FacebookWordpressWPForms::class,
-            'injectLeadEvent',
-        ),
-        20
-    );
-
-    \WP_Mock::userFunction(
-        'sanitize_text_field',
-        array(
-            'args'   => array( \Mockery::any() ),
-            'return' => function ( $input ) {
-                return $input;
-            },
-        )
-    );
-
-    FacebookWordpressWPForms::trackEvent(
-        $mock_entry,
-        $mock_form_data
-    );
-
-        $tracked_events =
-        FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-        $this->assertCount( 1, $tracked_events );
-
-        $event = $tracked_events[0];
-        $this->assertEquals( 'Lead', $event->getEventName() );
-        $this->assertNotNull( $event->getEventTime() );
-        $this->assertEquals(
-            'pika.chu@s2s.com',
-            $event->getUserData()->getEmail()
-        );
-        $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
-        $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
-        $this->assertEquals( '1234567', $event->getUserData()->getPhone() );
-        $this->assertEquals( 'us', $event->getUserData()->getCountryCode() );
-        $this->assertEquals( 'springfield', $event->getUserData()->getCity() );
-        $this->assertEquals( 'ohio', $event->getUserData()->getState() );
-        $this->assertEquals( '45401', $event->getUserData()->getZipCode() );
-        $this->assertEquals( 'TEST_REFERER', $event->getEventSourceUrl() );
-    }
-
-    /**
-     * Tests that ajax responses are enriched with pixel code.
-     *
-     * @return void
-     */
-    public function testInjectLeadEventAjaxAddsPixelCode() {
-        self::mockIsInternalUser( false );
-        self::mockFacebookWordpressOptions();
-
-    \WP_Mock::userFunction(
-        'sanitize_text_field',
-        array(
-            'args'   => array( \Mockery::any() ),
-            'return' => function ( $input ) {
-                return $input;
-            },
-        )
-    );
-
-    \WP_Mock::userFunction(
-        'wp_json_encode',
-        array(
-            'args'   => array(
-                \Mockery::type( 'array' ),
-        \Mockery::type( 'int' ),
+      array(
+        'email'      => 'pika.chu@s2s.com',
+        'first_name' => 'Pika',
+        'last_name'  => 'Chu',
       ),
-            'return' => function ( $data, $options ) {
-                return json_encode( $data );
-            },
-        )
+      $data->to_array()
     );
+  }
 
-        $event = ServerEventFactory::new_event( 'Lead' );
-        FacebookServerSideEvent::get_instance()->track( $event );
+  /**
+   * read_form_data returns null when the entry or form data is empty.
+   *
+   * @return void
+   */
+  public function testReadFormDataSkipsWhenEmpty() {
+    list( $integration ) = $this->makeIntegration();
 
-        $response = FacebookWordpressWPForms::injectLeadEventAjax( array(), 123, null );
-
-        $this->assertArrayHasKey( 'fb_pxl_code', $response );
-        $this->assertStringContainsString( "fbq('track'", $response['fb_pxl_code'] );
-    }
-
-    /**
-     * Tests that ajax responses remain unchanged for internal users.
-     *
-     * @return void
-     */
-    public function testInjectLeadEventAjaxSkipsForInternalUser() {
-        self::mockIsInternalUser( true );
-        self::mockFacebookWordpressOptions();
-
-        $response = FacebookWordpressWPForms::injectLeadEventAjax( array( 'foo' => 'bar' ), 123, null );
-
-        $this->assertArrayNotHasKey( 'fb_pxl_code', $response );
-        $this->assertEquals( 'bar', $response['foo'] );
-    }
-
-    /**
-     * Tests that the AJAX listener script is printed.
-     *
-     * @return void
-     */
-    public function testInjectAjaxListenerOutputsScript() {
-        FacebookWordpressWPForms::injectAjaxListener();
-        $this->expectOutputRegex( '/wpformsAjaxSubmitSuccess/' );
-    }
-
-    /**
-     * Creates a mock entry with predefined field values.
-     *
-     * This method creates a mock entry with sample data including email,
-     * first name, last name, phone, and address fields. It utilizes the
-     * simple format or the first-last format for the name field, depending on
-     * the value of the $simple_format parameter.
-     *
-     * @param bool $simple_format Whether to use the
-     * simple format for the name field.
-     *
-     * @return array The mock entry with predefined field values.
-     */
-    private function createMockEntry( $simple_format = false ) {
-        return array(
-            'fields' => array(
-                '0' => $simple_format ? 'Pika Chu' : array(
-                    'first' => 'Pika',
-                    'last'  => 'Chu',
-                ),
-                '1' => 'pika.chu@s2s.com',
-                '2' => '1234567',
-                '3' => array(
-                    'country' => 'US',
-                    'postal'  => '45401',
-                    'state'   => 'Ohio',
-                    'city'    => 'Springfield',
-                ),
-            ),
-        );
-    }
-
-    /**
-     * Creates a mock form data object with predefined field values.
-     *
-     * This method creates a mock form data object
-     * with sample data including email,
-     * first name, last name, phone, and address fields. It utilizes the
-     * simple format or the first-last format for the name field, depending on
-     * the value of the $simple_format parameter.
-     *
-     * @param bool $simple_format Whether to use
-     * the simple format for the name field.
-     *
-     * @return array The mock form data object with predefined field values.
-     */
-    private function createMockFormData( $simple_format = false ) {
-        return array(
-            'fields' => array(
-                array(
-                    'type'   => 'name',
-                    'id'     => '0',
-                    'format' => $simple_format ? 'simple' : 'first-last',
-                ),
-                array(
-                    'type' => 'email',
-                    'id'   => '1',
-                ),
-                array(
-                    'type' => 'phone',
-                    'id'   => '2',
-                ),
-                array(
-                    'type' => 'address',
-                    'id'   => '3',
-                ),
-            ),
-        );
-    }
+    $this->assertNull( $integration->read_form_data( array(), array() ) );
+  }
 }

--- a/__tests__/integration/FacebookWordpressWooCommerceTest.php
+++ b/__tests__/integration/FacebookWordpressWooCommerceTest.php
@@ -201,7 +201,7 @@ final class FacebookWordpressWooCommerceTest extends FacebookWordpressTestBase {
   }
 
   /**
-   * inject_pixel_code registers six Signals events when Facebook for
+   * set_up_tracking registers six Signals events when Facebook for
    * WooCommerce is not active, and AddToCart alone uses the cart-fragment
    * delivery while the rest use the inline-script delivery.
    *
@@ -225,7 +225,7 @@ final class FacebookWordpressWooCommerceTest extends FacebookWordpressTestBase {
         }
       );
 
-    $integration->inject_pixel_code();
+    $integration->set_up_tracking();
 
     $this->assertInstanceOf(
       CartFragmentDelivery::class,
@@ -246,7 +246,7 @@ final class FacebookWordpressWooCommerceTest extends FacebookWordpressTestBase {
   }
 
   /**
-   * inject_pixel_code registers nothing when Facebook for WooCommerce owns
+   * set_up_tracking registers nothing when Facebook for WooCommerce owns
    * tracking.
    *
    * @return void
@@ -262,7 +262,7 @@ final class FacebookWordpressWooCommerceTest extends FacebookWordpressTestBase {
 
     $signals->expects( $this->never() )->method( 'on' );
 
-    $integration->inject_pixel_code();
+    $integration->set_up_tracking();
 
     $this->assertConditionsMet();
   }

--- a/__tests__/integration/FacebookWordpressWooCommerceTest.php
+++ b/__tests__/integration/FacebookWordpressWooCommerceTest.php
@@ -2,15 +2,7 @@
 /**
  * Facebook Pixel Plugin FacebookWordpressWooCommerceTest class.
  *
- * This file contains the main logic for FacebookWordpressWooCommerceTest.
- *
  * @package FacebookPixelPlugin
- */
-
-/**
- * Define FacebookWordpressWooCommerceTest class.
- *
- * @return void
  */
 
 /*
@@ -27,785 +19,482 @@
 
 namespace FacebookPixelPlugin\Tests\Integration;
 
+use FacebookPixelPlugin\Core\Signals;
+use FacebookPixelPlugin\Core\EventDataBuilder;
+use FacebookPixelPlugin\Core\InlineScriptDelivery;
+use FacebookPixelPlugin\Core\CartFragmentDelivery;
+use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 use FacebookPixelPlugin\Integration\FacebookWordpressWooCommerce;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
 use FacebookPixelPlugin\Tests\Mocks\MockWC;
 use FacebookPixelPlugin\Tests\Mocks\MockWCCart;
 use FacebookPixelPlugin\Tests\Mocks\MockWCOrder;
 use FacebookPixelPlugin\Tests\Mocks\MockWCProduct;
-use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
 
 /**
  * FacebookWordpressWooCommerceTest class.
  *
+ * These tests assert the same observable behavior as before the Signals
+ * refactor: firing an event through the integration ends up tracking a
+ * server-side event carrying the correct user/custom data, and the AJAX
+ * add-to-cart path still yields a cart fragment with the pixel code. The only
+ * change is the entry point — the data provider plus the real Signals dispatch
+ * path instead of the old track/inject static methods.
+ *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
- *
- * All tests in this test class should be run in separate PHP process to
- * make sure tests are isolated.
- * Stop preserving global state from the parent process.
  */
 final class FacebookWordpressWooCommerceTest extends FacebookWordpressTestBase {
 
-    /**
-     * Tests the inject_pixel_code method when the
-     * Facebook for WooCommerce plugin is not active.
-     *
-     * This test verifies that the appropriate WordPress action hooks are added,
-     * specifically checking that the 'woocommerce_after_checkout_form' hook is
-     * registered with the 'trackInitiateCheckout' method from the
-     * FacebookWordpressWooCommerce class.
-     *
-     * @return void
-     */
-    public function testInjectPixelCodeWithWooNotActive() {
-        $this->mockFacebookForWooCommerce( false );
-
-    \WP_Mock::expectActionAdded(
-        'woocommerce_after_checkout_form',
-        array(
-            FacebookWordpressWooCommerce::class,
-            'trackInitiateCheckout',
-        ),
-        40
+  /**
+   * Builds a WooCommerce integration wired to a real Signals dispatcher, so a
+   * dispatched event actually tracks through FacebookServerSideEvent.
+   *
+   * @return array [ FacebookWordpressWooCommerce, Signals ]
+   */
+  private function makeIntegration() {
+    $signals     = new Signals();
+    $integration = new FacebookWordpressWooCommerce(
+      $signals,
+      new EventDataBuilder()
     );
+    return array( $integration, $signals );
+  }
 
-        FacebookWordpressWooCommerce::inject_pixel_code();
-    }
-
-    /**
-     * Tests the inject_pixel_code method when the Facebook
-     * for WooCommerce plugin is active.
-     *
-     * This test verifies that the 'woocommerce_after_checkout_form' action hook
-     * is not added when the plugin is active, ensuring
-     * that the 'trackInitiateCheckout'
-     * method from the FacebookWordpressWooCommerce class is not registered.
-     *
-     * @return void
-     */
-    public function testInjectPixelCodeWithWooActive() {
-        $this->mockFacebookForWooCommerce( true );
-
-    \WP_Mock::expectActionNotAdded(
-        'woocommerce_after_checkout_form',
-        array(
-            FacebookWordpressWooCommerce::class,
-            'trackInitiateCheckout',
-        ),
-        40
-    );
-
-        FacebookWordpressWooCommerce::inject_pixel_code();
-    }
-
-    /**
-     * Tests that the trackPurchaseEvent method correctly
-     * records a 'Purchase' event
-     * when the user is not an internal user.
-     *
-     * This test verifies that the server-side event tracking records the
-     * 'Purchase' event with the correct user and custom data attributes.
-     *
-     * @return void
-     */
-    public function testPurchaseEventWithoutInternalUser() {
-        self::mockIsInternalUser( false );
-        self::mockFacebookWordpressOptions();
-
-        $this->setupMocks();
-
+  /**
+   * Mocks the Facebook-for-WooCommerce active-plugin check.
+   *
+   * @param bool $active Whether the plugin is active.
+   * @return void
+   */
+  private function mockFacebookForWooCommerce( $active ) {
     \WP_Mock::userFunction(
-        'sanitize_text_field',
-        array(
-            'args'   => array( \Mockery::any() ),
-            'return' => function ( $input ) {
-                return $input;
-            },
-        )
+      'get_option',
+      array(
+        'return' => $active
+          ? array( 'facebook-for-woocommerce/facebook-for-woocommerce.php' )
+          : array(),
+      )
     );
+  }
 
+  /**
+   * Stubs the JSON/sanitize helpers the dispatch/render path relies on.
+   *
+   * @return void
+   */
+  private function mockRenderHelpers() {
     \WP_Mock::userFunction(
-        'wp_json_encode',
-        array(
-            'args'   => array(
-                \Mockery::type( 'array' ),
-        \Mockery::type( 'int' ),
-      ),
-            'return' => function ( $data, $options ) {
-                return json_encode( $data );
-            },
-        )
-    );
-
-        FacebookWordpressWooCommerce::trackPurchaseEvent( 1 );
-        $tracked_events =
-        FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-        $this->assertCount( 1, $tracked_events );
-
-        $event = $tracked_events[0];
-        $this->assertEquals( 'Purchase', $event->getEventName() );
-        $this->assertNotNull( $event->getEventTime() );
-        $this->assertEquals(
-            'pika.chu@s2s.com',
-            $event->getUserData()->getEmail()
-        );
-        $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
-        $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
-        $this->assertEquals( '2062062006', $event->getUserData()->getPhone() );
-        $this->assertEquals( 'springfield', $event->getUserData()->getCity() );
-        $this->assertEquals( 'ohio', $event->getUserData()->getState() );
-        $this->assertEquals( 'us', $event->getUserData()->getCountryCode() );
-        $this->assertEquals( '12345', $event->getUserData()->getZipCode() );
-        $this->assertEquals( 'USD', $event->getCustomData()->getCurrency() );
-        $this->assertEquals( 900, $event->getCustomData()->getValue() );
-        $this->assertEquals(
-            'wc_post_id_1',
-            $event->getCustomData()->getContentIds()[0]
-        );
-
-        $contents = $event->getCustomData()->getContents();
-        $this->assertCount( 1, $contents );
-        $this->assertEquals( 'wc_post_id_1', $contents[0]->getProductId() );
-        $this->assertEquals( 3, $contents[0]->getQuantity() );
-        $this->assertEquals( 300, $contents[0]->getItemPrice() );
-
-    $this->assertEquals(
-        'woocommerce',
-        $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
-    );
-    }
-
-    /**
-     * Tests that the trackInitiateCheckout method correctly records an
-     * 'InitiateCheckout' event when the user is not an internal user.
-     *
-     * This test verifies that the server-side event tracking records the
-     * 'InitiateCheckout' event with the correct user and custom data
-     * attributes.
-     *
-     * @return void
-     */
-    public function testInitiateCheckoutEventWithoutInternalUser() {
-        self::mockIsInternalUser( false );
-        self::mockFacebookWordpressOptions();
-
-        $this->setupMocks();
-        $this->setupCustomerBillingAddress();
-
-    \WP_Mock::userFunction(
-        'wp_json_encode',
-        array(
-            'args'   => array(
-                \Mockery::type( 'array' ),
-        \Mockery::type( 'int' ),
-      ),
-            'return' => function ( $data, $options ) {
-                return json_encode( $data );
-            },
-        )
-    );
-
-    \WP_Mock::userFunction(
-        'sanitize_text_field',
-        array(
-            'args'   => array( \Mockery::any() ),
-            'return' => function ( $input ) {
-                return $input;
-            },
-        )
-    );
-
-        FacebookWordpressWooCommerce::trackInitiateCheckout();
-        $tracked_events =
-        FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-        $this->assertCount( 1, $tracked_events );
-
-        $event = $tracked_events[0];
-
-        $this->assertEquals( 'InitiateCheckout', $event->getEventName() );
-        $this->assertNotNull( $event->getEventTime() );
-        $this->assertEquals(
-            'pika.chu@s2s.com',
-            $event->getUserData()->getEmail()
-        );
-        $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
-        $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
-        $this->assertEquals( '2062062006', $event->getUserData()->getPhone() );
-        $this->assertEquals( 'springfield', $event->getUserData()->getCity() );
-        $this->assertEquals( 'ohio', $event->getUserData()->getState() );
-        $this->assertEquals( 'us', $event->getUserData()->getCountryCode() );
-        $this->assertEquals( '12345', $event->getUserData()->getZipCode() );
-        $this->assertEquals( 'USD', $event->getCustomData()->getCurrency() );
-        $this->assertEquals( 900, $event->getCustomData()->getValue() );
-        $this->assertEquals( 3, $event->getCustomData()->getNumItems() );
-    $this->assertEquals(
-        'wc_post_id_1',
-        $event->getCustomData()->getContentIds()[0]
-    );
-
-        $contents = $event->getCustomData()->getContents();
-        $this->assertCount( 1, $contents );
-        $this->assertEquals( 'wc_post_id_1', $contents[0]->getProductId() );
-        $this->assertEquals( 3, $contents[0]->getQuantity() );
-        $this->assertEquals( 300, $contents[0]->getItemPrice() );
-
-    $this->assertEquals(
-        'woocommerce',
-        $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
-    );
-    }
-
-    /**
-     * Tests that the trackAddToCartEvent method correctly records an
-     * 'AddToCart' event when the user is not an internal user.
-     *
-     * This test verifies that the server-side event tracking records the
-     * 'AddToCart' event with the correct user and custom data attributes.
-     *
-     * @return void
-     */
-    public function testAddToCartEventWithoutInternalUser() {
-    \WP_Mock::userFunction(
-        'wp_doing_ajax',
-        array( 'return' => false )
-    );
-
-    \WP_Mock::userFunction(
-        'wp_json_encode',
-        array(
-            'args'   => array(
-                \Mockery::type( 'array' ),
-        \Mockery::type( 'int' ),
-      ),
-            'return' => function ( $data, $options ) {
-                return json_encode( $data );
-            },
-        )
-    );
-
-    \WP_Mock::userFunction(
-        'sanitize_text_field',
-        array(
-            'args'   => array( \Mockery::any() ),
-            'return' => function ( $input ) {
-                return $input;
-            },
-        )
-    );
-
-        self::mockIsInternalUser( false );
-        self::mockFacebookWordpressOptions();
-
-        $this->setupMocks();
-        $this->setupCustomerBillingAddress();
-
-        FacebookWordpressWooCommerce::trackAddToCartEvent( 1, 1, 3, null );
-        $tracked_events =
-        FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-        $this->assertCount( 1, $tracked_events );
-
-        $event = $tracked_events[0];
-
-        $this->assertEquals( 'AddToCart', $event->getEventName() );
-        $this->assertNotNull( $event->getEventTime() );
-        $this->assertEquals(
-            'pika.chu@s2s.com',
-            $event->getUserData()->getEmail()
-        );
-        $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
-        $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
-        $this->assertEquals( '2062062006', $event->getUserData()->getPhone() );
-        $this->assertEquals( 'springfield', $event->getUserData()->getCity() );
-        $this->assertEquals( 'ohio', $event->getUserData()->getState() );
-        $this->assertEquals( 'us', $event->getUserData()->getCountryCode() );
-        $this->assertEquals( '12345', $event->getUserData()->getZipCode() );
-        $this->assertEquals( 'USD', $event->getCustomData()->getCurrency() );
-        $this->assertEquals( 900, $event->getCustomData()->getValue() );
-    $this->assertEquals(
-        'wc_post_id_1',
-        $event->getCustomData()->getContentIds()[0]
-    );
-
-    $this->assertEquals(
-        'woocommerce',
-        $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
-    );
-    }
-
-    /**
-     * Tests the trackAddToCartEvent method
-     * when the user is not an internal user
-     * and the request is an AJAX request.
-     *
-     * This test verifies that the "woocommerce_add_to_cart_fragments" filter is
-     * added and that the server-side event
-     * is tracked with the correct parameters
-     * when the user is not an internal user and the request is an AJAX request.
-     */
-    public function testAddToCartEventAjaxWithoutInternalUser() {
-    \WP_Mock::userFunction(
-        'wp_doing_ajax',
-        array( 'return' => true )
-    );
-
-    \WP_Mock::userFunction(
-        'sanitize_text_field',
-        array(
-            'args'   => array( \Mockery::any() ),
-            'return' => function ( $input ) {
-                return $input;
-            },
-        )
-    );
-
-        self::mockIsInternalUser( false );
-        self::mockFacebookWordpressOptions();
-
-        $this->setupMocks();
-        $this->setupCustomerBillingAddress();
-
-    \WP_Mock::expectFilterAdded(
-        'woocommerce_add_to_cart_fragments',
-        array(
-            FacebookWordpressWooCommerce::class,
-            'addPixelCodeToAddToCartFragment',
-        )
-    );
-
-        FacebookWordpressWooCommerce::trackAddToCartEvent( 1, 1, 3, null );
-
-        $tracked_events =
-        FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-        $this->assertCount( 1, $tracked_events );
-
-        $event = $tracked_events[0];
-
-        $this->assertEquals( 'AddToCart', $event->getEventName() );
-        $this->assertNotNull( $event->getEventTime() );
-        $this->assertEquals(
-            'pika.chu@s2s.com',
-            $event->getUserData()->getEmail()
-        );
-        $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
-        $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
-        $this->assertEquals( '2062062006', $event->getUserData()->getPhone() );
-        $this->assertEquals( 'springfield', $event->getUserData()->getCity() );
-        $this->assertEquals( 'ohio', $event->getUserData()->getState() );
-        $this->assertEquals( 'us', $event->getUserData()->getCountryCode() );
-        $this->assertEquals( '12345', $event->getUserData()->getZipCode() );
-        $this->assertEquals( 'USD', $event->getCustomData()->getCurrency() );
-        $this->assertEquals( 900, $event->getCustomData()->getValue() );
-    $this->assertEquals(
-        'wc_post_id_1',
-        $event->getCustomData()->getContentIds()[0]
-    );
-
-    $this->assertEquals(
-        'woocommerce',
-        $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
-    );
-    }
-
-    /**
-     * Tests the trackViewContentEvent method when
-     * the user is not an internal user.
-     *
-     * This test verifies that the Pixel code is
-     * correctly injected into the HTML
-     * output and that the server-side event is
-     * tracked with the correct parameters
-     * when the user is not an internal user. It
-     * asserts that the output HTML matches
-     * the expected pattern for the "ViewContent" event.
-     *
-     * @return void
-     */
-    public function testViewContentWithoutAdmin() {
-    \WP_Mock::userFunction(
-        'wp_json_encode',
-        array(
-            'args'   => array(
-                \Mockery::type( 'array' ),
-        \Mockery::type( 'int' ),
-      ),
-            'return' => function ( $data, $options ) {
-                return json_encode( $data );
-            },
-        )
-    );
-
-        self::mockIsInternalUser( false );
-        self::mockFacebookWordpressOptions();
-
-        $this->setupMocks();
-        $this->setupCustomerBillingAddress();
-
-        $raw_post     = new \stdClass();
-        $raw_post->ID = 1;
-        global $post;
-        $post = $raw_post;
-
-    \WP_Mock::userFunction(
-        'sanitize_text_field',
-        array(
-            'args'   => array( \Mockery::any() ),
-            'return' => function ( $input ) {
-                return $input;
-            },
-        )
-    );
-
-    \WP_Mock::userFunction(
-        'wp_json_encode',
-        array(
-            'args'   => array(
-                \Mockery::type( 'array' ),
-        \Mockery::type( 'int' ),
-      ),
-            'return' => function ( $data, $options ) {
-                return json_encode( $data );
-            },
-        )
-    );
-
-        FacebookWordpressWooCommerce::trackViewContentEvent();
-
-        $tracked_events =
-        FacebookServerSideEvent::get_instance()->get_tracked_events();
-
-        $this->assertCount( 1, $tracked_events );
-
-        $event = $tracked_events[0];
-
-        $this->assertNotNull( $event->getEventTime() );
-        $this->assertEquals(
-            'pika.chu@s2s.com',
-            $event->getUserData()->getEmail()
-        );
-        $this->assertEquals( 'pika', $event->getUserData()->getFirstName() );
-        $this->assertEquals( 'chu', $event->getUserData()->getLastName() );
-        $this->assertEquals( '2062062006', $event->getUserData()->getPhone() );
-        $this->assertEquals( 'springfield', $event->getUserData()->getCity() );
-        $this->assertEquals( 'ohio', $event->getUserData()->getState() );
-        $this->assertEquals( 'us', $event->getUserData()->getCountryCode() );
-        $this->assertEquals( '12345', $event->getUserData()->getZipCode() );
-
-        $this->assertEquals( 10, $event->getCustomData()->getValue() );
-    $this->assertEquals(
-        'wc_post_id_1',
-        $event->getCustomData()->getContentIds()[0]
-    );
-    $this->assertEquals(
-        'Stegosaurus',
-        $event->getCustomData()->getContentName()
-    );
-    $this->assertEquals(
-        'product',
-        $event->getCustomData()->getContentType()
-    );
-    $this->assertEquals(
-        'USD',
-        $event->getCustomData()->getCurrency()
-    );
-    $this->assertEquals(
-        'Dinosaurs',
-        $event->getCustomData()->getContentCategory()
-    );
-
-    $this->assertEquals(
-        'woocommerce',
-        $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
-    );
-    }
-
-    /**
-     * Test that the enqueuePixelCode method correctly enqueues the
-     * appropriate Pixel code for WooCommerce events when the user
-     * is not an internal user.
-     *
-     * This test verifies that the output contains the expected Meta Pixel
-     * Event Code for WooCommerce and that the server-side event tracking
-     * records the event with the correct user and custom data attributes.
-     */
-    public function testEnqueuePixelEvent() {
-    \WP_Mock::userFunction(
-        'wp_json_encode',
-        array(
-            'args'   => array(
-                \Mockery::type( 'array' ),
-        \Mockery::type( 'int' ),
-      ),
-            'return' => function ( $data, $options ) {
-                return json_encode( $data );
-            },
-        )
-    );
-
-        self::mockIsInternalUser( false );
-        self::mockFacebookWordpressOptions();
-
-        $this->setupMocks();
-        $server_event = new Event();
-        $pixel_code   =
-        FacebookWordpressWooCommerce::enqueuePixelCode( $server_event );
-    $this->assertMatchesRegularExpression(
-        '/woocommerce[\s\S]+End Meta Pixel Event Code/',
-        $pixel_code
-    );
-    }
-
-    /**
-     * Tests that the addPixelCodeToAddToCartFragment method correctly adds
-     * the Pixel code to the AJAX response fragments.
-     *
-     * This test verifies that the Pixel code is included in the AJAX fragments
-     * returned by the addPixelCodeToAddToCartFragment method when the
-     * Facebook for WooCommerce integration is triggered. It ensures that the
-     * appropriate HTML element ID is present in the fragments array and that
-     * the Pixel code matches the expected pattern for WooCommerce.
-     *
-     * @return void
-     */
-    public function testAddPixelCodeToAddToCartFragment() {
-        self::mockFacebookWordpressOptions();
-
-        $server_event = new Event();
-    FacebookServerSideEvent::get_instance()->set_pending_pixel_event(
-        'addPixelCodeToAddToCartFragment',
-        $server_event
-    );
-
-    \WP_Mock::userFunction(
-        'wp_json_encode',
-        array(
-            'args'   => array(
-                \Mockery::type( 'array' ),
-        \Mockery::type( 'int' ),
-      ),
-            'return' => function ( $data, $options ) {
-                return json_encode( $data );
-            },
-        )
-    );
-
-        $fragments =
-        FacebookWordpressWooCommerce::addPixelCodeToAddToCartFragment(
-            array()
-        );
-
-    $this->assertArrayHasKey(
-        '#' . FacebookWordpressWooCommerce::DIV_ID_FOR_AJAX_PIXEL_EVENTS,
-        $fragments
-    );
-        $pxl_div_code = $fragments[ '#' .
-        FacebookWordpressWooCommerce::DIV_ID_FOR_AJAX_PIXEL_EVENTS ];
-    $this->assertMatchesRegularExpression(
-        '/id=\'fb-pxl-ajax-code\'[\s\S]+woocommerce/',
-        $pxl_div_code
-    );
-    }
-
-    /**
-     * Mocks the presence of the Facebook for WooCommerce plugin.
-     *
-     * This function simulates the activation status
-     * of the Facebook for WooCommerce
-     * plugin by mocking the 'get_option' function. It returns a specific plugin
-     * identifier if the plugin is active, otherwise returns an empty array.
-     *
-     * @param bool $active Determines if the plugin is considered active.
-     *                     If true, the plugin is mocked as active.
-     *                     If false, the plugin is mocked as inactive.
-     *
-     * @return void
-     */
-    private function mockFacebookForWooCommerce( $active ) {
-    \WP_Mock::userFunction(
-        'get_option',
-        array(
-            'return' => $active ? array(
-                'facebook-for-woocommerce/facebook-for-woocommerce.php',
-      ) : array(),
-        )
-    );
-    }
-
-    /**
-     * Sets up customer billing address mocks.
-     *
-     * This method is used to simulate the presence of customer billing address
-     * data. It uses WP_Mock to define the results of the get_user_meta function
-     * when requesting the billing city, state, postcode, country, and phone.
-     *
-     * @return void
-     */
-    private function setupCustomerBillingAddress() {
-    \WP_Mock::userFunction(
-        'get_user_meta',
-        array(
-            'times'  => 1,
-            'args'   => array(
-        \WP_Mock\Functions::type( 'int' ),
-        'billing_city',
-        true,
-      ),
-            'return' => 'Springfield',
-        )
+      'wp_json_encode',
+      array(
+        'args'   => array( \Mockery::type( 'array' ), \Mockery::type( 'int' ) ),
+        'return' => function ( $data, $options ) {
+          return json_encode( $data );
+        },
+      )
     );
     \WP_Mock::userFunction(
-        'get_user_meta',
-        array(
-            'times'  => 1,
-            'args'   => array(
-                \WP_Mock\Functions::type( 'int' ),
-        'billing_state',
-        true,
-      ),
-            'return' => 'Ohio',
-        )
+      'sanitize_text_field',
+      array(
+        'args'   => array( \Mockery::any() ),
+        'return' => function ( $input ) {
+          return $input;
+        },
+      )
     );
-    \WP_Mock::userFunction(
-        'get_user_meta',
-        array(
-            'times'  => 1,
-            'args'   => array(
-                \WP_Mock\Functions::type( 'int' ),
-                'billing_postcode',
-                true,
-            ),
-            'return' => '12345',
-        )
-    );
-    \WP_Mock::userFunction(
-        'get_user_meta',
-        array(
-            'times'  => 1,
-            'args'   => array(
-                \WP_Mock\Functions::type( 'int' ),
-                'billing_country',
-                true,
-            ),
-            'return' => 'US',
-        )
-    );
-    \WP_Mock::userFunction(
-        'get_user_meta',
-        array(
-            'times'  => 1,
-            'args'   => array(
-                \WP_Mock\Functions::type( 'int' ),
-        'billing_phone',
-        true,
-      ),
-            'return' => '2062062006',
-        )
-    );
-    }
+  }
 
-    /**
-     * Sets up various mocks for the WooCommerce integration tests.
-     *
-     * This method uses WP_Mock to define
-     * the results of various functions that are
-     * used in the WooCommerce integration code. It sets up the following mocks:
-     *
-     * - WC(): Returns a MockWC object.
-     * - wc_get_order(): Returns a MockWCOrder object.
-     * - wc_get_product(): Returns a MockWCProduct object.
-     * - get_current_user_id(): Returns 1.
-     * - get_the_terms(): Returns an array containing a
-     *                    stdClass object with a name
-     *                    property set to 'Dinosaurs'.
-     * - wp_add_inline_script(): Does nothing.
-     *
-     * Additionally, it sets up the MockWC object
-     * to return a MockWCCart object when
-     * calling WC()->cart.
-     *
-     * @return void
-     */
-    private function setupMocks() {
-        $this->mocked_fbpixel->shouldReceive( 'get_logged_in_user_info' )
-    ->andReturn(
+  /**
+   * Sets up the WooCommerce data-source mocks used by the create* builders.
+   *
+   * @return void
+   */
+  private function setupMocks() {
+    $this->mocked_fbpixel->shouldReceive( 'get_logged_in_user_info' )
+      ->andReturn(
         array(
-            'email'      => 'pika.chu@s2s.com',
-            'first_name' => 'Pika',
-            'last_name'  => 'Chu',
+          'email'      => 'pika.chu@s2s.com',
+          'first_name' => 'Pika',
+          'last_name'  => 'Chu',
         )
-    );
+      );
 
     \WP_Mock::userFunction(
-        'get_woocommerce_currency',
-        array(
-            'return' => 'USD',
-        )
+      'get_woocommerce_currency',
+      array( 'return' => 'USD' )
     );
 
-        $cart = new MockWCCart();
-        $cart->add_item( 1, 1, 3, 300 );
-
-    \WP_Mock::userFunction(
-        'WC',
-        array(
-            'return' => new MockWC( $cart ),
-        )
-    );
+    $cart = new MockWCCart();
+    $cart->add_item( 1, 1, 3, 300 );
+    \WP_Mock::userFunction( 'WC', array( 'return' => new MockWC( $cart ) ) );
 
     $order = new MockWCOrder(
-        'Pika',
-        'Chu',
-        'pika.chu@s2s.com',
-        '2062062006',
-        'Springfield',
-        '12345',
-        'Ohio',
-        'US'
+      'Pika',
+      'Chu',
+      'pika.chu@s2s.com',
+      '2062062006',
+      'Springfield',
+      '12345',
+      'Ohio',
+      'US'
     );
-        $order->add_item( 1, 3, 900 );
+    $order->add_item( 1, 3, 900 );
+    \WP_Mock::userFunction( 'wc_get_order', array( 'return' => $order ) );
 
     \WP_Mock::userFunction(
-        'wc_get_order',
-        array(
-            'return' => $order,
-        )
+      'wc_get_product',
+      array(
+        'return' => new MockWCProduct( 1, 'single_product', 'Stegosaurus', 10 ),
+      )
     );
 
-    \WP_Mock::userFunction(
-        'wc_get_product',
-        array(
-            'return' => new MockWCProduct(
-                1,
-                'single_product',
-                'Stegosaurus',
-                10
-            ),
-        )
-    );
+    \WP_Mock::userFunction( 'get_current_user_id', array( 'return' => 1 ) );
 
+    $term       = new \stdClass();
+    $term->name = 'Dinosaurs';
     \WP_Mock::userFunction(
-        'get_current_user_id',
-        array(
-            'return' => 1,
-        )
+      'get_the_terms',
+      array( 'return' => array( $term ) )
     );
-        $term       = new \stdClass();
-        $term->name = 'Dinosaurs';
-    \WP_Mock::userFunction(
-        'get_the_terms',
-        array(
-            'return' => array( $term ),
-        )
-    );
+  }
 
-        \WP_Mock::userFunction( 'wp_add_inline_script', array() );
-        \WP_Mock::userFunction('wp_script_is', array('return' => false));
-        \WP_Mock::userFunction('wp_register_script', array());
-        \WP_Mock::userFunction('wp_enqueue_script', array());
+  /**
+   * Sets up the logged-in customer's billing address meta.
+   *
+   * @return void
+   */
+  private function setupCustomerBillingAddress() {
+    $meta = array(
+      'billing_city'     => 'Springfield',
+      'billing_state'    => 'Ohio',
+      'billing_postcode' => '12345',
+      'billing_country'  => 'US',
+      'billing_phone'    => '2062062006',
+    );
+    foreach ( $meta as $key => $value ) {
+      \WP_Mock::userFunction(
+        'get_user_meta',
+        array(
+          'args'   => array( \WP_Mock\Functions::type( 'int' ), $key, true ),
+          'return' => $value,
+        )
+      );
     }
+  }
+
+  /**
+   * Asserts the shared user data present on every WooCommerce event.
+   *
+   * @param object $event The tracked server event.
+   * @return void
+   */
+  private function assertCustomerUserData( $event ) {
+    $user_data = $event->getUserData();
+    $this->assertEquals( 'pika.chu@s2s.com', $user_data->getEmail() );
+    $this->assertEquals( 'pika', $user_data->getFirstName() );
+    $this->assertEquals( 'chu', $user_data->getLastName() );
+    $this->assertEquals( '2062062006', $user_data->getPhone() );
+    $this->assertEquals( 'springfield', $user_data->getCity() );
+    $this->assertEquals( 'ohio', $user_data->getState() );
+    $this->assertEquals( 'us', $user_data->getCountryCode() );
+    $this->assertEquals( '12345', $user_data->getZipCode() );
+  }
+
+  /**
+   * inject_pixel_code registers six Signals events when Facebook for
+   * WooCommerce is not active, and AddToCart alone uses the cart-fragment
+   * delivery while the rest use the inline-script delivery.
+   *
+   * @return void
+   */
+  public function testInjectPixelCodeRegistersEventsWhenWooNotActive() {
+    $this->mockFacebookForWooCommerce( false );
+
+    $signals     = $this->createMock( Signals::class );
+    $integration = new FacebookWordpressWooCommerce(
+      $signals,
+      new EventDataBuilder()
+    );
+
+    $deliveries = array();
+    $signals->expects( $this->exactly( 6 ) )
+      ->method( 'on' )
+      ->willReturnCallback(
+        function ( $hook, $event, $provider, $delivery ) use ( &$deliveries ) {
+          $deliveries[ $event ] = $delivery;
+        }
+      );
+
+    $integration->inject_pixel_code();
+
+    $this->assertInstanceOf(
+      CartFragmentDelivery::class,
+      $deliveries['AddToCart']
+    );
+    $this->assertInstanceOf(
+      InlineScriptDelivery::class,
+      $deliveries['InitiateCheckout']
+    );
+    $this->assertInstanceOf(
+      InlineScriptDelivery::class,
+      $deliveries['Purchase']
+    );
+    $this->assertInstanceOf(
+      InlineScriptDelivery::class,
+      $deliveries['ViewContent']
+    );
+  }
+
+  /**
+   * inject_pixel_code registers nothing when Facebook for WooCommerce owns
+   * tracking.
+   *
+   * @return void
+   */
+  public function testInjectPixelCodeSkipsWhenWooActive() {
+    $this->mockFacebookForWooCommerce( true );
+
+    $signals     = $this->createMock( Signals::class );
+    $integration = new FacebookWordpressWooCommerce(
+      $signals,
+      new EventDataBuilder()
+    );
+
+    $signals->expects( $this->never() )->method( 'on' );
+
+    $integration->inject_pixel_code();
+
+    $this->assertConditionsMet();
+  }
+
+  /**
+   * A dispatched Purchase tracks a Purchase server event with order data.
+   *
+   * @return void
+   */
+  public function testPurchaseEventWithoutInternalUser() {
+    self::mockIsInternalUser( false );
+    self::mockFacebookWordpressOptions();
+    $this->setupMocks();
+    $this->setupCustomerBillingAddress();
+    $this->mockRenderHelpers();
+
+    list( $integration, $signals ) = $this->makeIntegration();
+
+    $data = $integration->read_purchase( 1 );
+    $signals->dispatch(
+      'Purchase',
+      $data,
+      FacebookWordpressWooCommerce::TRACKING_NAME
+    );
+
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 1, $tracked_events );
+
+    $event = $tracked_events[0];
+    $this->assertEquals( 'Purchase', $event->getEventName() );
+    $this->assertNotNull( $event->getEventTime() );
+    $this->assertCustomerUserData( $event );
+    $this->assertEquals( 'USD', $event->getCustomData()->getCurrency() );
+    $this->assertEquals( 900, $event->getCustomData()->getValue() );
+    $this->assertEquals(
+      'wc_post_id_1',
+      $event->getCustomData()->getContentIds()[0]
+    );
+
+    $contents = $event->getCustomData()->getContents();
+    $this->assertCount( 1, $contents );
+    $this->assertEquals( 'wc_post_id_1', $contents[0]->getProductId() );
+    $this->assertEquals( 3, $contents[0]->getQuantity() );
+    $this->assertEquals( 300, $contents[0]->getItemPrice() );
+
+    $this->assertEquals(
+      'woocommerce',
+      $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
+    );
+  }
+
+  /**
+   * A dispatched InitiateCheckout tracks an InitiateCheckout server event with
+   * the cart data.
+   *
+   * @return void
+   */
+  public function testInitiateCheckoutEventWithoutInternalUser() {
+    self::mockIsInternalUser( false );
+    self::mockFacebookWordpressOptions();
+    $this->setupMocks();
+    $this->setupCustomerBillingAddress();
+    $this->mockRenderHelpers();
+
+    list( $integration, $signals ) = $this->makeIntegration();
+
+    $data = $integration->read_initiate_checkout();
+    $signals->dispatch(
+      'InitiateCheckout',
+      $data,
+      FacebookWordpressWooCommerce::TRACKING_NAME
+    );
+
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 1, $tracked_events );
+
+    $event = $tracked_events[0];
+    $this->assertEquals( 'InitiateCheckout', $event->getEventName() );
+    $this->assertNotNull( $event->getEventTime() );
+    $this->assertCustomerUserData( $event );
+    $this->assertEquals( 'USD', $event->getCustomData()->getCurrency() );
+    $this->assertEquals( 900, $event->getCustomData()->getValue() );
+    $this->assertEquals( 3, $event->getCustomData()->getNumItems() );
+    $this->assertEquals(
+      'wc_post_id_1',
+      $event->getCustomData()->getContentIds()[0]
+    );
+
+    $contents = $event->getCustomData()->getContents();
+    $this->assertCount( 1, $contents );
+    $this->assertEquals( 'wc_post_id_1', $contents[0]->getProductId() );
+    $this->assertEquals( 3, $contents[0]->getQuantity() );
+    $this->assertEquals( 300, $contents[0]->getItemPrice() );
+
+    $this->assertEquals(
+      'woocommerce',
+      $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
+    );
+  }
+
+  /**
+   * A dispatched AddToCart tracks an AddToCart server event with cart data.
+   *
+   * @return void
+   */
+  public function testAddToCartEventWithoutInternalUser() {
+    self::mockIsInternalUser( false );
+    self::mockFacebookWordpressOptions();
+    $this->setupMocks();
+    $this->setupCustomerBillingAddress();
+    $this->mockRenderHelpers();
+
+    list( $integration, $signals ) = $this->makeIntegration();
+
+    $data = $integration->read_add_to_cart( 1, 1, 3, null );
+    $signals->dispatch(
+      'AddToCart',
+      $data,
+      FacebookWordpressWooCommerce::TRACKING_NAME
+    );
+
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 1, $tracked_events );
+
+    $event = $tracked_events[0];
+    $this->assertEquals( 'AddToCart', $event->getEventName() );
+    $this->assertNotNull( $event->getEventTime() );
+    $this->assertCustomerUserData( $event );
+    $this->assertEquals( 'USD', $event->getCustomData()->getCurrency() );
+    $this->assertEquals( 900, $event->getCustomData()->getValue() );
+    $this->assertEquals(
+      'wc_post_id_1',
+      $event->getCustomData()->getContentIds()[0]
+    );
+
+    $this->assertEquals(
+      'woocommerce',
+      $event->getCustomData()->getCustomProperty( 'fb_integration_tracking' )
+    );
+  }
+
+  /**
+   * A dispatched ViewContent tracks a ViewContent server event for the
+   * current product.
+   *
+   * @return void
+   */
+  public function testViewContentWithoutAdmin() {
+    self::mockIsInternalUser( false );
+    self::mockFacebookWordpressOptions();
+    $this->setupMocks();
+    $this->setupCustomerBillingAddress();
+    $this->mockRenderHelpers();
+
+    $raw_post     = new \stdClass();
+    $raw_post->ID = 1;
+    global $post;
+    $post = $raw_post;
+
+    list( $integration, $signals ) = $this->makeIntegration();
+
+    $data = $integration->read_view_content();
+    $signals->dispatch(
+      'ViewContent',
+      $data,
+      FacebookWordpressWooCommerce::TRACKING_NAME
+    );
+
+    $tracked_events =
+      FacebookServerSideEvent::get_instance()->get_tracked_events();
+    $this->assertCount( 1, $tracked_events );
+
+    $event = $tracked_events[0];
+    $this->assertEquals( 'ViewContent', $event->getEventName() );
+    $this->assertNotNull( $event->getEventTime() );
+    $this->assertCustomerUserData( $event );
+
+    $custom_data = $event->getCustomData();
+    $this->assertEquals( 10, $custom_data->getValue() );
+    $this->assertEquals( 'wc_post_id_1', $custom_data->getContentIds()[0] );
+    $this->assertEquals( 'Stegosaurus', $custom_data->getContentName() );
+    $this->assertEquals( 'product', $custom_data->getContentType() );
+    $this->assertEquals( 'USD', $custom_data->getCurrency() );
+    $this->assertEquals( 'Dinosaurs', $custom_data->getContentCategory() );
+
+    $this->assertEquals(
+      'woocommerce',
+      $custom_data->getCustomProperty( 'fb_integration_tracking' )
+    );
+  }
+
+  /**
+   * On an AJAX add-to-cart request the pixel code is delivered as a cart
+   * fragment keyed to the container div — same behavior as the old
+   * addPixelCodeToAddToCartFragment path.
+   *
+   * @return void
+   */
+  public function testAddToCartAjaxDeliversPixelFragment() {
+    self::mockIsInternalUser( false );
+    self::mockFacebookWordpressOptions();
+    $this->setupMocks();
+    $this->setupCustomerBillingAddress();
+    $this->mockRenderHelpers();
+    \WP_Mock::userFunction( 'wp_doing_ajax', array( 'return' => true ) );
+
+    list( $integration, $signals ) = $this->makeIntegration();
+
+    $delivery = new CartFragmentDelivery(
+      'woocommerce_add_to_cart_fragments',
+      FacebookWordpressWooCommerce::DIV_ID_FOR_AJAX_PIXEL_EVENTS
+    );
+    $delivery->register( FacebookWordpressWooCommerce::TRACKING_NAME );
+
+    $data  = $integration->read_add_to_cart( 1, 1, 3, null );
+    $event = $signals->dispatch(
+      'AddToCart',
+      $data,
+      FacebookWordpressWooCommerce::TRACKING_NAME
+    );
+    $delivery->queue( $event );
+
+    $fragments = $delivery->inject_fragment( array() );
+
+    $key = '#' . FacebookWordpressWooCommerce::DIV_ID_FOR_AJAX_PIXEL_EVENTS;
+    $this->assertArrayHasKey( $key, $fragments );
+    $this->assertMatchesRegularExpression(
+      '/id=\'fb-pxl-ajax-code\'[\s\S]+woocommerce/',
+      $fragments[ $key ]
+    );
+  }
 }

--- a/core/class-abstracteventdelivery.php
+++ b/core/class-abstracteventdelivery.php
@@ -50,6 +50,18 @@ abstract class AbstractEventDelivery implements EventDelivery {
      * @return void
      */
     public function queue( $event ) {
+        $this->store( $event );
+    }
+
+    /**
+     * Records an event without any delivery side effect. Subclasses that emit
+     * on queue() (e.g. inline enqueue) use this to keep the event for later
+     * rendering without triggering that side effect.
+     *
+     * @param \FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event $event The event.
+     * @return void
+     */
+    protected function store( $event ) {
         $this->events[] = $event;
     }
 

--- a/core/class-ajaxhtmldelivery.php
+++ b/core/class-ajaxhtmldelivery.php
@@ -36,6 +36,13 @@ class AjaxHtmlDelivery extends AbstractEventDelivery {
     private $filter;
 
     /**
+     * The response array key to append the code to.
+     *
+     * @var string
+     */
+    private $key;
+
+    /**
      * Filter priority.
      *
      * @var int
@@ -46,28 +53,32 @@ class AjaxHtmlDelivery extends AbstractEventDelivery {
      * Constructor.
      *
      * @param string $filter   The AJAX return filter name.
+     * @param string $key      The response array key to append to. Defaults
+     *                         to 'html'.
      * @param int    $priority Optional filter priority. Defaults to 20.
      */
-    public function __construct( $filter, $priority = 20 ) {
+    public function __construct( $filter, $key = 'html', $priority = 20 ) {
         $this->filter   = $filter;
+        $this->key      = $key;
         $this->priority = $priority;
     }
 
     /**
      * Registers the return filter that appends this delivery's queued events
-     * to $out['html'].
+     * to the configured response key.
      *
      * @param string $tracking_name The integration tracking name.
      * @return void
      */
     public function register( $tracking_name ) {
         $this->tracking_name = $tracking_name;
+        $key                 = $this->key;
         add_filter(
             $this->filter,
-            function ( $out ) {
-                if ( is_array( $out ) && isset( $out['html'] )
+            function ( $out ) use ( $key ) {
+                if ( is_array( $out ) && isset( $out[ $key ] )
                     && $this->has_events() ) {
-                    $out['html'] .= $this->render_code( true );
+                    $out[ $key ] .= $this->render_code( true );
                 }
                 return $out;
             },

--- a/core/class-cartfragmentdelivery.php
+++ b/core/class-cartfragmentdelivery.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Facebook Pixel Plugin CartFragmentDelivery class.
+ *
+ * Browser delivery for add-to-cart events. On a normal (non-AJAX) request the
+ * pixel code is enqueued inline like InlineScriptDelivery. On an AJAX add-to-cart
+ * request the code is instead injected into a page container div through the
+ * cart-fragments filter, so the pixel fires after the AJAX response replaces
+ * that div. The container is printed in the footer at registration time.
+ *
+ * @package FacebookPixelPlugin
+ */
+
+/*
+* Copyright (C) 2017-present, Meta, Inc.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; version 2 of the License.
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*/
+
+namespace FacebookPixelPlugin\Core;
+
+defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
+
+/**
+ * Class CartFragmentDelivery
+ */
+class CartFragmentDelivery extends InlineScriptDelivery {
+    /**
+     * The cart-fragments filter carrying the AJAX response.
+     *
+     * @var string
+     */
+    private $filter;
+
+    /**
+     * The id of the container div the fragment replaces.
+     *
+     * @var string
+     */
+    private $div_id;
+
+    /**
+     * Constructor.
+     *
+     * @param string $filter The cart-fragments filter name.
+     * @param string $div_id The container div id (without the leading '#').
+     */
+    public function __construct( $filter, $div_id ) {
+        $this->filter = $filter;
+        $this->div_id = $div_id;
+    }
+
+    /**
+     * Prints the container div in the footer and registers the cart-fragments
+     * filter that fills it on AJAX add-to-cart requests.
+     *
+     * @param string $tracking_name The integration tracking name.
+     * @return void
+     */
+    public function register( $tracking_name ) {
+        $this->tracking_name = $tracking_name;
+
+        $div_id = $this->div_id;
+        add_action(
+            'wp_footer',
+            function () use ( $div_id ) {
+                echo wp_kses(
+                    "<div id='" . $div_id . "'></div>",
+                    array( 'div' => array( 'id' => array() ) )
+                );
+            }
+        );
+
+        add_filter( $this->filter, array( $this, 'inject_fragment' ), 10, 1 );
+    }
+
+    /**
+     * On AJAX requests the event is held for the fragment filter; otherwise it
+     * is enqueued inline immediately.
+     *
+     * @param \FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event $event The event.
+     * @return void
+     */
+    public function queue( $event ) {
+        if ( function_exists( 'wp_doing_ajax' ) && wp_doing_ajax() ) {
+            $this->store( $event );
+        } else {
+            parent::queue( $event );
+        }
+    }
+
+    /**
+     * Injects the queued events' pixel code into the container div fragment.
+     *
+     * @param array $fragments The cart-fragments response array.
+     * @return array
+     */
+    public function inject_fragment( $fragments ) {
+        if ( is_array( $fragments ) && $this->has_events() ) {
+            $code                             = $this->render_code( true );
+            $fragments[ '#' . $this->div_id ] =
+                "<div id='" . $this->div_id . "'>" . $code . '</div>';
+        }
+        return $fragments;
+    }
+}

--- a/core/class-compositedelivery.php
+++ b/core/class-compositedelivery.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Facebook Pixel Plugin CompositeDelivery class.
+ *
+ * Fans a single event registration out to several delivery strategies (e.g. an
+ * integration that must deliver both in the footer and in an AJAX response,
+ * where only one path actually runs per request). Each queued event is
+ * forwarded to every wrapped delivery.
+ *
+ * @package FacebookPixelPlugin
+ */
+
+/*
+* Copyright (C) 2017-present, Meta, Inc.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; version 2 of the License.
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*/
+
+namespace FacebookPixelPlugin\Core;
+
+defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
+
+/**
+ * Class CompositeDelivery
+ */
+class CompositeDelivery implements EventDelivery {
+    /**
+     * Wrapped delivery strategies.
+     *
+     * @var EventDelivery[]
+     */
+    private $deliveries;
+
+    /**
+     * Constructor.
+     *
+     * @param EventDelivery[] $deliveries The delivery strategies to fan out to.
+     */
+    public function __construct( array $deliveries ) {
+        $this->deliveries = $deliveries;
+    }
+
+    /**
+     * Registers every wrapped delivery.
+     *
+     * @param string $tracking_name The integration tracking name.
+     * @return void
+     */
+    public function register( $tracking_name ) {
+        foreach ( $this->deliveries as $delivery ) {
+            if ( $delivery instanceof EventDelivery ) {
+                $delivery->register( $tracking_name );
+            }
+        }
+    }
+
+    /**
+     * Queues the event onto every wrapped delivery.
+     *
+     * @param \FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event $event The event.
+     * @return void
+     */
+    public function queue( $event ) {
+        foreach ( $this->deliveries as $delivery ) {
+            if ( $delivery instanceof EventDelivery ) {
+                $delivery->queue( $event );
+            }
+        }
+    }
+}

--- a/core/class-facebookwordpresspixelinjection.php
+++ b/core/class-facebookwordpresspixelinjection.php
@@ -103,7 +103,7 @@ class FacebookWordpressPixelInjection {
                 $this->signals,
                 $this->event_builder
             );
-            $integration->inject_pixel_code();
+            $integration->set_up_tracking();
             }
             add_action(
                 'wp_footer',

--- a/core/class-inlinescriptdelivery.php
+++ b/core/class-inlinescriptdelivery.php
@@ -1,0 +1,116 @@
+<?php
+/**
+ * Facebook Pixel Plugin InlineScriptDelivery class.
+ *
+ * Browser delivery that emits each dispatched event as an inline script via
+ * wp_add_inline_script (falling back to WooCommerce's $wc_queued_js when the
+ * page is rendered outside a normal enqueue cycle). Used by integrations whose
+ * pixel code must ride along with an already-registered script rather than be
+ * echoed in the footer or an AJAX response body.
+ *
+ * @package FacebookPixelPlugin
+ */
+
+/*
+* Copyright (C) 2017-present, Meta, Inc.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; version 2 of the License.
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*/
+
+namespace FacebookPixelPlugin\Core;
+
+defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
+
+/**
+ * Class InlineScriptDelivery
+ */
+class InlineScriptDelivery extends AbstractEventDelivery {
+    const HANDLE = 'meta_pixel_inline';
+
+    /**
+     * Whether the inline-script carrier handle has been registered this
+     * request. Static so multiple deliveries share a single handle.
+     *
+     * @var bool
+     */
+    private static $registered = false;
+
+    /**
+     * Records the tracking name; the events are emitted immediately on queue(),
+     * so there is no deferred hook to register.
+     *
+     * @param string $tracking_name The integration tracking name.
+     * @return void
+     */
+    public function register( $tracking_name ) {
+        $this->tracking_name = $tracking_name;
+    }
+
+    /**
+     * Renders the event to pixel code and enqueues it inline.
+     *
+     * @param \FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event $event The event.
+     * @return void
+     */
+    public function queue( $event ) {
+        $this->store( $event );
+        $this->enqueue_code( $this->render_block( $event ) );
+    }
+
+    /**
+     * Wraps a single event's pixel code in the Meta Pixel comment markers.
+     *
+     * @param \FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event $event The event.
+     * @return string
+     */
+    protected function render_block( $event ) {
+        $code = PixelRenderer::render(
+            array( $event ),
+            $this->tracking_name,
+            false
+        );
+
+        return sprintf(
+            "\n<!-- Meta Pixel Event Code -->\n%s\n<!-- End Meta Pixel Event Code -->\n",
+            $code
+        );
+    }
+
+    /**
+     * Enqueues the given code as an inline script, registering a carrier handle
+     * once per request. Falls back to WooCommerce's queued-JS buffer when the
+     * enqueue API is unavailable.
+     *
+     * @param string $code The pixel code to enqueue.
+     * @return void
+     */
+    protected function enqueue_code( $code ) {
+        if ( ! function_exists( 'wp_add_inline_script' ) ) {
+            global $wc_queued_js;
+            $wc_queued_js .= "\n" . $code;
+            return;
+        }
+
+        if ( ! self::$registered ) {
+            if ( ! wp_script_is( self::HANDLE, 'registered' ) ) {
+                wp_register_script(
+                    self::HANDLE,
+                    '',
+                    array(),
+                    FacebookPluginConfig::PLUGIN_VERSION,
+                    true
+                );
+            }
+            wp_enqueue_script( self::HANDLE );
+            self::$registered = true;
+        }
+
+        wp_add_inline_script( self::HANDLE, $code );
+    }
+}

--- a/integration/class-facebookwordpresscalderaform.php
+++ b/integration/class-facebookwordpresscalderaform.php
@@ -45,7 +45,7 @@ class FacebookWordpressCalderaForm extends FacebookWordpressIntegrationBase {
      *
      * @return void
      */
-    public function inject_pixel_code() {
+    public function set_up_tracking() {
         $this->signals->on(
             'caldera_forms_ajax_return',
             'Lead',

--- a/integration/class-facebookwordpresscalderaform.php
+++ b/integration/class-facebookwordpresscalderaform.php
@@ -29,13 +29,7 @@ namespace FacebookPixelPlugin\Integration;
 
 defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 
-use FacebookPixelPlugin\Core\FacebookPluginUtils;
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
-use FacebookPixelPlugin\Core\FacebookWordPressOptions;
-use FacebookPixelPlugin\Core\ServerEventFactory;
-use FacebookPixelPlugin\Core\PixelRenderer;
-use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
-use FacebookPixelPlugin\FacebookAds\Object\ServerSide\UserData;
+use FacebookPixelPlugin\Core\AjaxHtmlDelivery;
 
 /**
  * FacebookWordpressCalderaForm class.
@@ -45,89 +39,48 @@ class FacebookWordpressCalderaForm extends FacebookWordpressIntegrationBase {
     const TRACKING_NAME = 'caldera-forms';
 
     /**
-     * Hook into Caldera Forms to inject the Pixel code.
+     * Registers the Caldera hook: a Lead event dispatched through Signals when
+     * the AJAX submission completes, with the browser pixel appended to the
+     * response HTML (same caldera_forms_ajax_return filter).
      *
-     * Hooks into the `caldera_forms_ajax_return`
-     * action and calls the `injectLeadEvent` method.
-     *
-     * @since 0.9.0
+     * @return void
      */
-    public static function inject_pixel_code() {
-        add_action(
+    public function inject_pixel_code() {
+        $this->signals->on(
             'caldera_forms_ajax_return',
-            array( __CLASS__, 'injectLeadEvent' ),
+            'Lead',
+            array( $this, 'read_form_data' ),
+            new AjaxHtmlDelivery( 'caldera_forms_ajax_return' ),
+            self::TRACKING_NAME,
             10,
             2
         );
     }
 
     /**
-     * Injects the Pixel code into the Caldera Forms response.
+     * Extracts the Lead event data from a completed Caldera submission.
      *
-     * Hooks into the `caldera_forms_ajax_return` action and checks if the form
-     * is submitted successfully and if the user is not an internal user.
-     * If conditions are met, it creates a `Lead` event and tracks it using
-     * the `FacebookServerSideEvent` class.
-     * Then it renders the Pixel code using the `PixelRenderer` class and
-     * appends the code to the form response.
-     *
-     * @param array $out The Caldera Forms response.
+     * @param array $out  The Caldera Forms AJAX response.
      * @param array $form The form data.
-     *
-     * @return array The modified Caldera Forms response.
+     * @return \FacebookPixelPlugin\Core\EventData|null
      */
-    public static function injectLeadEvent( $out, $form ) {
-        if (
-        FacebookPluginUtils::is_internal_user() ||
-        'complete' !== $out['status']
-        ) {
-            return $out;
+    public function read_form_data( $out, $form = array() ) {
+        if ( ! is_array( $out ) || ! isset( $out['status'] )
+            || 'complete' !== $out['status'] ) {
+            return null;
         }
-
-        $server_event = ServerEventFactory::safe_create_event(
-            'Lead',
-            array( __CLASS__, 'readFormData' ),
-            array( $form ),
-            self::TRACKING_NAME,
-            true
-        );
-        FacebookServerSideEvent::get_instance()->track( $server_event );
-
-        $code = PixelRenderer::render(
-            array( $server_event ),
-            self::TRACKING_NAME
-        );
-        $code = sprintf(
-            '
-        <!-- Meta Pixel Event Code -->
-        %s
-        <!-- End Meta Pixel Event Code -->
-            ',
-            $code
-        );
-
-        $out['html'] .= $code;
-        return $out;
-    }
-
-    /**
-     * Reads the form data from the Caldera Forms submission.
-     *
-     * @param array $form The form data.
-     *
-     * @return array The form data in the format
-     * expected by the `FacebookServerSideEvent` class.
-     */
-    public static function readFormData( $form ) {
         if ( empty( $form ) ) {
-            return array();
+            return null;
         }
-        return array(
-            'email'      => self::getEmail( $form ),
-            'first_name' => self::getFirstName( $form ),
-            'last_name'  => self::getLastName( $form ),
-            'phone'      => self::getPhone( $form ),
-            'state'      => self::getState( $form ),
+
+        return $this->event_builder->build(
+            array(
+                'email'      => self::getEmail( $form ),
+                'first_name' => self::getFirstName( $form ),
+                'last_name'  => self::getLastName( $form ),
+                'phone'      => self::getPhone( $form ),
+                'state'      => self::getState( $form ),
+            )
         );
     }
 

--- a/integration/class-facebookwordpresscontactform7.php
+++ b/integration/class-facebookwordpresscontactform7.php
@@ -48,7 +48,7 @@ class FacebookWordpressContactForm7 extends FacebookWordpressIntegrationBase {
      *
      * @return void
      */
-    public function inject_pixel_code() {
+    public function set_up_tracking() {
         $this->signals->on(
             'wpcf7_submit',
             'Lead',

--- a/integration/class-facebookwordpresseasydigitaldownloads.php
+++ b/integration/class-facebookwordpresseasydigitaldownloads.php
@@ -56,7 +56,7 @@ class FacebookWordpressEasyDigitalDownloads extends FacebookWordpressIntegration
      *
      * @return void
      */
-    public function inject_pixel_code() {
+    public function set_up_tracking() {
         add_action(
             'edd_after_download_content',
             array( $this, 'inject_add_to_cart_listener' )

--- a/integration/class-facebookwordpresseasydigitaldownloads.php
+++ b/integration/class-facebookwordpresseasydigitaldownloads.php
@@ -31,12 +31,10 @@ defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 
 use FacebookPixelPlugin\Core\FacebookPixel;
 use FacebookPixelPlugin\Core\FacebookPluginUtils;
-use FacebookPixelPlugin\Core\ServerEventFactory;
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
-use FacebookPixelPlugin\Core\PixelRenderer;
 use FacebookPixelPlugin\Core\FacebookWordpressOptions;
 use FacebookPixelPlugin\Core\EventIdGenerator;
 use FacebookPixelPlugin\Core\FacebookSignalState;
+use FacebookPixelPlugin\Core\FooterDelivery;
 
 /**
  * FacebookWordpressEasyDigitalDownloads class.
@@ -46,63 +44,77 @@ class FacebookWordpressEasyDigitalDownloads extends FacebookWordpressIntegration
     const TRACKING_NAME = 'easy-digital-downloads';
 
     /**
-     * Injects various Facebook Pixel events for Easy Digital Downloads.
+     * Registers the Easy Digital Downloads events through Signals.
      *
-     * This method sets up WordPress actions to inject Facebook Pixel events
-     * for different stages of the Easy Digital Downloads process:
+     * - AddToCart: a hidden shared event id is printed onto the purchase form
+     *   and a JS listener fires the browser pixel; the AJAX add-to-cart request
+     *   dispatches the server event only (no browser delivery — the enqueued
+     *   listener owns the browser side), reusing the shared id for dedup.
+     * - InitiateCheckout: dispatched when the checkout cart renders.
+     * - Purchase: dispatched from the payment receipt.
+     * - ViewContent: dispatched on the download page.
      *
-     * - AddToCart: Adds JavaScript listeners and hooks for AJAX requests,
-     *   and injects a hidden field with an event ID.
-     * - InitiateCheckout: Fires a pixel event after the checkout cart is
-     *   displayed.
-     * - Purchase: Tracks purchase events after the payment receipt.
-     * - ViewContent: Injects view content events after download content.
+     * @return void
      */
-    public static function inject_pixel_code() {
+    public function inject_pixel_code() {
         add_action(
             'edd_after_download_content',
-            array( __CLASS__, 'injectAddToCartListener' )
+            array( $this, 'inject_add_to_cart_listener' )
         );
         add_action(
             'edd_downloads_list_after',
-            array( __CLASS__, 'injectAddToCartListener' )
+            array( $this, 'inject_add_to_cart_listener' )
         );
-
-        add_action(
-            'wp_ajax_edd_add_to_cart',
-            array( __CLASS__, 'injectAddToCartEventAjax' ),
-            5
-        );
-
-        add_action(
-            'wp_ajax_nopriv_edd_add_to_cart',
-            array( __CLASS__, 'injectAddToCartEventAjax' ),
-            5
-        );
-
         add_action(
             'edd_purchase_link_top',
-            array( __CLASS__, 'injectAddToCartEventId' )
+            array( $this, 'inject_add_to_cart_event_id' )
         );
 
-        self::add_pixel_fire_for_hook(
-            array(
-                'hook_name'       => 'edd_after_checkout_cart',
-                'classname'       => __CLASS__,
-                'inject_function' => 'injectInitiateCheckoutEvent',
-            )
+        $this->signals->on(
+            'wp_ajax_edd_add_to_cart',
+            'AddToCart',
+            array( $this, 'read_add_to_cart' ),
+            null,
+            self::TRACKING_NAME,
+            5,
+            0
+        );
+        $this->signals->on(
+            'wp_ajax_nopriv_edd_add_to_cart',
+            'AddToCart',
+            array( $this, 'read_add_to_cart' ),
+            null,
+            self::TRACKING_NAME,
+            5,
+            0
         );
 
-        add_action(
+        $this->signals->on(
+            'edd_after_checkout_cart',
+            'InitiateCheckout',
+            array( $this, 'read_initiate_checkout' ),
+            new FooterDelivery(),
+            self::TRACKING_NAME,
+            10,
+            0
+        );
+
+        $this->signals->on(
             'edd_payment_receipt_after',
-            array( __CLASS__, 'trackPurchaseEvent' ),
+            'Purchase',
+            array( $this, 'read_purchase' ),
+            new FooterDelivery(),
+            self::TRACKING_NAME,
             10,
             2
         );
 
-        add_action(
+        $this->signals->on(
             'edd_after_download_content',
-            array( __CLASS__, 'injectViewContentEvent' ),
+            'ViewContent',
+            array( $this, 'read_view_content' ),
+            new FooterDelivery(),
+            self::TRACKING_NAME,
             40,
             1
         );
@@ -111,16 +123,17 @@ class FacebookWordpressEasyDigitalDownloads extends FacebookWordpressIntegration
     /**
      * Injects a hidden field with a unique event ID into the AddToCart form.
      *
-     * The event ID is used to identify the AddToCart event
-     * for a given download.
+     * The shared event ID lets the browser AddToCart pixel (fired by the JS
+     * listener) deduplicate against the server event dispatched on the AJAX
+     * add-to-cart request.
      *
      * @return void
      */
-    public static function injectAddToCartEventId() {
+    public function inject_add_to_cart_event_id() {
         if ( FacebookPluginUtils::is_internal_user() ) {
             return;
         }
-            $event_id = EventIdGenerator::guidv4();
+        $event_id = EventIdGenerator::guidv4();
         printf(
             '<input type="hidden" name="facebook_event_id" value="%s">',
             esc_attr( $event_id )
@@ -128,49 +141,34 @@ class FacebookWordpressEasyDigitalDownloads extends FacebookWordpressIntegration
     }
 
     /**
-     * Triggers the AddToCart event for Easy Digital Downloads.
+     * Extracts the AddToCart event data from the AJAX add-to-cart request.
      *
-     * The `edd-add-to-cart` nonce check is performed to ensure that the request
-     * comes from a valid EDD form submission. The event
-     * ID is verified to ensure that
-     * it is a valid Event ID.
+     * Verifies the EDD add-to-cart nonce and reuses the shared event id carried
+     * in the posted form data so the server event deduplicates against the
+     * browser event fired by the JS listener.
      *
-     * @since 1.0.0
+     * @return \FacebookPixelPlugin\Core\EventData|null
      */
-    public static function injectAddToCartEventAjax() {
-        if ( isset( $_POST['nonce'] ) && isset( $_POST['download_id'] )
-            && isset( $_POST['post_data'] ) ) {
-            $download_id = absint( $_POST['download_id'] );
-            $nonce       = sanitize_text_field( wp_unslash( $_POST['nonce'] ) );
-            if ( wp_verify_nonce( $nonce, 'edd-add-to-cart-' . $download_id )
-            === false ) {
-                return;
-            }
-            parse_str( $_POST['post_data'], $post_data ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-            if ( isset( $post_data['facebook_event_id'] ) ) {
-                $event_id = $post_data['facebook_event_id'];
-            $server_event = ServerEventFactory::safe_create_event(
-                'AddToCart',
-                array( __CLASS__, 'createAddToCartEvent' ),
-                array( $download_id ),
-                self::TRACKING_NAME
-            );
-                $server_event->setEventId( $event_id );
-                FacebookServerSideEvent::get_instance()->track( $server_event );
-            }
+    public function read_add_to_cart() {
+        if ( ! isset( $_POST['nonce'], $_POST['download_id'], $_POST['post_data'] ) ) {
+            return null;
         }
+
+        $download_id = absint( wp_unslash( $_POST['download_id'] ) );
+        $nonce       = sanitize_text_field( wp_unslash( $_POST['nonce'] ) );
+        if ( false === wp_verify_nonce( $nonce, 'edd-add-to-cart-' . $download_id ) ) {
+            return null;
+        }
+
         parse_str( $_POST['post_data'], $post_data ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
-        if ( isset( $post_data['facebook_event_id'] ) ) {
-            $event_id     = $post_data['facebook_event_id'];
-            $server_event = ServerEventFactory::safe_create_event(
-                'AddToCart',
-                array( __CLASS__, 'createAddToCartEvent' ),
-                array( $download_id ),
-                self::TRACKING_NAME
-            );
-            $server_event->setEventId( $event_id );
-            FacebookServerSideEvent::get_instance()->track( $server_event );
-        }
+        $event_id = isset( $post_data['facebook_event_id'] )
+            ? sanitize_text_field( $post_data['facebook_event_id'] )
+            : null;
+
+        return $this->event_builder->build(
+            self::createAddToCartEvent( $download_id ),
+            $event_id
+        );
     }
 
     /**
@@ -178,15 +176,13 @@ class FacebookWordpressEasyDigitalDownloads extends FacebookWordpressIntegration
      * for Easy Digital Downloads.
      *
      * This method enqueues a JavaScript file that listens for
-     * the `edd_add_to_cart`
-     * event, and sends a server-side event to Facebook
-     * for the AddToCart pixel event.
+     * the `edd_add_to_cart` event and fires the browser AddToCart pixel.
      *
      * @param int $download_id The ID of the download item.
      *
-     * @since 1.0.0
+     * @return void
      */
-    public static function injectAddToCartListener( $download_id ) {
+    public function inject_add_to_cart_listener( $download_id ) {
         if ( FacebookPluginUtils::is_internal_user() ) {
             return;
         }
@@ -215,131 +211,50 @@ class FacebookWordpressEasyDigitalDownloads extends FacebookWordpressIntegration
     }
 
     /**
-     * Injects a Meta Pixel InitiateCheckout event.
+     * Extracts the InitiateCheckout event data when the checkout cart renders.
      *
-     * This method is a callback for the `edd_purchase_link_top` action hook.
-     * It injects a Meta Pixel InitiateCheckout event into
-     * the page whenever a purchase link is rendered.
-     *
-     * @since 1.0.0
+     * @return \FacebookPixelPlugin\Core\EventData|null
      */
-    public static function injectInitiateCheckoutEvent() {
-        if ( FacebookPluginUtils::is_internal_user() ||
-        ! function_exists( 'EDD' ) ) {
-            return;
+    public function read_initiate_checkout() {
+        if ( ! function_exists( 'EDD' ) ) {
+            return null;
         }
 
-        $server_event = ServerEventFactory::safe_create_event(
-            'InitiateCheckout',
-            array( __CLASS__, 'createInitiateCheckoutEvent' ),
-            array(),
-            self::TRACKING_NAME
+        return $this->event_builder->build(
+            self::createInitiateCheckoutEvent()
         );
-        FacebookServerSideEvent::get_instance()->track( $server_event );
-
-        $code = PixelRenderer::render(
-            array( $server_event ),
-            self::TRACKING_NAME
-        );
-    printf(
-        '
-<!-- Meta Pixel Event Code -->
-%s
-<!-- End Meta Pixel Event Code -->
-      ',
-        $code // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-    );
     }
 
     /**
-     * Tracks a Meta Pixel Purchase event.
+     * Extracts the Purchase event data from the payment receipt.
      *
-     * This method is a callback for the `edd_complete_purchase` action hook.
-     * It tracks a Meta Pixel Purchase event whenever a purchase is completed.
-     *
-     * @param object $payment The payment object.
-     * @param array  $edd_receipt_args The receipt arguments.
-     *
-     * @since 1.0.0
+     * @param object $payment          The payment object.
+     * @param array  $edd_receipt_args The receipt arguments (unused).
+     * @return \FacebookPixelPlugin\Core\EventData|null
      */
-    public static function trackPurchaseEvent( $payment, $edd_receipt_args ) {
-        if ( FacebookPluginUtils::is_internal_user() || empty( $payment->ID ) ) {
-            return;
+    public function read_purchase( $payment, $edd_receipt_args = array() ) {
+        if ( empty( $payment->ID ) ) {
+            return null;
         }
 
-        $server_event = ServerEventFactory::safe_create_event(
-            'Purchase',
-            array( __CLASS__, 'createPurchaseEvent' ),
-            array( $payment ),
-            self::TRACKING_NAME
-        );
-            FacebookServerSideEvent::get_instance()->track( $server_event );
-
-        add_action(
-            'wp_footer',
-            array( __CLASS__, 'injectPurchaseEvent' ),
-            20
+        return $this->event_builder->build(
+            self::createPurchaseEvent( $payment )
         );
     }
 
     /**
-     * Injects a Meta Pixel Purchase event.
-     *
-     * This method is a callback for the `wp_footer` action hook.
-     * It injects a Meta Pixel Purchase event
-     * into the page whenever a purchase is completed.
-     *
-     * @since 1.0.0
-     */
-    public static function injectPurchaseEvent() {
-        $events = FacebookServerSideEvent::get_instance()->get_tracked_events();
-        $code   = PixelRenderer::render( $events, self::TRACKING_NAME );
-
-        printf(
-            '
-    <!-- Meta Pixel Event Code -->
-    %s
-    <!-- End Meta Pixel Event Code -->
-          ',
-            $code // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-        );
-    }
-
-    /**
-     * Injects a Meta Pixel ViewContent event.
-     *
-     * This method is a callback for the
-     * `edd_download_before_content` action hook.
-     * It injects a Meta Pixel ViewContent event
-     * into the page whenever a download
-     * item is viewed.
+     * Extracts the ViewContent event data for a viewed download.
      *
      * @param int $download_id The ID of the download item.
-     *
-     * @since 1.0.0
+     * @return \FacebookPixelPlugin\Core\EventData|null
      */
-    public static function injectViewContentEvent( $download_id ) {
-        if ( FacebookPluginUtils::is_internal_user() || empty( $download_id ) ) {
-            return;
+    public function read_view_content( $download_id = 0 ) {
+        if ( empty( $download_id ) ) {
+            return null;
         }
 
-        $server_event = ServerEventFactory::safe_create_event(
-            'ViewContent',
-            array( __CLASS__, 'createViewContentEvent' ),
-            array( $download_id ),
-            self::TRACKING_NAME
-        );
-
-        FacebookServerSideEvent::get_instance()->track( $server_event );
-
-        $code = PixelRenderer::render( array( $server_event ), self::TRACKING_NAME );
-        printf(
-            '
-    <!-- Meta Pixel Event Code -->
-    %s
-    <!-- End Meta Pixel Event Code -->
-          ',
-            $code // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        return $this->event_builder->build(
+            self::createViewContentEvent( $download_id )
         );
     }
 

--- a/integration/class-facebookwordpressformidableform.php
+++ b/integration/class-facebookwordpressformidableform.php
@@ -44,7 +44,7 @@ class FacebookWordpressFormidableForm extends FacebookWordpressIntegrationBase {
      *
      * @return void
      */
-    public function inject_pixel_code() {
+    public function set_up_tracking() {
         $this->signals->on(
             'frm_after_create_entry',
             'Lead',

--- a/integration/class-facebookwordpressformidableform.php
+++ b/integration/class-facebookwordpressformidableform.php
@@ -29,14 +29,7 @@ namespace FacebookPixelPlugin\Integration;
 
 defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 
-use FacebookPixelPlugin\Core\FacebookPixel;
-use FacebookPixelPlugin\Core\FacebookPluginUtils;
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
-use FacebookPixelPlugin\Core\FacebookWordPressOptions;
-use FacebookPixelPlugin\Core\ServerEventFactory;
-use FacebookPixelPlugin\Core\PixelRenderer;
-use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
-use FacebookPixelPlugin\FacebookAds\Object\ServerSide\UserData;
+use FacebookPixelPlugin\Core\FooterDelivery;
 
 /**
  * FacebookWordpressFormidableForm class.
@@ -46,123 +39,54 @@ class FacebookWordpressFormidableForm extends FacebookWordpressIntegrationBase {
   const TRACKING_NAME = 'formidable-lite';
 
     /**
-     * Injects pixel code for the Formidable Form plugin.
-     *
-     * This method hooks into the 'frm_after_create_entry' action, which is
-     * fired by the Formidable Form plugin after a form entry is created. It
-     * then calls the trackServerEvent method, which generates a lead event
-     * for the form submission.
+     * Registers the Formidable hook: a Lead event dispatched through Signals
+     * after an entry is created, with the browser pixel emitted in the footer.
      *
      * @return void
      */
-    public static function inject_pixel_code() {
-        add_action(
+    public function inject_pixel_code() {
+        $this->signals->on(
             'frm_after_create_entry',
-            array( __CLASS__, 'trackServerEvent' ),
+            'Lead',
+            array( $this, 'read_form_data' ),
+            new FooterDelivery(),
+            self::TRACKING_NAME,
             20,
             2
         );
     }
 
     /**
-     * Tracks a server-side event for a form submission in Formidable Form.
+     * Extracts the Lead event data for a created Formidable entry.
      *
-     * This method is hooked into the 'frm_after_create_entry' action, which is
-     * fired by the Formidable Form plugin after a form entry is created. It
-     * then calls the track method on the FacebookServerSideEvent instance,
-     * which generates a lead event for the form submission.
-     *
-     * @param int $entry_id The ID of the form entry.
-     * @param int $form_id The ID of the form.
-     *
-     * @return void
+     * @param int      $entry_id The ID of the form entry.
+     * @param int|null $form_id  The ID of the form (unused).
+     * @return \FacebookPixelPlugin\Core\EventData|null
      */
-    public static function trackServerEvent( $entry_id, $form_id ) {
-        if ( FacebookPluginUtils::is_internal_user() ) {
-            return;
+    public function read_form_data( $entry_id, $form_id = null ) {
+        if ( empty( $entry_id ) ) {
+            return null;
         }
-
-        $server_event = ServerEventFactory::safe_create_event(
-            'Lead',
-            array( __CLASS__, 'readFormData' ),
-            array( $entry_id ),
-            self::TRACKING_NAME,
-            true
-        );
-        FacebookServerSideEvent::get_instance()->track( $server_event );
-
-        add_action(
-            'wp_footer',
-            array( __CLASS__, 'injectLeadEvent' ),
-            20
-        );
-    }
-
-    /**
-     * Injects lead event code into the footer.
-     *
-     * This method retrieves tracked events from the FacebookServerSideEvent
-     * instance and renders them into pixel code using the PixelRenderer.
-     * The resulting code is printed into the footer section of the page.
-     * If the user is an internal user, the method returns without injecting
-     * any code.
-     *
-     * @return void
-     */
-    public static function injectLeadEvent() {
-        if ( FacebookPluginUtils::is_internal_user() ) {
-            return;
-        }
-
-        $events = FacebookServerSideEvent::get_instance()->get_tracked_events();
-        $code   = PixelRenderer::render( $events, self::TRACKING_NAME );
-
-        printf(
-            '
-    <!-- Meta Pixel Event Code -->
-    %s
-    <!-- End Meta Pixel Event Code -->
-          ',
-            $code // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-        );
-    }
-
-    /**
-     * Reads form data for a given entry ID.
-     *
-     * This method retrieves the entry values from Formidable
-     * Forms using the provided
-     * entry ID. It extracts specific user information such as
-     * email, first name,
-     * last name, and phone, and combines this information with address data.
-     *
-     * @param int $entry_id The ID of the form entry.
-     * @return array An associative array containing user and
-     *               address information,
-     *               or an empty array if the entry ID is
-     *               empty or no data is found.
-     */
-    public static function readFormData( $entry_id ) {
-    if ( empty( $entry_id ) ) {
-        return array();
-    }
 
         $entry_values =
-        IntegrationUtils::get_formidable_forms_entry_values( $entry_id );
+            IntegrationUtils::get_formidable_forms_entry_values( $entry_id );
 
         $field_values = $entry_values->get_field_values();
-        if ( ! empty( $field_values ) ) {
-            $user_data    = array(
-                'email'      => self::getEmail( $field_values ),
-                'first_name' => self::getFirstName( $field_values ),
-                'last_name'  => self::getLastName( $field_values ),
-                'phone'      => self::getPhone( $field_values ),
-            );
-            $address_data = self::getAddressInformation( $field_values );
-            return array_merge( $user_data, $address_data );
+        if ( empty( $field_values ) ) {
+            return null;
         }
 
-        return array();
+        return $this->event_builder->build(
+            array_merge(
+                array(
+                    'email'      => self::getEmail( $field_values ),
+                    'first_name' => self::getFirstName( $field_values ),
+                    'last_name'  => self::getLastName( $field_values ),
+                    'phone'      => self::getPhone( $field_values ),
+                ),
+                self::getAddressInformation( $field_values )
+            )
+        );
     }
 
     /**

--- a/integration/class-facebookwordpressmailchimpforwp.php
+++ b/integration/class-facebookwordpressmailchimpforwp.php
@@ -44,7 +44,7 @@ class FacebookWordpressMailchimpForWp extends FacebookWordpressIntegrationBase {
      *
      * @return void
      */
-    public function inject_pixel_code() {
+    public function set_up_tracking() {
         $this->signals->on(
             'mc4wp_form_subscribed',
             'Lead',

--- a/integration/class-facebookwordpressmailchimpforwp.php
+++ b/integration/class-facebookwordpressmailchimpforwp.php
@@ -29,11 +29,7 @@ namespace FacebookPixelPlugin\Integration;
 
 defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 
-use FacebookPixelPlugin\Core\FacebookPixel;
-use FacebookPixelPlugin\Core\FacebookPluginUtils;
-use FacebookPixelPlugin\Core\ServerEventFactory;
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
-use FacebookPixelPlugin\Core\PixelRenderer;
+use FacebookPixelPlugin\Core\FooterDelivery;
 
 /**
  * FacebookWordpressMailchimpForWp class.
@@ -43,80 +39,30 @@ class FacebookWordpressMailchimpForWp extends FacebookWordpressIntegrationBase {
     const TRACKING_NAME = 'mailchimp-for-wp';
 
     /**
-     * Injects Facebook Pixel events for the MailChimp for WP plugin.
-     *
-     * This method sets up WordPress actions to inject Facebook Pixel events
-     * for different stages of the MailChimp for WP plugin process.
+     * Registers the Mailchimp for WP hook: a Lead event dispatched through
+     * Signals on a successful subscribe, with the pixel emitted in the footer.
      *
      * @return void
      */
-    public static function inject_pixel_code() {
-    self::add_pixel_fire_for_hook(
-        array(
-            'hook_name'       => 'mc4wp_form_subscribed',
-            'classname'       => __CLASS__,
-            'inject_function' => 'injectLeadEvent',
-        )
-    );
-    }
-
-    /**
-     * Injects Facebook Pixel events for the MailChimp for WP plugin.
-     *
-     * This method sets up WordPress actions to inject Facebook Pixel events
-     * for different stages of the MailChimp for WP plugin process.
-     *
-     * @return void
-     */
-    public static function injectLeadEvent() {
-        if ( FacebookPluginUtils::is_internal_user() ) {
-            return;
-        }
-
-        $server_event = ServerEventFactory::safe_create_event(
+    public function inject_pixel_code() {
+        $this->signals->on(
+            'mc4wp_form_subscribed',
             'Lead',
-            array( __CLASS__, 'readFormData' ),
-            array(),
+            array( $this, 'read_form_data' ),
+            new FooterDelivery(),
             self::TRACKING_NAME,
-            true
-        );
-        FacebookServerSideEvent::get_instance()->track( $server_event );
-
-        $code = PixelRenderer::render(
-            array( $server_event ),
-            self::TRACKING_NAME
-        );
-        printf(
-            '
-    <!-- Meta Pixel Event Code -->
-      %s
-    <!-- End Meta Pixel Event Code -->
-        ',
-            $code // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+            10,
+            1
         );
     }
 
     /**
-     * Reads form data from the $_POST global array.
+     * Extracts the Lead event data from the Mailchimp submission ($_POST).
      *
-     * This function extracts user-related data
-     * such as email, first name, last name,
-     * phone number, and address details from the
-     * $_POST array, commonly used in form
-     * submissions. The extracted data includes:
-     * - 'email': The user's email address.
-     * - 'first_name': The user's first name.
-     * - 'last_name': The user's last name.
-     * - 'phone': The user's phone number.
-     * - 'city', 'state', 'zip', 'country': Address details,
-     * where the country must
-     *   be specified using a 2-letter code.
-     *
-     * The function returns an associative array containing the extracted data.
-     *
-     * @return array An associative array of form data.
+     * @param mixed $form The mc4wp form (unused; data is read from $_POST).
+     * @return \FacebookPixelPlugin\Core\EventData
      */
-    public static function readFormData() {
+    public function read_form_data( $form = null ) {
         $event_data = array();
         if ( ! empty( $_POST['EMAIL'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
             $event_data['email'] = sanitize_email( wp_unslash( $_POST['EMAIL'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
@@ -157,6 +103,7 @@ class FacebookWordpressMailchimpForWp extends FacebookWordpressIntegrationBase {
                 $event_data['country'] = $address_data['country'];
             }
         }
-        return $event_data;
+
+        return $this->event_builder->build( $event_data );
     }
 }

--- a/integration/class-facebookwordpressninjaforms.php
+++ b/integration/class-facebookwordpressninjaforms.php
@@ -48,7 +48,7 @@ class FacebookWordpressNinjaForms extends FacebookWordpressIntegrationBase {
      *
      * @return void
      */
-    public function inject_pixel_code() {
+    public function set_up_tracking() {
         $this->signals->on(
             'ninja_forms_submission_actions',
             'Lead',

--- a/integration/class-facebookwordpressninjaforms.php
+++ b/integration/class-facebookwordpressninjaforms.php
@@ -29,14 +29,8 @@ namespace FacebookPixelPlugin\Integration;
 
 defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 
-use FacebookPixelPlugin\Core\FacebookPixel;
-use FacebookPixelPlugin\Core\FacebookPluginUtils;
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
-use FacebookPixelPlugin\Core\FacebookWordPressOptions;
 use FacebookPixelPlugin\Core\ServerEventFactory;
-use FacebookPixelPlugin\Core\PixelRenderer;
-use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
-use FacebookPixelPlugin\FacebookAds\Object\ServerSide\UserData;
+use FacebookPixelPlugin\Core\AjaxFilterDelivery;
 
 /**
  * FacebookWordpressNinjaForms class.
@@ -46,107 +40,87 @@ class FacebookWordpressNinjaForms extends FacebookWordpressIntegrationBase {
     const TRACKING_NAME = 'ninja-forms';
 
     /**
-     * Injects Facebook Pixel code for Ninja Forms.
+     * Registers the Ninja Forms hooks.
      *
-     * This method hooks into the 'ninja_forms_submission_actions' action,
-     * which is triggered during the form submission process in Ninja Forms.
-     * It adds the 'injectLeadEvent' method to handle form submission events,
-     * allowing the tracking of lead events with Facebook Pixel.
+     * A Lead event is dispatched through Signals when a submission runs its
+     * success-message action; the browser pixel is delivered into the
+     * success-message AJAX response and a front-end listener evaluates it.
      *
      * @return void
      */
-    public static function inject_pixel_code() {
-        add_action(
+    public function inject_pixel_code() {
+        $this->signals->on(
             'ninja_forms_submission_actions',
-            array( __CLASS__, 'injectLeadEvent' ),
+            'Lead',
+            array( $this, 'read_form_data' ),
+            new AjaxFilterDelivery(
+                'ninja_forms_post_run_action_type_successmessage',
+                'fb_pxl_code'
+            ),
+            self::TRACKING_NAME,
             10,
             3
         );
-        add_filter(
-            'ninja_forms_post_run_action_type_successmessage',
-            array( __CLASS__, 'injectLeadEventResponse' )
-        );
         add_action(
             'wp_footer',
-            array( __CLASS__, 'injectAjaxListener' ),
+            array( $this, 'inject_ajax_listener' ),
             9
         );
     }
 
     /**
-     * Injects lead event code into the form submission process of Ninja Forms.
+     * Extracts the Lead event data from a Ninja Forms submission, or null when
+     * the submission has no success-message action.
      *
-     * This method hooks into the 'ninja_forms_submission_actions' action,
-     * which is triggered during the form submission process in Ninja Forms.
-     * It generates a lead event for successful submissions so the event can be
-     * added to the AJAX response later in the request lifecycle.
-     *
-     * @param array $actions An array of form submission actions.
-     * @param array $form_cache An array of form cache data.
-     * @param array $form_data An array of form data.
-     *
-     * @return array An array of form submission actions with the injected code.
+     * @param array $actions    The form submission actions.
+     * @param array $form_cache The form cache data (unused).
+     * @param array $form_data  The submitted form data.
+     * @return \FacebookPixelPlugin\Core\EventData|null
      */
-    public static function injectLeadEvent(
+    public function read_form_data(
         $actions,
-        $form_cache,
-        $form_data
+        $form_cache = array(),
+        $form_data = array()
     ) {
-        if ( FacebookPluginUtils::is_internal_user() ) {
-            return $actions;
+        if ( ! self::has_success_message( $actions ) || empty( $form_data ) ) {
+            return null;
         }
 
-        foreach ( $actions as $action ) {
-            if ( ! isset( $action['settings'] ) ||
-            ! isset( $action['settings']['type'] ) ) {
-                continue;
-            }
+        $name = self::getName( $form_data );
 
-            $type = $action['settings']['type'];
-            if ( ! is_string( $type ) ) {
-                continue;
-            }
-
-            if ( 'successmessage' === $type ) {
-                $event = ServerEventFactory::safe_create_event(
-                    'Lead',
-                    array( __CLASS__, 'readFormData' ),
-                    array( $form_data ),
-                    self::TRACKING_NAME,
-                    true
-                );
-                FacebookServerSideEvent::get_instance()->track( $event );
-                break;
-            }
-        }
-
-        return $actions;
+        return $this->event_builder->build(
+            array(
+                'first_name' => $name ? $name[0] : self::getFirstName( $form_data ),
+                'last_name'  => $name ? $name[1] : self::getLastName( $form_data ),
+                'email'      => self::getEmail( $form_data ),
+                'phone'      => self::getPhone( $form_data ),
+                'city'       => self::getCity( $form_data ),
+                'zip'        => self::getZipCode( $form_data ),
+                'state'      => self::getState( $form_data ),
+                'country'    => self::getCountry( $form_data ),
+                'gender'     => self::getGender( $form_data ),
+            )
+        );
     }
 
     /**
-     * Adds raw pixel calls to the Ninja Forms AJAX response.
+     * Whether the submission actions include a success-message action.
      *
-     * @param array $data Submission response data.
-     * @return array
+     * @param array $actions The form submission actions.
+     * @return bool
      */
-    public static function injectLeadEventResponse( $data ) {
-        if ( FacebookPluginUtils::is_internal_user()
-            || isset( $data['fb_pxl_code'] ) ) {
-            return $data;
+    private static function has_success_message( $actions ) {
+        if ( ! is_array( $actions ) ) {
+            return false;
         }
-
-        $events = FacebookServerSideEvent::get_instance()->get_tracked_events();
-        if ( empty( $events ) ) {
-            return $data;
+        foreach ( $actions as $action ) {
+            if ( isset( $action['settings']['type'] )
+                && is_string( $action['settings']['type'] )
+                && 'successmessage' === $action['settings']['type'] ) {
+                return true;
+            }
         }
-
-        $data['fb_pxl_code'] = PixelRenderer::render(
-            $events,
-            self::TRACKING_NAME,
-            false
-        );
-
-        return $data;
+        return false;
     }
 
     /**
@@ -154,7 +128,7 @@ class FacebookWordpressNinjaForms extends FacebookWordpressIntegrationBase {
      *
      * @return void
      */
-    public static function injectAjaxListener() {
+    public function inject_ajax_listener() {
         ?>
         <!-- Meta Pixel Event Code -->
         <script type='text/javascript'>
@@ -192,52 +166,6 @@ class FacebookWordpressNinjaForms extends FacebookWordpressIntegrationBase {
         </script>
         <!-- End Meta Pixel Event Code -->
         <?php
-    }
-
-    /**
-     * Reads form data from the $_POST global array.
-     *
-     * This function extracts user-related data such as email,
-     * first name, last name,
-     * phone number, and address details from the $_POST array,
-     * commonly used in form
-     * submissions. The extracted data includes:
-     * - 'email': The user's email address.
-     * - 'first_name': The user's first name.
-     * - 'last_name': The user's last name.
-     * - 'phone': The user's phone number.
-     * - 'city', 'state', 'zip', 'country': Address
-     * details, where the country must
-     *   be specified using a 2-letter code.
-     *
-     * The function returns an associative array containing the extracted data.
-     *
-     * @param array $form_data The form data as an associative array.
-     * @return array An associative array of form data.
-     */
-    public static function readFormData( $form_data ) {
-        if ( empty( $form_data ) ) {
-            return array();
-        }
-
-            $event_data = array();
-            $name       = self::getName( $form_data );
-        if ( $name ) {
-            $event_data['first_name'] = $name[0];
-            $event_data['last_name']  = $name[1];
-        } else {
-            $event_data['first_name'] = self::getFirstName( $form_data );
-            $event_data['last_name']  = self::getLastName( $form_data );
-        }
-        $event_data['email']   = self::getEmail( $form_data );
-        $event_data['phone']   = self::getPhone( $form_data );
-        $event_data['city']    = self::getCity( $form_data );
-        $event_data['zip']     = self::getZipCode( $form_data );
-        $event_data['state']   = self::getState( $form_data );
-        $event_data['country'] = self::getCountry( $form_data );
-        $event_data['gender']  = self::getGender( $form_data );
-
-        return $event_data;
     }
 
     /**

--- a/integration/class-facebookwordpresswoocommerce.php
+++ b/integration/class-facebookwordpresswoocommerce.php
@@ -57,7 +57,7 @@ class FacebookWordpressWooCommerce extends FacebookWordpressIntegrationBase {
      *
      * @return void
      */
-    public function inject_pixel_code() {
+    public function set_up_tracking() {
         if ( self::isFacebookForWooCommerceActive() ) {
             return;
         }

--- a/integration/class-facebookwordpresswoocommerce.php
+++ b/integration/class-facebookwordpresswoocommerce.php
@@ -29,11 +29,9 @@ namespace FacebookPixelPlugin\Integration;
 
 defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 
-use FacebookPixelPlugin\Core\FacebookPixel;
 use FacebookPixelPlugin\Core\FacebookPluginUtils;
-use FacebookPixelPlugin\Core\ServerEventFactory;
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
-use FacebookPixelPlugin\Core\PixelRenderer;
+use FacebookPixelPlugin\Core\InlineScriptDelivery;
+use FacebookPixelPlugin\Core\CartFragmentDelivery;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Content;
 
 /**
@@ -49,144 +47,156 @@ class FacebookWordpressWooCommerce extends FacebookWordpressIntegrationBase {
     const DIV_ID_FOR_AJAX_PIXEL_EVENTS = 'fb-pxl-ajax-code';
 
     /**
-     * Injects Facebook Pixel events for WooCommerce.
+     * Registers the WooCommerce events through Signals, unless the Facebook for
+     * WooCommerce plugin owns tracking.
      *
-     * This method sets up WordPress actions to inject Facebook Pixel events
-     * for different stages of the WooCommerce process, only if the
-     * Facebook for WooCommerce plugin is not active.
-     *
-     * - InitiateCheckout: Injects pixel event after checkout form.
-     * - AddToCart: Tracks add to cart actions.
-     * - Purchase: Fires pixel event on purchase completion.
-     * - ViewContent: Tracks product page views.
-     * - AJAX: Adds a footer div for AJAX-triggered events.
-     *
-     * Hooks are added with a priority of 40, and the add to cart event
-     * includes four parameters.
+     * All events use the inline-script delivery except AddToCart, which uses a
+     * cart-fragment delivery so the pixel rides the AJAX add-to-cart response.
+     * InitiateCheckout and Purchase register on two hooks each to cover the
+     * classic/block and thankyou/payment-complete flows.
      *
      * @return void
      */
-    public static function inject_pixel_code() {
-        if ( ! self::isFacebookForWooCommerceActive() ) {
-            // InitiateCheckout events for classic checkout.
-            add_action(
-                'woocommerce_after_checkout_form',
-                array( __CLASS__, 'trackInitiateCheckout' ),
-                40
-            );
-            // InitiateCheckout events for block-based checkout.
-            add_action(
-                'woocommerce_blocks_checkout_enqueue_data',
-                array( __CLASS__, 'trackInitiateCheckout' )
-            );
-
-            add_action(
-                'woocommerce_add_to_cart',
-                array( __CLASS__, 'trackAddToCartEvent' ),
-                40,
-                4
-            );
-
-            add_action(
-                'woocommerce_thankyou',
-                array( __CLASS__, 'trackPurchaseEvent' ),
-                40
-            );
-
-            add_action(
-                'woocommerce_payment_complete',
-                array( __CLASS__, 'trackPurchaseEvent' ),
-                40
-            );
-
-            add_action(
-                'woocommerce_after_single_product',
-                array( __CLASS__, 'trackViewContentEvent' ),
-                40
-            );
-
-            add_action(
-                'wp_footer',
-                array( __CLASS__, 'addDivForAjaxPixelEvent' )
-            );
+    public function inject_pixel_code() {
+        if ( self::isFacebookForWooCommerceActive() ) {
+            return;
         }
-    }
 
-    /**
-     * Injects a hidden div with an id of
-     * 'fb-pxl-ajax-code' into the page footer.
-     * This div is used to inject pixel events via AJAX requests.
-     */
-    public static function addDivForAjaxPixelEvent() {
-        echo wp_kses(
-            self::getDivForAjaxPixelEvent(),
-            array(
-                'div' => array(
-                    'id' => array(),
-                ),
-            )
+        // InitiateCheckout: classic checkout form + block-based checkout.
+        $this->signals->on(
+            'woocommerce_after_checkout_form',
+            'InitiateCheckout',
+            array( $this, 'read_initiate_checkout' ),
+            new InlineScriptDelivery(),
+            self::TRACKING_NAME,
+            40,
+            0
+        );
+        $this->signals->on(
+            'woocommerce_blocks_checkout_enqueue_data',
+            'InitiateCheckout',
+            array( $this, 'read_initiate_checkout' ),
+            new InlineScriptDelivery(),
+            self::TRACKING_NAME,
+            10,
+            0
+        );
+
+        $this->signals->on(
+            'woocommerce_add_to_cart',
+            'AddToCart',
+            array( $this, 'read_add_to_cart' ),
+            new CartFragmentDelivery(
+                'woocommerce_add_to_cart_fragments',
+                self::DIV_ID_FOR_AJAX_PIXEL_EVENTS
+            ),
+            self::TRACKING_NAME,
+            40,
+            4
+        );
+
+        // Purchase: thankyou page + payment completion.
+        $this->signals->on(
+            'woocommerce_thankyou',
+            'Purchase',
+            array( $this, 'read_purchase' ),
+            new InlineScriptDelivery(),
+            self::TRACKING_NAME,
+            40,
+            1
+        );
+        $this->signals->on(
+            'woocommerce_payment_complete',
+            'Purchase',
+            array( $this, 'read_purchase' ),
+            new InlineScriptDelivery(),
+            self::TRACKING_NAME,
+            40,
+            1
+        );
+
+        $this->signals->on(
+            'woocommerce_after_single_product',
+            'ViewContent',
+            array( $this, 'read_view_content' ),
+            new InlineScriptDelivery(),
+            self::TRACKING_NAME,
+            40,
+            0
         );
     }
 
     /**
-     * Generates a div element with a specific ID for
-     * AJAX-triggered pixel events.
+     * Extracts the ViewContent event data for the current product page.
      *
-     * This method returns a div element with the ID defined
-     * by DIV_ID_FOR_AJAX_PIXEL_EVENTS.
-     * The function allows for optional content to be included inside the div.
-     *
-     * @param string $content Optional content to be placed inside the div.
-     * @return string HTML div element as a string.
+     * @return \FacebookPixelPlugin\Core\EventData|null
      */
-    public static function getDivForAjaxPixelEvent( $content = '' ) {
-        return "<div id='" . self::DIV_ID_FOR_AJAX_PIXEL_EVENTS . "'>"
-        . $content . '</div>';
-    }
-
-    /**
-     * Injects a ViewContent event into the page, but only if the user is not an
-     * internal user (i.e. an admin user).
-     *
-     * The event is only injected if a valid product
-     * object can be retrieved from
-     * the current post ID. If not, the method simply exits.
-     *
-     * The ViewContent event is generated by calling
-     * the createViewContentEvent method
-     * and passing in the product object as an argument.
-     * The event is then tracked
-     * using the FacebookServerSideEvent singleton,
-     * and the pixel code is enqueued
-     * for output.
-     *
-     * @return void
-     */
-    public static function trackViewContentEvent() {
-        if ( FacebookPluginUtils::is_internal_user() ) {
-            return;
-        }
-
+    public function read_view_content() {
         global $post;
         if ( ! isset( $post->ID ) ) {
-            return;
+            return null;
         }
 
         $product = wc_get_product( $post->ID );
         if ( ! $product ) {
-            return;
+            return null;
         }
 
-        $server_event = ServerEventFactory::safe_create_event(
-            'ViewContent',
-            array( __CLASS__, 'createViewContentEvent' ),
-            array( $product ),
-            self::TRACKING_NAME
+        return $this->event_builder->build(
+            self::createViewContentEvent( $product )
         );
+    }
 
-        FacebookServerSideEvent::get_instance()->track( $server_event, false );
+    /**
+     * Extracts the Purchase event data for a completed order.
+     *
+     * @param int $order_id The order ID.
+     * @return \FacebookPixelPlugin\Core\EventData|null
+     */
+    public function read_purchase( $order_id = 0 ) {
+        if ( empty( $order_id ) ) {
+            return null;
+        }
 
-        self::enqueuePixelCode( $server_event );
+        return $this->event_builder->build(
+            self::createPurchaseEvent( $order_id )
+        );
+    }
+
+    /**
+     * Extracts the AddToCart event data for a cart addition.
+     *
+     * @param string $cart_item_key The cart item key.
+     * @param int    $product_id    The product ID.
+     * @param int    $quantity      The quantity.
+     * @param int    $variation_id  The variation ID (unused).
+     * @return \FacebookPixelPlugin\Core\EventData|null
+     */
+    public function read_add_to_cart(
+        $cart_item_key = '',
+        $product_id = 0,
+        $quantity = 0,
+        $variation_id = 0
+    ) {
+        return $this->event_builder->build(
+            self::createAddToCartEvent( $cart_item_key, $product_id, $quantity )
+        );
+    }
+
+    /**
+     * Extracts the InitiateCheckout event data from the WooCommerce session.
+     *
+     * @return \FacebookPixelPlugin\Core\EventData|null
+     */
+    public function read_initiate_checkout() {
+        if ( null === WC()->cart
+            || 0 === WC()->cart->get_cart_contents_count() ) {
+            return null;
+        }
+
+        return $this->event_builder->build(
+            self::createInitiateCheckoutEvent()
+        );
     }
 
     /**
@@ -235,33 +245,6 @@ class FacebookWordpressWooCommerce extends FacebookWordpressIntegrationBase {
             'product_cat'
         );
         return ! empty( $categories ) && count( $categories ) > 0 ? $categories[0]->name : null;
-    }
-
-    /**
-     * Tracks a Meta Pixel Purchase event.
-     *
-     * This method is a callback for the `woocommerce_thankyou` action hook.
-     * It tracks a Meta Pixel Purchase event whenever a purchase is completed.
-     *
-     * @param int $order_id The order ID.
-     *
-     * @since 1.0.0
-     */
-    public static function trackPurchaseEvent( $order_id ) {
-        if ( FacebookPluginUtils::is_internal_user() ) {
-            return;
-        }
-
-        $server_event = ServerEventFactory::safe_create_event(
-            'Purchase',
-            array( __CLASS__, 'createPurchaseEvent' ),
-            array( $order_id ),
-            self::TRACKING_NAME
-        );
-
-        FacebookServerSideEvent::get_instance()->track( $server_event );
-
-        self::enqueuePixelCode( $server_event );
     }
 
     /**
@@ -320,89 +303,6 @@ class FacebookWordpressWooCommerce extends FacebookWordpressIntegrationBase {
     }
 
     /**
-     * Generates a Meta Pixel AddToCart event data.
-     *
-     * The AddToCart event is fired when a customer
-     * adds a product to their cart.
-     * It is typically sent when a customer submits a
-     * form to add a product to their cart.
-     *
-     * The method loops through the items in the cart and creates a
-     * Meta Pixel Content object for each item. The method then sets the
-     * content_type, currency, value, content_ids and contents fields in
-     * the event data.
-     *
-     * @param string $cart_item_key The cart item key.
-     * @param int    $product_id    The product ID.
-     * @param int    $quantity      The quantity of the item in the cart.
-     * @param int    $variation_id  The variation ID.
-     *
-     * @since 1.0.0
-     */
-    public static function trackAddToCartEvent(
-        $cart_item_key,
-        $product_id,
-        $quantity,
-        $variation_id
-    ) {
-        if ( FacebookPluginUtils::is_internal_user() ) {
-            return;
-        }
-
-        $server_event = ServerEventFactory::safe_create_event(
-            'AddToCart',
-            array( __CLASS__, 'createAddToCartEvent' ),
-            array( $cart_item_key, $product_id, $quantity ),
-            self::TRACKING_NAME
-        );
-
-            $is_ajax_request = wp_doing_ajax();
-
-        FacebookServerSideEvent::get_instance()->track(
-            $server_event,
-            $is_ajax_request
-        );
-
-        if ( ! $is_ajax_request ) {
-            self::enqueuePixelCode( $server_event );
-        } else {
-            FacebookServerSideEvent::get_instance()->set_pending_pixel_event(
-                'addPixelCodeToAddToCartFragment',
-                $server_event
-            );
-            add_filter(
-                'woocommerce_add_to_cart_fragments',
-                array( __CLASS__, 'addPixelCodeToAddToCartFragment' )
-            );
-        }
-    }
-
-    /**
-     * Modifies the WooCommerce "add to cart" AJAX fragment response
-     * to include the Meta Pixel code.
-     *
-     * This method is used to inject the Meta Pixel code into the
-     * page after the user has added a product to their cart.
-     *
-     * @param array $fragments The response array passed to the
-     *                          "woocommerce_add_to_cart_fragments" filter.
-     *
-     * @return array The modified response array.
-     *
-     * @since 1.0.0
-     */
-    public static function addPixelCodeToAddToCartFragment( $fragments ) {
-        $server_event = FacebookServerSideEvent::get_instance()
-        ->get_pending_pixel_event( 'addPixelCodeToAddToCartFragment' );
-        if ( ! is_null( $server_event ) ) {
-            $pixel_code = self::generatePixelCode( $server_event, true );
-            $fragments[ '#' . self::DIV_ID_FOR_AJAX_PIXEL_EVENTS ] =
-            self::getDivForAjaxPixelEvent( $pixel_code );
-        }
-        return $fragments;
-    }
-
-    /**
      * Creates a Meta Pixel AddToCart event data.
      *
      * The AddToCart event is fired when a customer adds a product to their
@@ -440,32 +340,6 @@ class FacebookWordpressWooCommerce extends FacebookWordpressIntegrationBase {
         }
 
         return $event_data;
-    }
-
-    /**
-     * Tracks a Meta Pixel InitiateCheckout event.
-     *
-     * This method is a wrapper of FacebookServerSideEvent::track() method.
-     * It creates a Meta Pixel InitiateCheckout event data with the data
-     * from the WooCommerce session, and then tracks the event.
-     *
-     * @since 1.0.0
-     */
-    public static function trackInitiateCheckout() {
-        if ( FacebookPluginUtils::is_internal_user() || null === WC()->cart || WC()->cart->get_cart_contents_count() === 0 ) {
-            return;
-        }
-
-        $server_event = ServerEventFactory::safe_create_event(
-            'InitiateCheckout',
-            array( __CLASS__, 'createInitiateCheckoutEvent' ),
-            array(),
-            self::TRACKING_NAME
-        );
-
-        FacebookServerSideEvent::get_instance()->track( $server_event );
-
-        self::enqueuePixelCode( $server_event );
     }
 
     /**
@@ -708,81 +582,5 @@ class FacebookWordpressWooCommerce extends FacebookWordpressIntegrationBase {
             get_option( 'active_plugins' ),
             true
         );
-    }
-
-    /**
-     * Generates the pixel code for a given server event.
-     *
-     * @param FacebookServerSideEvent $server_event The server event
-     * to generate the pixel code for.
-     * @param bool                    $script_tag   Whether to wrap
-     * the pixel code in a script tag. Default to false.
-     *
-     * @return string The pixel code for the given server event.
-     *
-     * @since 1.0.0
-     */
-    public static function generatePixelCode(
-        $server_event,
-        $script_tag = false
-) {
-        $code = PixelRenderer::render(
-            array( $server_event ),
-            self::TRACKING_NAME,
-            $script_tag
-        );
-        $code = sprintf(
-            '
-    <!-- Meta Pixel Event Code -->
-    %s
-    <!-- End Meta Pixel Event Code -->
-          ',
-            $code
-        );
-        return $code;
-    }
-
-    /**
-     * Enqueues a Meta Pixel event code for a given server event.
-     *
-     * This method renders the Meta Pixel code for the given server event,
-     * and then enqueues it using the WooCommerce JavaScript enqueueing
-     * system.
-     *
-     * @param FacebookServerSideEvent $server_event The server
-     * event to enqueue the pixel code for.
-     *
-     * @return string The Meta Pixel code for the given server event.
-     *
-     * @since 1.0.0
-     */
-    public static function enqueuePixelCode( $server_event ) {
-        $code   = self::generatePixelCode( $server_event, false );
-        $handle = 'meta_pixel_inline';
-
-        if ( ! function_exists( 'wp_add_inline_script' ) ) {
-            global $wc_queued_js;
-            $wc_queued_js .= "\n" . $code;
-            return $code;
-        }
-
-        static $registered = false;
-        if ( ! $registered ) {
-            if ( ! wp_script_is( $handle, 'registered' ) ) {
-                wp_register_script(
-                    $handle,
-                    '',
-                    array(),
-                    \FacebookPixelPlugin\Core\FacebookPluginConfig::PLUGIN_VERSION,
-                    true
-                );
-            }
-            wp_enqueue_script( $handle );
-            $registered = true;
-        }
-
-        wp_add_inline_script( $handle, $code );
-
-        return $code;
     }
 }

--- a/integration/class-facebookwordpresswpecommerce.php
+++ b/integration/class-facebookwordpresswpecommerce.php
@@ -49,7 +49,7 @@ class FacebookWordpressWPECommerce extends FacebookWordpressIntegrationBase {
      *
      * @return void
      */
-    public function inject_pixel_code() {
+    public function set_up_tracking() {
         $this->signals->on(
             'wpsc_add_to_cart_json_response',
             'AddToCart',

--- a/integration/class-facebookwordpresswpecommerce.php
+++ b/integration/class-facebookwordpresswpecommerce.php
@@ -29,11 +29,9 @@ namespace FacebookPixelPlugin\Integration;
 
 defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 
-use FacebookPixelPlugin\Core\FacebookPixel;
 use FacebookPixelPlugin\Core\FacebookPluginUtils;
-use FacebookPixelPlugin\Core\ServerEventFactory;
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
-use FacebookPixelPlugin\Core\PixelRenderer;
+use FacebookPixelPlugin\Core\FooterDelivery;
+use FacebookPixelPlugin\Core\AjaxHtmlDelivery;
 
 /**
  * FacebookWordpressWPECommerce class.
@@ -43,199 +41,104 @@ class FacebookWordpressWPECommerce extends FacebookWordpressIntegrationBase {
     const TRACKING_NAME = 'wp-e-commerce';
 
     /**
-     * Injects Facebook Pixel events for WP eCommerce.
+     * Registers the WP eCommerce events through Signals:
+     *  - AddToCart: on the add-to-cart JSON response (appended to
+     *    widget_output).
+     *  - InitiateCheckout: in the footer of the shopping cart page.
+     *  - Purchase: in the footer after a transaction completes.
      *
-     * This method sets up WordPress actions to inject Facebook Pixel events
-     * for different stages of the WP eCommerce process:
-     *
-     * - AddToCart: Hooks into the JSON response
-     * after an item is added to the cart.
-     * - InitiateCheckout: Fires a pixel event before
-     * the shopping cart page is displayed.
-     * - Purchase: Triggers a pixel event after
-     * the transaction results are processed.
-     *
-     * Hooks are added with specific priorities
-     * to ensure correct execution order.
+     * @return void
      */
-    public static function inject_pixel_code() {
-        add_action(
+    public function inject_pixel_code() {
+        $this->signals->on(
             'wpsc_add_to_cart_json_response',
-            array( __CLASS__, 'injectAddToCartEvent' ),
-            11
+            'AddToCart',
+            array( $this, 'read_add_to_cart' ),
+            new AjaxHtmlDelivery(
+                'wpsc_add_to_cart_json_response',
+                'widget_output'
+            ),
+            self::TRACKING_NAME,
+            11,
+            1
         );
 
-        self::add_pixel_fire_for_hook(
-            array(
-                'hook_name'       => 'wpsc_before_shopping_cart_page',
-                'classname'       => __CLASS__,
-                'inject_function' => 'injectInitiateCheckoutEvent',
-            )
+        $this->signals->on(
+            'wpsc_before_shopping_cart_page',
+            'InitiateCheckout',
+            array( $this, 'read_initiate_checkout' ),
+            new FooterDelivery(),
+            self::TRACKING_NAME,
+            10,
+            1
         );
 
-        add_action(
+        $this->signals->on(
             'wpsc_transaction_results_shutdown',
-            array( __CLASS__, 'injectPurchaseEvent' ),
+            'Purchase',
+            array( $this, 'read_purchase' ),
+            new FooterDelivery(),
+            self::TRACKING_NAME,
             11,
             3
         );
     }
 
     /**
-     * Injects Facebook Pixel code for add to cart events.
+     * Builds the AddToCart EventData from the add-to-cart JSON response.
      *
-     * This method is called from the
-     * `wpsc_add_to_cart_json_response` action hook.
-     * It creates an "AddToCart" event and tracks
-     * it using the Facebook server-side
-     * API. It then injects the Facebook Pixel code into the response.
-     *
-     * @param array $response The JSON response
-     * after an item is added to the cart.
-     * @return array The modified response with the Facebook Pixel code added.
+     * @param array $response The add-to-cart JSON response.
+     * @return \FacebookPixelPlugin\Core\EventData|null
      */
-    public static function injectAddToCartEvent( $response ) {
-        if ( FacebookPluginUtils::is_internal_user() ) {
-            return $response;
+    public function read_add_to_cart( $response ) {
+        if ( empty( $response['product_id'] ) ) {
+            return null;
         }
-
-        $product_id   = $response['product_id'];
-        $server_event = ServerEventFactory::safe_create_event(
-            'AddToCart',
-            array( __CLASS__, 'createAddToCartEvent' ),
-            array( $product_id ),
-            self::TRACKING_NAME
-        );
-            FacebookServerSideEvent::get_instance()->track( $server_event );
-
-            $code                   = PixelRenderer::render(
-                array( $server_event ),
-                self::TRACKING_NAME
-            );
-        $code                       = sprintf(
-            '
-        <!-- Meta Pixel Event Code -->
-        %s
-        <!-- End Meta Pixel Event Code -->
-            ',
-            $code
-        );
-        $response['widget_output'] .= $code;
-        return $response;
-    }
-
-    /**
-     * Injects a Meta Pixel InitiateCheckout event.
-     *
-     * This method is called from the
-     * `wpsc_before_shopping_cart_page` action hook.
-     * It injects a Meta Pixel InitiateCheckout
-     * event into the page whenever a shopping cart is rendered.
-     *
-     * @since 1.0.0
-     */
-    public static function injectInitiateCheckoutEvent() {
-        if ( FacebookPluginUtils::is_internal_user() ) {
-            return;
-        }
-
-        $server_event = ServerEventFactory::safe_create_event(
-            'InitiateCheckout',
-            array( __CLASS__, 'createInitiateCheckoutEvent' ),
-            array(),
-            self::TRACKING_NAME
-        );
-            FacebookServerSideEvent::get_instance()->track( $server_event );
-
-            $code = PixelRenderer::render(
-                array(
-                    $server_event,
-                ),
-                self::TRACKING_NAME
-            );
-        printf(
-            '
-    <!-- Meta Pixel Event Code -->
-    %s
-    <!-- End Meta Pixel Event Code -->
-          ',
-            $code // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        return $this->event_builder->build(
+            self::createAddToCartEvent( $response['product_id'] )
         );
     }
 
     /**
-     * Injects a Meta Pixel Purchase event.
+     * Builds the InitiateCheckout EventData for the shopping cart page.
      *
-     * This method is triggered by the
-     * `wpsc_transaction_results_shutdown` action hook.
-     * It creates and tracks a "Purchase"
-     * event using the Facebook server-side API,
-     * injecting the Facebook Pixel code
-     * into the page if the user is not internal and
-     * the display_to_screen flag is true.
-     *
-     * @param object $purchase_log_object The
-     * purchase log object containing transaction details.
-     * @param mixed  $session_id The session
-     * ID for the current user session.
-     * @param bool   $display_to_screen Flag
-     * indicating whether to display the Pixel code on screen.
-     *
-     * @since 1.0.0
+     * @return \FacebookPixelPlugin\Core\EventData
      */
-    public static function injectPurchaseEvent(
+    public function read_initiate_checkout() {
+        return $this->event_builder->build(
+            self::createInitiateCheckoutEvent()
+        );
+    }
+
+    /**
+     * Builds the Purchase EventData from a completed transaction.
+     *
+     * @param object $purchase_log_object The purchase log object.
+     * @param mixed  $session_id          The session id (unused).
+     * @param bool   $display_to_screen   Whether the results are shown.
+     * @return \FacebookPixelPlugin\Core\EventData|null
+     */
+    public function read_purchase(
         $purchase_log_object,
-        $session_id,
-        $display_to_screen
+        $session_id = null,
+        $display_to_screen = false
     ) {
-        if ( FacebookPluginUtils::is_internal_user() || ! $display_to_screen ) {
-            return;
+        if ( ! $display_to_screen ) {
+            return null;
         }
-
-        $server_event = ServerEventFactory::safe_create_event(
-            'Purchase',
-            array( __CLASS__, 'createPurchaseEvent' ),
-            array( $purchase_log_object ),
-            self::TRACKING_NAME
-        );
-        FacebookServerSideEvent::get_instance()->track( $server_event );
-
-        $code = PixelRenderer::render(
-            array(
-                $server_event,
-            ),
-            self::TRACKING_NAME
-        );
-
-        printf(
-            '
-    <!-- Meta Pixel Event Code -->
-    %s
-    <!-- End Meta Pixel Event Code -->
-        ',
-            $code // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        return $this->event_builder->build(
+            self::createPurchaseEvent( $purchase_log_object )
         );
     }
 
     /**
      * Generates a Meta Pixel Purchase event data.
      *
-     * The Purchase event is fired when a customer completes a purchase.
-     * It is typically sent when a customer submits an order.
-     *
-     * The method loops through the items in the order and creates a
-     * Meta Pixel Content object for each item. The method then sets the
-     * content_type, currency, value, content_ids and contents fields in
-     * the event data.
-     *
-     * @param object $purchase_log_object The
-     * purchase log object containing transaction details.
-     *
+     * @param object $purchase_log_object The purchase log object containing
+     *                                    transaction details.
      * @return array The event data.
-     *
-     * @since 1.0.0
      */
-    public static function createPurchaseEvent( $purchase_log_object ) {
+    private static function createPurchaseEvent( $purchase_log_object ) {
         $event_data = FacebookPluginUtils::get_logged_in_user_info();
 
         $cart_items  = $purchase_log_object->get_items();
@@ -260,22 +163,10 @@ class FacebookWordpressWPECommerce extends FacebookWordpressIntegrationBase {
     /**
      * Generates a Meta Pixel AddToCart event data.
      *
-     * The AddToCart event is fired when a customer adds a product to their
-     * cart. It is typically sent when a customer adds a product to their
-     * cart.
-     *
-     * The method loops through the items in the cart and creates a Meta Pixel
-     * Content object for the product that was added to the cart. The method
-     * then sets the content_type, currency, value, content_ids and contents
-     * fields in the event data.
-     *
      * @param int $product_id The product ID.
-     *
      * @return array The event data.
-     *
-     * @since 1.0.0
      */
-    public static function createAddToCartEvent( $product_id ) {
+    private static function createAddToCartEvent( $product_id ) {
         $event_data = FacebookPluginUtils::get_logged_in_user_info();
 
         global $wpsc_cart;
@@ -300,19 +191,9 @@ class FacebookWordpressWPECommerce extends FacebookWordpressIntegrationBase {
     /**
      * Generates a Meta Pixel InitiateCheckout event data.
      *
-     * The InitiateCheckout event is fired when a customer initiates a checkout.
-     * It is typically sent when a customer clicks a "checkout" button
-     * or submits an order.
-     *
-     * The method loops through the items in the cart and creates a Meta Pixel
-     * Content object for each item. The method then sets the content_type,
-     * currency, value, content_ids and contents fields in the event data.
-     *
      * @return array The event data.
-     *
-     * @since 1.0.0
      */
-    public static function createInitiateCheckoutEvent() {
+    private static function createInitiateCheckoutEvent() {
         $event_data  = FacebookPluginUtils::get_logged_in_user_info();
         $content_ids = array();
 

--- a/integration/class-facebookwordpresswpforms.php
+++ b/integration/class-facebookwordpresswpforms.php
@@ -29,14 +29,10 @@ namespace FacebookPixelPlugin\Integration;
 
 defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 
-use FacebookPixelPlugin\Core\FacebookPixel;
-use FacebookPixelPlugin\Core\FacebookPluginUtils;
-use FacebookPixelPlugin\Core\FacebookServerSideEvent;
-use FacebookPixelPlugin\Core\FacebookWordPressOptions;
 use FacebookPixelPlugin\Core\ServerEventFactory;
-use FacebookPixelPlugin\Core\PixelRenderer;
-use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
-use FacebookPixelPlugin\FacebookAds\Object\ServerSide\UserData;
+use FacebookPixelPlugin\Core\CompositeDelivery;
+use FacebookPixelPlugin\Core\FooterDelivery;
+use FacebookPixelPlugin\Core\AjaxFilterDelivery;
 
 /**
  * FacebookWordpressWPForms class.
@@ -46,148 +42,52 @@ class FacebookWordpressWPForms extends FacebookWordpressIntegrationBase {
     const TRACKING_NAME = 'wpforms-lite';
 
     /**
-     * Hooks into WPForms to inject the Pixel code.
+     * Registers the WPForms hooks.
      *
-     * This method adds an action to the 'wpforms_process_before' hook,
-     * which will trigger the 'trackEvent' method. It ensures that
-     * the Pixel code is injected during the form processing stage.
+     * A Lead event is dispatched through Signals when a submission is
+     * processed. The browser pixel is delivered both in the footer (classic
+     * submit) and in the AJAX success/redirect responses (AJAX submit); a
+     * front-end listener evaluates the AJAX-delivered code.
+     *
+     * @return void
      */
-    public static function inject_pixel_code() {
-        // Tracks server and browser events when a submission is processed.
-        add_action(
+    public function inject_pixel_code() {
+        $this->signals->on(
             'wpforms_process_before',
-            array( __CLASS__, 'trackEvent' ),
+            'Lead',
+            array( $this, 'read_form_data' ),
+            new CompositeDelivery(
+                array(
+                    new FooterDelivery(),
+                    new AjaxFilterDelivery(
+                        'wpforms_ajax_submit_success_response',
+                        'fb_pxl_code'
+                    ),
+                    new AjaxFilterDelivery(
+                        'wpforms_ajax_submit_redirect',
+                        'fb_pxl_code'
+                    ),
+                )
+            ),
+            self::TRACKING_NAME,
             20,
             2
         );
 
-        // Enriches AJAX responses (success or redirect) with pixel code.
-        add_filter(
-            'wpforms_ajax_submit_success_response',
-            array( __CLASS__, 'injectLeadEventAjax' ),
-            20,
-            3
-        );
-        add_filter(
-            'wpforms_ajax_submit_redirect',
-            array( __CLASS__, 'injectLeadEventAjax' ),
-            20,
-            3
-        );
-
-        // Adds a front-end listener that fires pixel code returned in AJAX responses.
         add_action(
             'wp_footer',
-            array( __CLASS__, 'injectAjaxListener' ),
+            array( $this, 'inject_ajax_listener' ),
             9
         );
     }
 
     /**
-     * Tracks a server-side event for a form submission in WPForms.
-     *
-     * This method is hooked into the 'wpforms_process_before' action, which is
-     * fired by WPForms before a form is processed.
-     * It then calls the track method
-     * on the FacebookServerSideEvent instance, which generates a lead event for
-     * the form submission.
-     *
-     * If the user is an internal user, the method returns without tracking
-     * any event.
-     *
-     * @param array $entry The form entry data.
-     * @param array $form_data The form data.
+     * Outputs a JS listener that evaluates fb_pxl_code from WPForms AJAX
+     * responses (the AJAX path does not re-render wp_footer).
      *
      * @return void
      */
-    public static function trackEvent( $entry, $form_data ) {
-        if ( FacebookPluginUtils::is_internal_user() ) {
-            return;
-        }
-
-        $server_event = ServerEventFactory::safe_create_event(
-            'Lead',
-            array( __CLASS__, 'readFormData' ),
-            array( $entry, $form_data ),
-            self::TRACKING_NAME,
-            true
-        );
-        FacebookServerSideEvent::get_instance()->track( $server_event );
-
-        add_action(
-            'wp_footer',
-            array( __CLASS__, 'injectLeadEvent' ),
-            20
-        );
-    }
-
-    /**
-     * Injects lead event code into the footer.
-     *
-     * This method retrieves tracked events from the FacebookServerSideEvent
-     * instance and renders them into pixel code using the PixelRenderer.
-     * The resulting code is printed into the footer section of the page.
-     * If the user is an internal user, the method returns without injecting
-     * any code.
-     *
-     * @return void
-     */
-    public static function injectLeadEvent() {
-        if ( FacebookPluginUtils::is_internal_user() ) {
-            return;
-        }
-
-        $events     =
-            FacebookServerSideEvent::get_instance()->get_tracked_events();
-        $pixel_code = PixelRenderer::render( $events, self::TRACKING_NAME );
-
-        printf(
-            '
-    <!-- Meta Pixel Event Code -->
-    %s
-    <!-- End Meta Pixel Event Code -->
-          ',
-            $pixel_code // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-        );
-    }
-
-    /**
-     * Add pixel code into AJAX success/redirect responses.
-     *
-     * @param array $response  Existing AJAX response payload.
-     * @param int   $form_id   Form ID (provided by WPForms).
-     * @param mixed $extra     Unused extra parameter (URL or form data).
-     *
-     * @return array Modified response containing fb_pxl_code when available.
-     */
-    public static function injectLeadEventAjax( $response, $form_id = null, $extra = null ) {
-        if ( FacebookPluginUtils::is_internal_user() ) {
-            return $response;
-        }
-
-        $events = FacebookServerSideEvent::get_instance()->get_tracked_events();
-        if ( empty( $events ) ) {
-            return $response;
-        }
-
-        $response['fb_pxl_code'] = PixelRenderer::render(
-            $events,
-            self::TRACKING_NAME,
-            false // Return raw fbq calls; they will be eval'd on the client.
-        );
-
-        return $response;
-    }
-
-    /**
-     * Outputs a JS listener that evaluates fb_pxl_code from WPForms AJAX responses.
-     *
-     * This covers the default WPForms AJAX path where the page is not reloaded
-     * and no wp_footer hook is executed after submission.
-     *
-     * @return void
-     */
-    public static function injectAjaxListener() {
+    public function inject_ajax_listener() {
         ?>
         <!-- Meta Pixel Event Code -->
         <script type='text/javascript'>
@@ -212,45 +112,30 @@ class FacebookWordpressWPForms extends FacebookWordpressIntegrationBase {
     }
 
     /**
-     * Reads the form submission data and extracts user information.
+     * Extracts the Lead event data from a WPForms submission.
      *
-     * This method processes the form entry and form
-     * data to extract user-related
-     * information such as email, first name, last name,
-     * and phone number. It also
-     * retrieves the address data, including city,
-     * state, country, and postal code.
-     *
-     * If either the form entry or form data is
-     * empty, an empty array is returned.
-     *
-     * @param array $entry The form entry data.
+     * @param array $entry     The form entry data.
      * @param array $form_data The form schema data.
-     *
-     * @return array An associative array
-     *               containing user and address information
-     *               extracted from the form entry.
+     * @return \FacebookPixelPlugin\Core\EventData|null
      */
-    public static function readFormData( $entry, $form_data ) {
+    public function read_form_data( $entry, $form_data = array() ) {
         if ( empty( $entry ) || empty( $form_data ) ) {
-            return array();
+            return null;
         }
 
         $name = self::getName( $entry, $form_data );
 
-        $event_data = array(
-            'email'      => self::getEmail( $entry, $form_data ),
-            'first_name' => ! empty( $name ) ? $name[0] : null,
-            'last_name'  => ! empty( $name ) ? $name[1] : null,
-            'phone'      => self::getPhone( $entry, $form_data ),
+        return $this->event_builder->build(
+            array_merge(
+                array(
+                    'email'      => self::getEmail( $entry, $form_data ),
+                    'first_name' => ! empty( $name ) ? $name[0] : null,
+                    'last_name'  => ! empty( $name ) ? $name[1] : null,
+                    'phone'      => self::getPhone( $entry, $form_data ),
+                ),
+                self::getAddress( $entry, $form_data )
+            )
         );
-
-        $event_data = array_merge(
-            $event_data,
-            self::getAddress( $entry, $form_data )
-        );
-
-        return $event_data;
     }
 
     /**

--- a/integration/class-facebookwordpresswpforms.php
+++ b/integration/class-facebookwordpresswpforms.php
@@ -51,7 +51,7 @@ class FacebookWordpressWPForms extends FacebookWordpressIntegrationBase {
      *
      * @return void
      */
-    public function inject_pixel_code() {
+    public function set_up_tracking() {
         $this->signals->on(
             'wpforms_process_before',
             'Lead',


### PR DESCRIPTION
## Summary
Converts every remaining integration to the instance + `Signals` model, renames the integration entry point, and makes all integration tests behavior-preserving. Builds on #159.

### Integrations converted (instance + `Signals::on`, pure `read_*` `EventData` providers)
WPForms, Ninja Forms, Formidable, Caldera, Mailchimp, WP eCommerce, Easy Digital Downloads, WooCommerce.

### Delivery strategies (browser-side placement lives here, not in integrations)
- `FooterDelivery`, `AjaxFilterDelivery`, `AjaxHtmlDelivery` (from the foundation)
- `CompositeDelivery` — WPForms (footer + AJAX)
- `InlineScriptDelivery` — WooCommerce (`wp_add_inline_script`, `$wc_queued_js` fallback)
- `CartFragmentDelivery` — WooCommerce AJAX add-to-cart (inline on classic, cart fragment on AJAX)
- `AbstractEventDelivery` gains a `store()` seam

### Entry-point rename
`inject_pixel_code()` → `set_up_tracking()` on every integration (it registers tracking now; it doesn't inject pixel code). `PixelInjection`'s own base-pixel `inject_pixel_code()` is unchanged.

### Tests
All integration tests are behavior-preserving: they drive the real `Signals` dispatch path and assert the same tracked-event user/custom data as before the refactor, plus a lightweight `Signals::on()` wiring check per integration.

### Behavior note
Server sends are now uniform (immediate) via `Signals::dispatch`; WooCommerce's old per-event `send_now=false` deferral (ViewContent, non-AJAX AddToCart) is dropped — those events send once at dispatch time like every other integration.

## Follow-ups (not in this PR)
- Remove the `FacebookServerSideEvent` singleton (inject it everywhere).
- Rebase the field-mapping stack (#153–#157) onto this tip.

## Test plan
`phpunit __tests__` → 240 tests green; `phpcs` whole-tree clean.