### PR TITLE
Split the CAPI sender: RestCallBase + ServerEventSender + AdminEventSender

### DIFF
--- a/__tests__/core/AdminEventSenderTest.php
+++ b/__tests__/core/AdminEventSenderTest.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Facebook Pixel Plugin ServerEventSenderTest class.
+ * Facebook Pixel Plugin AdminEventSenderTest class.
  *
  * @package FacebookPixelPlugin
  */
@@ -19,17 +19,17 @@
 
 namespace FacebookPixelPlugin\Tests\Core;
 
+use FacebookPixelPlugin\Core\AdminEventSender;
 use FacebookPixelPlugin\Core\FacebookPluginConfig;
-use FacebookPixelPlugin\Core\ServerEventSender;
 use FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 
 /**
- * ServerEventSenderTest class.
+ * AdminEventSenderTest class.
  *
- * ServerEventSender is fire-and-forget: send() returns nothing, so these tests
- * assert its side effects (whether it attempts the API call) rather than a
- * return value.
+ * AdminEventSender sends admin "Test Events" and returns the result for the
+ * admin panel. Unlike ServerEventSender it never consults the circuit breaker,
+ * so a rejected test event cannot block real traffic.
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
@@ -38,20 +38,20 @@ use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
  * make sure tests are isolated.
  * Stop preserving global state from the parent process.
  */
-final class ServerEventSenderTest extends FacebookWordpressTestBase {
+final class AdminEventSenderTest extends FacebookWordpressTestBase {
   /**
    * A fresh sender for each test.
    *
-   * @var ServerEventSender
+   * @var AdminEventSender
    */
   private $sender;
 
   public function setUp(): void {
     parent::setUp();
-    $this->sender = new ServerEventSender();
+    $this->sender = new AdminEventSender();
   }
 
-  public function testSendDoesNotCallApiWhenNoCredentials() {
+  public function testSendReturnsErrorWhenNoCredentials() {
     self::mockFacebookWordpressOptions(
       array(
         'pixel_id'     => '',
@@ -62,32 +62,42 @@ final class ServerEventSenderTest extends FacebookWordpressTestBase {
     $api = \Mockery::mock( 'alias:FacebookPixelPlugin\FacebookAds\Api' );
     $api->shouldReceive( 'init' )->never();
 
-    $event = ( new Event() )->setEventName( 'Lead' );
-    $this->sender->send( array( $event ) );
+    $event  = ( new Event() )->setEventName( 'Lead' );
+    $result = $this->sender->send( array( $event ) );
 
-    $this->assertConditionsMet();
+    $this->assertFalse( $result['success'] );
+    $this->assertStringContainsString(
+      'configured',
+      $result['error']['message']
+    );
   }
 
-  public function testSendIsBlockedWhenCircuitOpen() {
+  public function testSendBypassesCircuitBreaker() {
     self::mockFacebookWordpressOptions();
 
-    // Fresh transient → circuit open → the sender must not attempt the call.
+    // Fresh transient → circuit would be open for ServerEventSender. The admin
+    // sender must ignore it and still attempt the call (init is reached).
     \WP_Mock::userFunction(
       'get_transient',
       array(
         'args'   => array(
           FacebookPluginConfig::CONNECTION_INVALID_TRANSIENT,
         ),
-        'return' => time() - 10,
+        'return' => time(),
       )
     );
 
     $api = \Mockery::mock( 'alias:FacebookPixelPlugin\FacebookAds\Api' );
-    $api->shouldReceive( 'init' )->never();
+    $api->shouldReceive( 'init' )
+      ->once()
+      ->andThrow( new \Exception( 'boom' ) );
 
-    $event = ( new Event() )->setEventName( 'Lead' );
-    $this->sender->send( array( $event ) );
+    $event  = ( new Event() )->setEventName( 'Lead' );
+    $result = $this->sender->send( array( $event ) );
 
+    // Reached the API (breaker bypassed) and surfaced the error to the caller.
+    $this->assertFalse( $result['success'] );
+    $this->assertEquals( 'boom', $result['error']['message'] );
     $this->assertConditionsMet();
   }
 }

--- a/__tests__/core/AdminTestCapiEventTest.php
+++ b/__tests__/core/AdminTestCapiEventTest.php
@@ -20,19 +20,20 @@
 namespace FacebookPixelPlugin\Tests\Core;
 
 use FacebookPixelPlugin\Core\AdminTestCapiEvent;
-use FacebookPixelPlugin\Core\Signals;
+use FacebookPixelPlugin\Core\AdminEventSender;
 use FacebookPixelPlugin\Tests\FacebookWordpressTestBase;
 
 /**
  * AdminTestCapiEventTest class.
  *
- * Characterizes the admin "Test Events" endpoint (wp_ajax_send_capi_event) as a
- * behavior baseline for the upcoming refactor that offloads event structure to
- * EventFactory + the SDK objects. The contract that must not regress:
- *  - the posted payload is mapped to Event(s) and passed to Signals::send()
- *    (one event per data entry, with the right event name), and
- *  - the Signals::send() result is captured and returned to the admin panel —
- *    events_received on success, the error message on a non-success result.
+ * Characterizes the admin "Test Events" endpoint (wp_ajax_send_capi_event). The
+ * event structure is offloaded to EventFactory + the SDK objects. The contract
+ * that must not regress:
+ *  - the posted payload is mapped to Event(s) and passed to
+ *    AdminEventSender::send() (one event per data entry, right event name), and
+ *  - the AdminEventSender::send() result is captured and returned to the admin
+ *    panel — events_received on success, the error message on a non-success
+ *    result.
  *
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
@@ -95,7 +96,7 @@ final class AdminTestCapiEventTest extends FacebookWordpressTestBase {
    * result, capturing the JSON response and the events handed to send().
    *
    * @param array $post          The $_POST payload.
-   * @param mixed $send_result   What Signals::send() should return.
+   * @param mixed $send_result   What AdminEventSender::send() should return.
    * @param bool  $nonce_valid   Whether wp_verify_nonce passes.
    * @param bool  $expect_send   Whether send() is expected to be called.
    *
@@ -128,10 +129,10 @@ final class AdminTestCapiEventTest extends FacebookWordpressTestBase {
       )
     );
 
-    $sent    = null;
-    $signals = \Mockery::mock( Signals::class );
+    $sent   = null;
+    $sender = \Mockery::mock( AdminEventSender::class );
     if ( $expect_send ) {
-      $signals->shouldReceive( 'send' )
+      $sender->shouldReceive( 'send' )
         ->andReturnUsing(
           function ( $events, $code = null ) use ( &$sent, $send_result ) {
             $sent = $events;
@@ -139,7 +140,7 @@ final class AdminTestCapiEventTest extends FacebookWordpressTestBase {
           }
         );
     } else {
-      $signals->shouldReceive( 'send' )->never();
+      $sender->shouldReceive( 'send' )->never();
     }
 
     $captured = null;
@@ -164,7 +165,7 @@ final class AdminTestCapiEventTest extends FacebookWordpressTestBase {
 
     $_POST = $post;
 
-    $obj = new AdminTestCapiEvent( $signals );
+    $obj = new AdminTestCapiEvent( $sender );
     try {
       $obj->send_capi_event();
     } catch ( \RuntimeException $e ) {

--- a/core/class-signals.php
+++ b/core/class-signals.php
@@ -107,7 +107,7 @@ class Signals {
         );
         $this->register();
         new ReleaseSignalsAjax( $this );
-        new AdminTestCapiEvent( $this );
+        new AdminTestCapiEvent( new AdminEventSender() );
         new ServerEventAsyncTask( $this );
 
         if ( $this->should_hold_signals() ) {
@@ -255,32 +255,33 @@ class Signals {
     }
 
     /**
-     * Sends events straight to the Conversions API. The facade entry point for
-     * one-off server sends (release flow, OpenBridge, CAPI event endpoint,
-     * async task) so callers never touch the sender directly.
+     * Sends events to the Conversions API. The facade entry point for server
+     * dispatch (release flow, OpenBridge, async task, integrations) so callers
+     * never touch the sender directly.
      *
      * Applies the before_conversions_api_event_sent filter and the consent gate
      * (when signals are held on the frontend the events are queued for browser
-     * release instead of being sent), then delegates the actual send.
+     * release instead of being sent), then hands off to the sender.
+     * Fire-and-forget: nothing is returned. (The admin "Test Events" path is
+     * handled separately by AdminEventSender, which reports its result.)
      *
      * @param \FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event[] $events The events.
-     * @param string|null                                                $test_event_code Optional test code.
-     * @return array|null
+     * @return void
      */
-    public function send( $events, $test_event_code = null ) {
+    public function send( $events ) {
         $events = apply_filters( 'before_conversions_api_event_sent', $events );
         if ( empty( $events ) ) {
-            return null;
+            return;
         }
 
         if ( $this->should_suppress_frontend_send() ) {
             foreach ( $events as $queued_event ) {
                 FacebookSignalState::queue_event( $queued_event );
             }
-            return null;
+            return;
         }
 
-        return self::$sender->send( $events, $test_event_code );
+        self::$sender->send( $events );
     }
 
     /**

--- a/core/signals/class-admineventsender.php
+++ b/core/signals/class-admineventsender.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Copyright (C) 2017-present, Meta, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * @package FacebookPixelPlugin
+ */
+
+namespace FacebookPixelPlugin\Core;
+
+defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
+
+/**
+ * Class AdminEventSender
+ *
+ * Sends admin "Test Events" to the Conversions API and returns the result so
+ * the admin panel can report it (events_received on success, the error message
+ * otherwise). Unlike ServerEventSender it does NOT engage the circuit breaker:
+ * a malformed or rejected test event must not trip the breaker for real
+ * traffic.
+ *
+ * @internal Not part of the plugin's public API.
+ */
+class AdminEventSender extends RestCallBase {
+    /**
+     * Sends test events to the Conversions API and returns the result.
+     *
+     * @param \FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event[] $events          The events to send.
+     * @param string|null                                                $test_event_code Optional test event code.
+     * @return array Result array with a 'success' key.
+     */
+    public function send( $events, $test_event_code = null ) {
+        return $this->call( $events, $test_event_code );
+    }
+
+    /**
+     * Reports missing configuration to the admin panel.
+     *
+     * @return array
+     */
+    protected function handle_missing_config() {
+        return array(
+            'success' => false,
+            'error'   => array(
+                'message' => 'Pixel ID or access token is not configured.',
+                'code'    => 0,
+            ),
+        );
+    }
+
+    /**
+     * Returns the successful result with the number of events received.
+     *
+     * @param mixed $response The EventResponse.
+     * @return array
+     */
+    protected function handle_success( $response ) {
+        return array(
+            'success'         => true,
+            'events_received' => $response->getEventsReceived(),
+        );
+    }
+
+    /**
+     * Returns the failure result with the error details.
+     *
+     * @param \Exception $e The caught exception.
+     * @return array
+     */
+    protected function handle_error( \Exception $e ) {
+        return array(
+            'success' => false,
+            'error'   => array(
+                'message' => $e->getMessage(),
+                'code'    => $e->getCode(),
+            ),
+        );
+    }
+}

--- a/core/signals/class-admintestcapievent.php
+++ b/core/signals/class-admintestcapievent.php
@@ -34,25 +34,27 @@ defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
  *
  * Admin "Test Events" endpoint (wp_ajax_send_capi_event). It is a thin
  * controller: read the admin-supplied inputs, map them to server Event(s) via
- * EventFactory, send them through Signals, and return the result to the admin
- * panel. The event structure lives in EventFactory / the SDK objects, not here;
- * a malformed event surfaces as a non-success result from the Conversions API.
+ * EventFactory, send them through the AdminEventSender, and return the result
+ * to the admin panel. The event structure lives in EventFactory / the SDK
+ * objects, not here; a malformed event surfaces as a non-success result from
+ * the Conversions API. The AdminEventSender deliberately bypasses the circuit
+ * breaker so a rejected test event never blocks real traffic.
  */
 class AdminTestCapiEvent {
     /**
-     * Shared Signals service.
+     * Sender for admin test events (circuit breaker bypassed).
      *
-     * @var Signals
+     * @var AdminEventSender
      */
-    private $signals;
+    private $sender;
 
     /**
      * Hook into WordPress's AJAX actions to handle sending a CAPI event.
      *
-     * @param Signals $signals Shared signals service.
+     * @param AdminEventSender $sender Sender for admin test events.
      */
-    public function __construct( Signals $signals ) {
-        $this->signals = $signals;
+    public function __construct( AdminEventSender $sender ) {
+        $this->sender = $sender;
         add_action(
             'wp_ajax_send_capi_event',
             array( $this, 'send_capi_event' )
@@ -63,8 +65,9 @@ class AdminTestCapiEvent {
      * Handles the admin "Test Events" request.
      *
      * Reads the posted inputs, maps them to server Event(s) via EventFactory,
-     * sends them through Signals, and returns the Conversions API result to the
-     * admin panel (events_received on success, the error message otherwise).
+     * sends them through the AdminEventSender, and returns the Conversions API
+     * result to the admin panel (events_received on success, the error message
+     * otherwise).
      */
     public function send_capi_event() {
         $nonce = isset( $_POST['nonce'] ) ?
@@ -141,7 +144,7 @@ class AdminTestCapiEvent {
             }
         }
 
-        $result = $this->signals->send( $events, $test_event_code );
+        $result = $this->sender->send( $events, $test_event_code );
 
         if ( $result && $result['success'] ) {
             wp_send_json_success(

--- a/core/signals/class-restcallbase.php
+++ b/core/signals/class-restcallbase.php
@@ -1,0 +1,159 @@
+<?php
+/**
+ * Copyright (C) 2017-present, Meta, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * @package FacebookPixelPlugin
+ */
+
+namespace FacebookPixelPlugin\Core;
+
+use FacebookPixelPlugin\FacebookAds\Api;
+use FacebookPixelPlugin\FacebookAds\Object\ServerSide\EventRequest;
+
+defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
+
+/**
+ * Base for Conversions API callers.
+ *
+ * Owns the shared call flow as a template method: check configuration, build
+ * the EventRequest, execute it, and route the outcome through hooks the
+ * subclasses fill in. It knows nothing about the circuit breaker or the shape
+ * of the result — subclasses decide those (e.g. ServerEventSender engages the
+ * breaker and returns nothing; AdminEventSender skips the breaker and returns
+ * the result for the admin panel).
+ *
+ * @internal Not part of the plugin's public API.
+ */
+abstract class RestCallBase {
+    /**
+     * Lazily-initialized Conversions API client, reused across calls in the
+     * same request (the access token is request-stable).
+     *
+     * @var \FacebookPixelPlugin\FacebookAds\Api|null
+     */
+    private $api = null;
+
+    /**
+     * Template method: run the REST call and route the outcome through the
+     * subclass hooks.
+     *
+     * @param \FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event[] $events          The events.
+     * @param string|null                                                $test_event_code Optional test event code.
+     * @return mixed Whatever the subclass hooks return.
+     */
+    protected function call( $events, $test_event_code = null ) {
+        if ( ! $this->has_config() ) {
+            return $this->handle_missing_config();
+        }
+
+        if ( ! $this->can_call() ) {
+            return $this->handle_blocked();
+        }
+
+        try {
+            $request  = $this->build_request( $events, $test_event_code );
+            $response = $request->execute();
+            return $this->handle_success( $response );
+        } catch ( \Exception $e ) {
+            return $this->handle_error( $e );
+        }
+    }
+
+    /**
+     * Whether the pixel id and access token are configured.
+     *
+     * @return bool
+     */
+    protected function has_config() {
+        return ! empty( FacebookWordpressOptions::get_active_pixel_id() )
+            && ! empty( FacebookWordpressOptions::get_active_access_token() );
+    }
+
+    /**
+     * Builds the Conversions API request for the given events.
+     *
+     * @param \FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event[] $events          The events.
+     * @param string|null                                                $test_event_code Optional test event code.
+     * @return \FacebookPixelPlugin\FacebookAds\Object\ServerSide\EventRequest
+     */
+    protected function build_request( $events, $test_event_code = null ) {
+        $pixel_id     = FacebookWordpressOptions::get_active_pixel_id();
+        $access_token = FacebookWordpressOptions::get_active_access_token();
+
+        if ( null === $this->api ) {
+            $this->api = Api::init( null, null, $access_token );
+        }
+
+        $request = ( new EventRequest( $pixel_id ) )
+            ->setEvents( $events )
+            ->setPartnerAgent( $this->partner_agent( $events ) );
+
+        if ( $test_event_code ) {
+            $request->setTestEventCode( $test_event_code );
+        }
+
+        return $request;
+    }
+
+    /**
+     * The partner agent string to stamp on the request. Base uses the plain
+     * configured agent; subclasses may decorate it using the events.
+     *
+     * @return string
+     */
+    protected function partner_agent() {
+        return FacebookWordpressOptions::get_agent_string();
+    }
+
+    /**
+     * Whether the call may proceed. Base always allows; subclasses gate here
+     * (e.g. on the circuit breaker).
+     *
+     * @return bool
+     */
+    protected function can_call() {
+        return true;
+    }
+
+    /**
+     * Outcome when the pixel id / access token are missing. Base does nothing.
+     *
+     * @return mixed
+     */
+    protected function handle_missing_config() {
+        return null;
+    }
+
+    /**
+     * Outcome when can_call() blocked the call. Base does nothing.
+     *
+     * @return mixed
+     */
+    protected function handle_blocked() {
+        return null;
+    }
+
+    /**
+     * Handles a successful Conversions API response.
+     *
+     * @param mixed $response The EventResponse.
+     * @return mixed
+     */
+    abstract protected function handle_success( $response );
+
+    /**
+     * Handles a failed Conversions API call.
+     *
+     * @param \Exception $e The caught exception.
+     * @return mixed
+     */
+    abstract protected function handle_error( \Exception $e );
+}

--- a/core/signals/class-servereventsender.php
+++ b/core/signals/class-servereventsender.php
@@ -15,100 +15,79 @@
 
 namespace FacebookPixelPlugin\Core;
 
-use FacebookPixelPlugin\FacebookAds\Api;
-use FacebookPixelPlugin\FacebookAds\Object\ServerSide\EventRequest;
-
 defined( 'ABSPATH' ) || die( 'Direct access not allowed' );
 
 /**
  * Class ServerEventSender
  *
- * Sends server-side (CAPI) events to the Conversions API and owns the API
- * client instance. It is a plain sender: consent gating and the
+ * Sends server-side (CAPI) events to the Conversions API as fire-and-forget: it
+ * engages the circuit breaker and returns nothing. Consent gating and the
  * before_conversions_api_event_sent filter live in Signals; this class assumes
  * it is only handed events that should actually be sent. Reached only through
  * Signals.
  *
  * @internal Not part of the plugin's public API; use the Signals facade.
  */
-class ServerEventSender {
+class ServerEventSender extends RestCallBase {
     /**
-     * Lazily-initialized Conversions API client, reused across sends in the
-     * same request (the access token is request-stable).
+     * Sends a list of events to the Conversions API. Fire-and-forget.
      *
-     * @var \FacebookPixelPlugin\FacebookAds\Api|null
+     * @param \FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event[] $events The events to send.
+     * @return void
      */
-    private $api = null;
-
-    /**
-     * Sends a list of events to the Conversions API.
-     *
-     * @param \FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event[] $events          The events to send.
-     * @param string|null                                                $test_event_code Optional test event code.
-     * @return array|null Result array with a 'success' key, or null if skipped.
-     */
-    public function send( $events, $test_event_code = null ) {
-        $pixel_id     = FacebookWordpressOptions::get_active_pixel_id();
-        $access_token = FacebookWordpressOptions::get_active_access_token();
-        $agent        = FacebookWordpressOptions::get_agent_string();
-
-        if ( self::is_open_bridge_event( $events ) ) {
-            $agent .= '_ob';
-        }
-
-        if ( empty( $pixel_id ) || empty( $access_token ) ) {
-            return null;
-        }
-
-        if ( ! FacebookCapiCircuitBreaker::is_send_allowed() ) {
-            return array(
-                'success' => false,
-                'error'   => array(
-                    'message' => 'Connection invalid (circuit open)',
-                    'code'    => 0,
-                ),
-            );
-        }
-
-        try {
-            if ( null === $this->api ) {
-                $this->api = Api::init( null, null, $access_token );
-            }
-
-            $request = ( new EventRequest( $pixel_id ) )
-                    ->setEvents( $events )
-                    ->setPartnerAgent( $agent );
-
-            if ( $test_event_code ) {
-                $request->setTestEventCode( $test_event_code );
-            }
-
-            $response = $request->execute();
-
-            FacebookCapiCircuitBreaker::record_success();
-
-            return array(
-                'success'         => true,
-                'events_received' => $response->getEventsReceived(),
-            );
-        } catch ( \Exception $e ) {
-            FacebookCapiCircuitBreaker::record_exception( $e );
-            // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
-            error_log( '[Facebook Pixel for WordPress] CAPI error: ' . $e->getMessage() );
-            error_log( $e->getTraceAsString() );
-            // phpcs:enable WordPress.PHP.DevelopmentFunctions.error_log_error_log
-            return array(
-                'success' => false,
-                'error'   => array(
-                    'message' => $e->getMessage(),
-                    'code'    => $e->getCode(),
-                ),
-            );
-        }
+    public function send( $events ) {
+        $this->call( $events );
     }
 
     /**
-     * Checks if the given event is an OpenBridge event.
+     * Suffixes the partner agent with '_ob' for OpenBridge events.
+     *
+     * @param \FacebookPixelPlugin\FacebookAds\Object\ServerSide\Event[] $events The events.
+     * @return string
+     */
+    protected function partner_agent( $events = array() ) {
+        $agent = parent::partner_agent();
+        if ( self::is_open_bridge_event( $events ) ) {
+            $agent .= '_ob';
+        }
+        return $agent;
+    }
+
+    /**
+     * Gates sending on the circuit breaker.
+     *
+     * @return bool
+     */
+    protected function can_call() {
+        return FacebookCapiCircuitBreaker::is_send_allowed();
+    }
+
+    /**
+     * Records the successful send with the circuit breaker.
+     *
+     * @param mixed $response The EventResponse.
+     * @return void
+     */
+    protected function handle_success( $response ) {
+        FacebookCapiCircuitBreaker::record_success();
+    }
+
+    /**
+     * Records the failure with the circuit breaker and logs it.
+     *
+     * @param \Exception $e The caught exception.
+     * @return void
+     */
+    protected function handle_error( \Exception $e ) {
+        FacebookCapiCircuitBreaker::record_exception( $e );
+        // phpcs:disable WordPress.PHP.DevelopmentFunctions.error_log_error_log
+        error_log( '[Facebook Pixel for WordPress] CAPI error: ' . $e->getMessage() );
+        error_log( $e->getTraceAsString() );
+        // phpcs:enable WordPress.PHP.DevelopmentFunctions.error_log_error_log
+    }
+
+    /**
+     * Checks if the given events are a single OpenBridge event.
      *
      * Determines whether the array contains exactly one event whose custom data
      * has a 'fb_integration_tracking' property set to 'wp-cloudbridge-plugin',


### PR DESCRIPTION
## What

Splits the single `ServerEventSender` into a small class hierarchy so the two callers of the Conversions API don't share one over-loaded method with a tri-state return.

`ServerEventSender::send()` previously did credential lookup, OpenBridge agent tagging, the circuit-breaker gate, the send, breaker recording, logging, **and** returned `null | success-array | error-array` — a shape only the admin "Test Events" panel consumed while every real-dispatch caller ignored it.

## Changes

- **`RestCallBase`** (new) — template method for the shared flow: check config → build the `EventRequest` → execute → route the outcome through hooks (`handle_success` / `handle_error` / `handle_missing_config` / `handle_blocked`). Knows nothing about the circuit breaker or the result shape.
- **`ServerEventSender`** — fire-and-forget dispatch. Engages the circuit breaker (gate + record) and returns nothing. Keeps the OpenBridge `_ob` agent tagging.
- **`AdminEventSender`** (new) — admin test sends. Returns the CAPI result (`events_received` / error) for the panel and **deliberately bypasses the circuit breaker**, so a rejected test event never trips the breaker for real traffic.
- **`Signals::send()`** — now void, and drops its unused `$test_event_code` param (only the admin path ever passed one).
- **`AdminTestCapiEvent`** — owns an `AdminEventSender` directly (no longer routes test sends through `Signals`).

## Testing

- `composer install`
- `vendor/bin/phpunit --bootstrap ./__tests__/bootstrap.php ./__tests__` → **216 tests, OK** (1 skipped).
- `phpcs` clean on the changed files.

New/updated tests: `ServerEventSenderTest` (void + no-call-when-blocked), `AdminEventSenderTest` (new — proves the breaker is bypassed and errors are returned), `AdminTestCapiEventTest` (mocks `AdminEventSender`).

## Notes

- Stacked on #168 (`feat/integration-conversions`).
- Follow-up the author plans: revisit how the admin AJAX senders are constructed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)