### PR TITLE
Avoid tripping CAPI circuit breaker on invalid test events

### DIFF
--- a/core/class-facebookserversideevent.php
+++ b/core/class-facebookserversideevent.php
@@ -32,6 +32,7 @@ use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\EventRequest;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\UserData;
 use FacebookPixelPlugin\FacebookAds\Exception\Exception;
+use FacebookPixelPlugin\FacebookAds\Http\Exception\RequestException;
 
 defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 
@@ -226,19 +227,73 @@ class FacebookServerSideEvent {
                 'events_received' => $response->getEventsReceived(),
             );
         } catch ( \Exception $e ) {
-            FacebookCapiCircuitBreaker::record_exception( $e );
-            // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
-            error_log( '[Facebook Pixel for WordPress] CAPI error: ' . $e->getMessage() );
-            error_log( $e->getTraceAsString() );
-            // phpcs:enable WordPress.PHP.DevelopmentFunctions.error_log_error_log
+            if ( ! self::is_expected_test_event_request_exception( $e, $test_event_code ) ) {
+                FacebookCapiCircuitBreaker::record_exception( $e );
+            }
+            if ( self::should_log_exception( $e, $test_event_code ) ) {
+                // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
+                error_log( '[Facebook Pixel for WordPress] CAPI error: ' . $e->getMessage() );
+                error_log( $e->getTraceAsString() );
+                // phpcs:enable WordPress.PHP.DevelopmentFunctions.error_log_error_log
+            }
             return array(
                 'success' => false,
-                'error'   => array(
-                    'message' => $e->getMessage(),
-                    'code'    => $e->getCode(),
-                ),
+                'error'   => self::build_error_payload( $e ),
             );
         }
+    }
+
+    /**
+     * Builds a user-facing error payload from an exception.
+     *
+     * @param \Exception $e The exception raised by the CAPI send.
+     * @return array
+     */
+    private static function build_error_payload( \Exception $e ) {
+        $error_message      = $e->getMessage();
+        $error_user_message = $error_message;
+
+        if ( $e instanceof RequestException ) {
+            $error_user_message = $e->getErrorUserMessage();
+            if ( empty( $error_user_message ) ) {
+                $error_user_message = $error_message;
+            }
+        }
+
+        return array(
+            'message'        => $error_message,
+            'error_user_msg' => $error_user_message,
+            'code'           => $e->getCode(),
+        );
+    }
+
+    /**
+     * Determines whether a RequestException is an expected test-event error.
+     *
+     * Invalid test-event payloads can produce RequestException responses from
+     * Meta. Those errors should be surfaced to the admin UI, but they should
+     * not trip the connection circuit breaker or be written to debug.log.
+     *
+     * @param \Exception  $e The exception raised by the CAPI send.
+     * @param string|null $test_event_code Optional test event code.
+     * @return bool
+     */
+    private static function is_expected_test_event_request_exception( \Exception $e, $test_event_code = null ) {
+        return ! empty( $test_event_code ) && $e instanceof RequestException;
+    }
+
+    /**
+     * Determines whether an exception should be written to debug.log.
+     *
+     * For test-event sends, RequestException errors are expected when payloads
+     * are invalid and are therefore not logged.
+     *
+     * @param \Exception  $e The exception raised by the CAPI send.
+     * @param string|null $test_event_code Optional test event code.
+     * @return bool
+     */
+    private static function should_log_exception( \Exception $e, $test_event_code = null ) {
+        return ! self::is_expected_test_event_request_exception( $e, $test_event_code );
     }
 
     /**


### PR DESCRIPTION
## Description

This PR fixes CAPI test-event handling so expected Meta `RequestException` responses from invalid test-event payloads are returned to the admin UI without tripping the CAPI circuit breaker or spamming `debug.log`.

Motivation: invalid test events are useful admin feedback during setup/debugging, but they should not mark the connection as invalid or pause normal CAPI sends.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices. Meta employees to follow this [wiki]([url](https://fburl.com/wiki/b2b0midg)).
- [ ] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary).

## Changelog entry

Avoid tripping the CAPI circuit breaker for expected invalid test-event errors.

## Test Plan

1. Get a test event code from Events Manager.
2. Submit event(s) from the plugin.
3. Open **Edit Event Data (Advanced)**, make the JSON invalid, for example add `x` to `event_time`, and submit the event.
4. Submit a secondary event with bad data.
5. Clear the bad data and submit a good event.
6. Before this fix, the event log shows `Connection invalid (circuit open)` and all further attempts fail until reconnecting.
7. After this fix, invalid test-event errors are shown without opening the circuit, and a later good event can be submitted.