### PR TITLE
Fix/release changelog generation

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -93,11 +93,13 @@ jobs:
           HAS_RELEASE: ${{ steps.get_release.outputs.has_release }}
           LATEST_TAG: ${{ steps.get_release.outputs.latest_tag }}
           NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
+          CHANGELOG_BASE_BRANCH: ${{ github.ref_name }}
         with:
           script: |
             const newVersion = process.env.NEW_VERSION.trim();
             const hasRelease = process.env.HAS_RELEASE === 'true';
             const latestTag = process.env.LATEST_TAG;
+            const changelogBaseBranch = process.env.CHANGELOG_BASE_BRANCH.trim();
 
             // Determine the cutoff date for PRs included in this release.
             let since = null;
@@ -131,16 +133,17 @@ jobs:
                 `${normalized.charAt(0).toUpperCase()}${normalized.slice(1)}`;
             }
 
-            // Query closed PRs directly — only returns PRs on this repo.
+            // Query closed PRs directly for the branch used to prepare this release.
             // Meta's sync flow closes PRs with a "Merged" label but leaves
             // merged_at empty, so closed_at is used as a fallback for those PRs.
+            console.log(`Querying PRs targeting ${changelogBaseBranch}`);
             const prs = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'closed',
               sort: 'updated',
               direction: 'desc',
-              base: 'main',
+              base: changelogBaseBranch,
               per_page: 100,
             });
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -93,13 +93,11 @@ jobs:
           HAS_RELEASE: ${{ steps.get_release.outputs.has_release }}
           LATEST_TAG: ${{ steps.get_release.outputs.latest_tag }}
           NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
-          CHANGELOG_BASE_BRANCH: ${{ github.ref_name }}
         with:
           script: |
             const newVersion = process.env.NEW_VERSION.trim();
             const hasRelease = process.env.HAS_RELEASE === 'true';
             const latestTag = process.env.LATEST_TAG;
-            const changelogBaseBranch = process.env.CHANGELOG_BASE_BRANCH.trim();
 
             // Determine the cutoff date for PRs included in this release.
             let since = null;
@@ -133,17 +131,16 @@ jobs:
                 `${normalized.charAt(0).toUpperCase()}${normalized.slice(1)}`;
             }
 
-            // Query closed PRs directly for the branch used to prepare this release.
+            // Query closed PRs directly — only returns PRs on this repo.
             // Meta's sync flow closes PRs with a "Merged" label but leaves
             // merged_at empty, so closed_at is used as a fallback for those PRs.
-            console.log(`Querying PRs targeting ${changelogBaseBranch}`);
             const prs = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: 'closed',
               sort: 'updated',
               direction: 'desc',
-              base: changelogBaseBranch,
+              base: 'main',
               per_page: 100,
             });
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.version }}
@@ -98,7 +99,7 @@ jobs:
             const hasRelease = process.env.HAS_RELEASE === 'true';
             const latestTag = process.env.LATEST_TAG;
 
-            // Determine the cutoff date for merged PRs
+            // Determine the cutoff date for PRs included in this release.
             let since = null;
             if (hasRelease) {
               const release = await github.rest.repos.getReleaseByTag({
@@ -107,12 +108,32 @@ jobs:
                 tag: latestTag,
               });
               since = new Date(release.data.published_at);
-              console.log(`Including PRs merged after ${since.toISOString()}`);
+              console.log(`Including PRs closed/merged after ${since.toISOString()}`);
             } else {
               console.log("No previous release. Including all merged PRs.");
             }
 
-            // Query merged PRs directly — only returns PRs on this repo
+            function categoryLabel(category) {
+              const normalized = category.toLowerCase();
+              const labels = {
+                add: 'Added',
+                added: 'Added',
+                change: 'Changed',
+                changed: 'Changed',
+                fix: 'Fixed',
+                fixed: 'Fixed',
+                remove: 'Removed',
+                removed: 'Removed',
+                security: 'Security',
+              };
+
+              return labels[normalized] ||
+                `${normalized.charAt(0).toUpperCase()}${normalized.slice(1)}`;
+            }
+
+            // Query closed PRs directly — only returns PRs on this repo.
+            // Meta's sync flow closes PRs with a "Merged" label but leaves
+            // merged_at empty, so closed_at is used as a fallback for those PRs.
             const prs = await github.paginate(github.rest.pulls.list, {
               owner: context.repo.owner,
               repo: context.repo.repo,
@@ -123,20 +144,40 @@ jobs:
               per_page: 100,
             });
 
-            const changelog = [];
+            const entries = [];
+            const labelPrefix = "changelog:";
             for (const pr of prs) {
-              if (!pr.merged_at) continue;
-              if (since && new Date(pr.merged_at) < since) continue;
+              const labelNames = pr.labels.map(l => l.name);
+              const lowerLabels = labelNames.map(l => l.toLowerCase());
+              const isMerged = Boolean(pr.merged_at) || lowerLabels.includes('merged');
+              if (!isMerged) continue;
 
-              const labelPrefix = "changelog:";
-              const labels = pr.labels
-                .map(l => l.name)
+              const changeDateValue = pr.merged_at || pr.closed_at;
+              if (!changeDateValue) continue;
+
+              const changeDate = new Date(changeDateValue);
+              if (since && changeDate <= since) continue;
+
+              const changelogLabels = lowerLabels
                 .filter(l => l.startsWith(labelPrefix))
-                .map(l => l.replace(labelPrefix, "").trim());
-              if (labels.length === 0 || labels[0].toLowerCase() === 'none') continue;
+                .map(l => l.replace(labelPrefix, '').trim());
+              if (changelogLabels.includes('none')) continue;
+              if (/^release\s+\d+\.\d+\.\d+/i.test(pr.title)) continue;
 
-              const category = labels[0];
-              changelog.push(`* ${category.charAt(0).toUpperCase()}${category.slice(1)} - ${pr.title} by @${pr.user.login} in #${pr.number}`);
+              if (changelogLabels.length === 0) continue;
+
+              const category = changelogLabels[0];
+              const entry = `${categoryLabel(category)} - ${pr.title}`;
+              entries.push({
+                date: changeDate,
+                line: `* ${entry} by @${pr.user.login} in #${pr.number}`,
+              });
+            }
+
+            entries.sort((a, b) => a.date - b.date);
+            const changelog = entries.map(entry => entry.line);
+            if (changelog.length === 0) {
+              throw new Error('Generated changelog is empty. Check PR merge state, labels, and the release cutoff.');
             }
 
             const date = new Date().toISOString().slice(0, 10);

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -86,28 +86,34 @@ jobs:
               }
             }
 
+      - name: Get release cutoff date
+        id: get_release_cutoff
+        if: steps.get_release.outputs.has_release == 'true'
+        env:
+          LATEST_TAG: ${{ steps.get_release.outputs.latest_tag }}
+        run: |
+          git fetch origin tag "$LATEST_TAG"
+          TAG_COMMIT_TIMESTAMP=$(git log -1 --format=%ct "$LATEST_TAG")
+          echo "Latest release tag commit timestamp: $TAG_COMMIT_TIMESTAMP"
+          echo "cutoff_timestamp=$TAG_COMMIT_TIMESTAMP" >> "$GITHUB_OUTPUT"
+
       - name: Build changelog from PRs
         id: changelog
         uses: actions/github-script@v8
         env:
           HAS_RELEASE: ${{ steps.get_release.outputs.has_release }}
-          LATEST_TAG: ${{ steps.get_release.outputs.latest_tag }}
+          RELEASE_CUTOFF_TIMESTAMP: ${{ steps.get_release_cutoff.outputs.cutoff_timestamp }}
           NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
         with:
           script: |
             const newVersion = process.env.NEW_VERSION.trim();
             const hasRelease = process.env.HAS_RELEASE === 'true';
-            const latestTag = process.env.LATEST_TAG;
+            const releaseCutoffTimestamp = process.env.RELEASE_CUTOFF_TIMESTAMP;
 
             // Determine the cutoff date for PRs included in this release.
             let since = null;
             if (hasRelease) {
-              const release = await github.rest.repos.getReleaseByTag({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                tag: latestTag,
-              });
-              since = new Date(release.data.published_at);
+              since = new Date(Number(releaseCutoffTimestamp) * 1000);
               console.log(`Including PRs closed/merged after ${since.toISOString()}`);
             } else {
               console.log("No previous release. Including all merged PRs.");

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -161,8 +161,9 @@ jobs:
               const changelogLabels = lowerLabels
                 .filter(l => l.startsWith(labelPrefix))
                 .map(l => l.replace(labelPrefix, '').trim());
+              // Exclude PRs that intentionally should not appear in the changelog,
+              // such as release PRs.
               if (changelogLabels.includes('none')) continue;
-              if (/^release\s+\d+\.\d+\.\d+/i.test(pr.title)) continue;
 
               if (changelogLabels.length === 0) continue;
 


### PR DESCRIPTION
## Description

Fixes changelog generation in the `prepare-release` workflow for Facebook Pixel for WordPress.

The workflow previously built changelog entries from closed PRs, but it only treated PRs as merged when `merged_at` was set. After changes to the release/sync process, some PRs can be closed with a `Merged` label while `merged_at` remains empty in the GitHub API response. As a result, those PRs were skipped and release changelog entries were not populated.

This updates the changelog generation to include PRs that either have `merged_at` set or have the `Merged` label, using `closed_at` as the fallback PR date when needed. It also uses the latest release tag commit timestamp as the cutoff so PRs merged after the release cut-off, but before the GitHub release is published, are not missed.

## Changes included

* Add the `pull-requests: read` permission to the workflow.
* Treat PRs as merged if they either:
  * have `merged_at` set, or
  * have the `Merged` label.
* Use `closed_at` as a fallback PR date when `merged_at` is unavailable.
* Use the latest release tag commit timestamp as the cutoff for included PRs.
* Preserve the existing `changelog:` label behavior:
  * Skip PRs labeled `changelog:none`.
  * Skip PRs that do not have a `changelog:` label.
* Remove title-based release PR exclusion.
* Use `changelog:none` to exclude release PRs from generated changelog entries.
* Fail the workflow if no changelog entries are generated instead of silently creating an empty changelog section.

## Type of change

Bug fix (non-breaking change that fixes an issue)

## Checklist

* [ ] I followed general Pull Request best practices. Meta employees should also follow the internal PR wiki.
* [x] I have completed dogfooding and QA testing, or otherwise verified that the changes do not break existing functionality.

## Changelog entry

Fix changelog generation in the Facebook Pixel for WordPress release workflow when PRs are closed by the Meta sync flow.

## Test Plan

* Reviewed the changelog generation logic in `.github/workflows/prepare-release.yml`.
* Verified that PRs with the `Merged` label and an empty `merged_at` value are no longer skipped.
* Verified that `closed_at` is used as the fallback PR date when `merged_at` is unavailable.
* Verified that the latest release tag commit timestamp is used as the cutoff instead of the GitHub release publish date.
* Verified that PRs labeled `changelog:none` or without a `changelog:` label continue to be excluded.
* Verified that release PRs are excluded through `changelog:none` instead of title matching.
* Verified that the workflow now fails if no changelog entries are generated.