### PR TITLE
Normalize array input wpforms

### DIFF
--- a/FacebookAds/Object/ServerSide/Normalizer.php
+++ b/FacebookAds/Object/ServerSide/Normalizer.php
@@ -35,28 +35,17 @@ use InvalidArgumentException;
 class Normalizer {
   /**
    * @param string $field to be normalized.
-   * @param string $data value to be normalized
-   * @return string
+   * @param mixed $data value to be normalized
+   * @return string|null
    */
   public static function normalize($field, $data) {
     if (is_array($data)) {
-      foreach ($data as $value) {
-        if (is_scalar($value) && $value !== '') {
-          $data = (string) $value;
-          break;
-        }
-      }
-
-      if (!is_scalar($data)) {
-        return null;
-      }
+      $data = self::getFirstNormalizableArrayValue($data);
+    } else {
+      $data = self::coerceToString($data);
     }
 
-    if (is_numeric($data)) {
-      $data = (string) $data;
-    }
-
-    if ($data == null || strlen($data) == 0) {
+    if ($data === null || strlen($data) === 0) {
       return null;
     }
 
@@ -66,6 +55,10 @@ class Normalizer {
     }
 
     $data = trim(strtolower($data));
+    if (strlen($data) === 0) {
+      return null;
+    }
+
     $normalized_data = $data;
 
     switch ($field) {
@@ -133,6 +126,41 @@ class Normalizer {
     }
 
     return $normalized_data;
+  }
+
+  /**
+   * @param mixed $data value to be converted to a string.
+   * @return string|null
+   */
+  private static function coerceToString($data) {
+    if (is_string($data)) {
+      return $data;
+    }
+
+    if (is_numeric($data)) {
+      return (string) $data;
+    }
+
+    if (is_object($data) && method_exists($data, '__toString')) {
+      return (string) $data;
+    }
+
+    return null;
+  }
+
+  /**
+   * @param array $data values to inspect.
+   * @return string|null
+   */
+  private static function getFirstNormalizableArrayValue($data) {
+    foreach ($data as $value) {
+      $value = self::coerceToString($value);
+      if ($value !== null && strlen($value) > 0) {
+        return $value;
+      }
+    }
+
+    return null;
   }
 
   /**

--- a/FacebookAds/Object/ServerSide/Normalizer.php
+++ b/FacebookAds/Object/ServerSide/Normalizer.php
@@ -40,11 +40,61 @@ class Normalizer {
    */
   public static function normalize($field, $data) {
     if (is_array($data)) {
-      $data = self::getFirstNormalizableArrayValue($data);
-    } else {
-      $data = self::coerceToString($data);
+      return self::normalizeArrayValue($field, $data);
     }
 
+    return self::normalizeStringValue($field, self::coerceToString($data));
+  }
+
+  /**
+   * @param mixed $data value to be converted to a string.
+   * @return string|null
+   */
+  private static function coerceToString($data) {
+    if (is_string($data)) {
+      return $data;
+    }
+
+    if (is_numeric($data)) {
+      return (string) $data;
+    }
+
+    if (is_object($data) && method_exists($data, '__toString')) {
+      return (string) $data;
+    }
+
+    return null;
+  }
+
+  /**
+   * @param array $data values to inspect.
+   * @return string|null
+   */
+  private static function normalizeArrayValue($field, $data) {
+    foreach ($data as $value) {
+      try {
+        $normalized_value = self::normalizeStringValue(
+          $field,
+          self::coerceToString($value)
+        );
+      } catch (InvalidArgumentException $e) {
+        continue;
+      }
+
+      if ($normalized_value !== null) {
+        return $normalized_value;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * @param string $field to be normalized.
+   * @param string|null $data value to be normalized.
+   * @return string|null
+   */
+  private static function normalizeStringValue($field, $data) {
     if ($data === null || strlen($data) === 0) {
       return null;
     }
@@ -126,41 +176,6 @@ class Normalizer {
     }
 
     return $normalized_data;
-  }
-
-  /**
-   * @param mixed $data value to be converted to a string.
-   * @return string|null
-   */
-  private static function coerceToString($data) {
-    if (is_string($data)) {
-      return $data;
-    }
-
-    if (is_numeric($data)) {
-      return (string) $data;
-    }
-
-    if (is_object($data) && method_exists($data, '__toString')) {
-      return (string) $data;
-    }
-
-    return null;
-  }
-
-  /**
-   * @param array $data values to inspect.
-   * @return string|null
-   */
-  private static function getFirstNormalizableArrayValue($data) {
-    foreach ($data as $value) {
-      $value = self::coerceToString($value);
-      if ($value !== null && strlen($value) > 0) {
-        return $value;
-      }
-    }
-
-    return null;
   }
 
   /**

--- a/FacebookAds/Object/ServerSide/Normalizer.php
+++ b/FacebookAds/Object/ServerSide/Normalizer.php
@@ -39,6 +39,23 @@ class Normalizer {
    * @return string
    */
   public static function normalize($field, $data) {
+    if (is_array($data)) {
+      foreach ($data as $value) {
+        if (is_scalar($value) && $value !== '') {
+          $data = (string) $value;
+          break;
+        }
+      }
+
+      if (!is_scalar($data)) {
+        return null;
+      }
+    }
+
+    if (is_numeric($data)) {
+      $data = (string) $data;
+    }
+
     if ($data == null || strlen($data) == 0) {
       return null;
     }

--- a/FacebookAds/Object/ServerSide/UserData.php
+++ b/FacebookAds/Object/ServerSide/UserData.php
@@ -986,10 +986,19 @@ class UserData implements ArrayAccess {
     }
     $deduped = array();
     foreach($valueList as $val){
-      $hashedVal = Util::hash(Normalizer::normalize($fieldName, $val));
+      $normalizedVal = Normalizer::normalize($fieldName, $val);
+      if ($normalizedVal === null) {
+        continue;
+      }
+
+      $hashedVal = Util::hash($normalizedVal);
+      if ($hashedVal === null) {
+        continue;
+      }
+
       $deduped[$hashedVal] = true;
     }
-    return array_keys($deduped);
+    return empty($deduped) ? null : array_keys($deduped);
   }
 
   /**

--- a/__tests_sdk__/FacebookAdsTest/Object/ServerSide/ServerSideNormalizeTest.php
+++ b/__tests_sdk__/FacebookAdsTest/Object/ServerSide/ServerSideNormalizeTest.php
@@ -554,13 +554,26 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
     $this->assertNull(Normalizer::normalize('em', '   '));
   }
 
-  public function testNormalizeUsesFirstNormalizableArrayValue() {
+  public function testNormalizeUsesFirstValidArrayValue() {
     $this->assertSame(
       'pika.42@example.com',
       Normalizer::normalize(
         'em',
-        array(new \stdClass(), '', 'Pika.42@Example.com', 'ignored@example.com')
+        array(
+          new \stdClass(),
+          '',
+          '    ',
+          '$djubre',
+          'Pika.42@Example.com',
+          'ignored@example.com'
+        )
       )
+    );
+  }
+
+  public function testNormalizeReturnsNullWhenArrayHasNoValidValue() {
+    $this->assertNull(
+      Normalizer::normalize('em', array(new \stdClass(), '', '$djubre'))
     );
   }
 

--- a/__tests_sdk__/FacebookAdsTest/Object/ServerSide/ServerSideNormalizeTest.php
+++ b/__tests_sdk__/FacebookAdsTest/Object/ServerSide/ServerSideNormalizeTest.php
@@ -36,7 +36,7 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
   public function emailNormalizeData() {
     return array(
       array(
-        "foo(.bar)@baz.com/",
+        'foo(.bar)@baz.com/',
         'foo.bar@baz.com',
       ),
       array(
@@ -54,9 +54,10 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
    * @dataProvider emailNormalizeData
    */
   public function testEmailNormalize($input, $expected) {
-    $this->assertEquals(
+    $this->assertSame(
       $expected,
-      Normalizer::normalize('em', $input));
+      Normalizer::normalize('em', $input)
+    );
   }
 
   /**
@@ -79,7 +80,7 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
       array(
         '44-12390821300A',
         '4412390821300',
-      )
+      ),
     );
   }
 
@@ -87,9 +88,10 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
    * @dataProvider phoneNormalizeData
    */
   public function testPhoneNormalize($input, $expected) {
-    $this->assertEquals(
+    $this->assertSame(
       $expected,
-      Normalizer::normalize('ph', $input));
+      Normalizer::normalize('ph', $input)
+    );
   }
 
   /**
@@ -120,9 +122,10 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
    * @dataProvider postalCodeNormalizeData
    */
   public function testPostalCodeNormalize($input, $expected) {
-    $this->assertEquals(
+    $this->assertSame(
       $expected,
-      Normalizer::normalize('zp', $input));
+      Normalizer::normalize('zp', $input)
+    );
   }
 
   /**
@@ -149,9 +152,10 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
    * @dataProvider cityNormalizeData
    */
   public function testCityNormalize($input, $expected) {
-    $this->assertEquals(
+    $this->assertSame(
       $expected,
-      Normalizer::normalize('ct', $input));
+      Normalizer::normalize('ct', $input)
+    );
   }
 
   /**
@@ -174,9 +178,10 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
    * @dataProvider countryNormalizeData
    */
   public function testCountryNormalize($input, $expected) {
-    $this->assertEquals(
+    $this->assertSame(
       $expected,
-      Normalizer::normalize('country', $input));
+      Normalizer::normalize('country', $input)
+    );
   }
 
   /**
@@ -199,9 +204,10 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
    * @dataProvider currencyNormalizeData
    */
   public function testCurrencyNormalize($input, $expected) {
-    $this->assertEquals(
+    $this->assertSame(
       $expected,
-      Normalizer::normalize('currency', $input));
+      Normalizer::normalize('currency', $input)
+    );
   }
 
   /**
@@ -255,7 +261,7 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
       ),
       array(
         '',
-        '',
+        null,
       ),
       array(
         null,
@@ -268,7 +274,7 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
    * @dataProvider f5firstData
    */
   public function testF5first($input, $expected) {
-    $this->assertEquals(
+    $this->assertSame(
       $expected,
       Normalizer::normalize('f5first', $input)
     );
@@ -286,7 +292,7 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
       ),
       array(
         '',
-        '',
+        null,
       ),
       array(
         null,
@@ -299,7 +305,7 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
    * @dataProvider f5lastData
    */
   public function testF5last($input, $expected) {
-    $this->assertEquals(
+    $this->assertSame(
       $expected,
       Normalizer::normalize('f5last', $input)
     );
@@ -317,7 +323,7 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
       ),
       array(
         '',
-        '',
+        null,
       ),
       array(
         null,
@@ -330,7 +336,7 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
    * @dataProvider fiData
    */
   public function testFi($input, $expected) {
-    $this->assertEquals(
+    $this->assertSame(
       $expected,
       Normalizer::normalize('fi', $input)
     );
@@ -352,11 +358,15 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
       ),
       array(
         '',
-        '',
+        null,
       ),
       array(
         null,
         null,
+      ),
+      array(
+        7,
+        '07',
       ),
     );
   }
@@ -365,7 +375,7 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
    * @dataProvider dobdData
    */
   public function testDobd($input, $expected) {
-    $this->assertEquals(
+    $this->assertSame(
       $expected,
       Normalizer::normalize('dobd', $input)
     );
@@ -380,7 +390,6 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
       'ab',
     );
     $exceptions_counter = 0;
-    $has_throw_exception = false;
     foreach ($failure_cases as $case) {
       try {
         Normalizer::normalize('dobd', $case);
@@ -388,7 +397,7 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
         $exceptions_counter += 1;
       }
     }
-    $this->assertEquals(count($failure_cases), $exceptions_counter);
+    $this->assertSame(count($failure_cases), $exceptions_counter);
   }
 
   public function dobmData() {
@@ -407,11 +416,15 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
       ),
       array(
         '',
-        '',
+        null,
       ),
       array(
         null,
         null,
+      ),
+      array(
+        9,
+        '09',
       ),
     );
   }
@@ -420,7 +433,7 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
    * @dataProvider dobmData
    */
   public function testDobm($input, $expected) {
-    $this->assertEquals(
+    $this->assertSame(
       $expected,
       Normalizer::normalize('dobm', $input)
     );
@@ -436,7 +449,6 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
       'oc',
     );
     $exceptions_counter = 0;
-    $has_throw_exception = false;
     foreach ($failure_cases as $case) {
       try {
         Normalizer::normalize('dobm', $case);
@@ -444,7 +456,7 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
         $exceptions_counter += 1;
       }
     }
-    $this->assertEquals(count($failure_cases), $exceptions_counter);
+    $this->assertSame(count($failure_cases), $exceptions_counter);
   }
 
   public function dobyData() {
@@ -463,11 +475,15 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
       ),
       array(
         '',
-        '',
+        null,
       ),
       array(
         null,
         null,
+      ),
+      array(
+        1980,
+        '1980',
       ),
     );
   }
@@ -476,7 +492,7 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
    * @dataProvider dobyData
    */
   public function testDoby($input, $expected) {
-    $this->assertEquals(
+    $this->assertSame(
       $expected,
       Normalizer::normalize('doby', $input)
     );
@@ -491,7 +507,6 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
       'nineteen-eighty',
     );
     $exceptions_counter = 0;
-    $has_throw_exception = false;
     foreach ($failure_cases as $case) {
       try {
         Normalizer::normalize('doby', $case);
@@ -499,7 +514,7 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
         $exceptions_counter += 1;
       }
     }
-    $this->assertEquals(count($failure_cases), $exceptions_counter);
+    $this->assertSame(count($failure_cases), $exceptions_counter);
   }
 
   /**
@@ -526,8 +541,36 @@ class ServerSideNormalizeTest extends AbstractUnitTestCase {
    * @dataProvider deliveryCategoryNormalizeData
    */
   public function testDeliveryCategoryNormalize($input, $expected) {
-    $this->assertEquals(
+    $this->assertSame(
       $expected,
-      Normalizer::normalize('delivery_category', $input));
+      Normalizer::normalize('delivery_category', $input)
+    );
+  }
+
+  public function testNormalizeReturnsNullForUnsupportedInputTypes() {
+    $this->assertNull(Normalizer::normalize('em', new \stdClass()));
+    $this->assertNull(Normalizer::normalize('em', false));
+    $this->assertNull(Normalizer::normalize('em', array(new \stdClass())));
+    $this->assertNull(Normalizer::normalize('em', '   '));
+  }
+
+  public function testNormalizeUsesFirstNormalizableArrayValue() {
+    $this->assertSame(
+      'pika.42@example.com',
+      Normalizer::normalize(
+        'em',
+        array(new \stdClass(), '', 'Pika.42@Example.com', 'ignored@example.com')
+      )
+    );
+  }
+
+  public function testNormalizeAcceptsStringableObjects() {
+    $stringable = new class() {
+      public function __toString() {
+        return '  Seattle-98121  ';
+      }
+    };
+
+    $this->assertSame('seattle', Normalizer::normalize('ct', $stringable));
   }
 }

--- a/__tests_sdk__/FacebookAdsTest/Object/ServerSide/UserDataTest.php
+++ b/__tests_sdk__/FacebookAdsTest/Object/ServerSide/UserDataTest.php
@@ -379,6 +379,23 @@ class UserDataTest extends AbstractUnitTestCase {
     $this->assertEquals(array(), $normalized);
   }
 
+  public function testNormalizeSkipsNullArrayValues() {
+    $userData = (new UserData())->setEmails(array(array('   ')));
+
+    $this->assertEquals(array(), $userData->normalize());
+  }
+
+  public function testNormalizeKeepsValidValueAfterInvalidArrayValue() {
+    $userData = (new UserData())->setEmails(
+      array(array('$djubre', 'john@example.com'))
+    );
+
+    $this->assertEquals(
+      array('em' => array(Util::hash('john@example.com'))),
+      $userData->normalize()
+    );
+  }
+
   private function hashList($arr){
     return array_map(
       function($val){


### PR DESCRIPTION
## Description

Fixes ServerSide `Normalizer` handling for array and scalar inputs so WPForms payloads are normalized safely before string operations. This prevents warnings/errors when form fields provide non-string values.

### Type of change

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [X] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [X] I followed general Pull Request best practices. Meta employees to follow this [wiki](https://fburl.com/wiki/b2b0midg).
- [X] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [X] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [ ] I have updated or requested update to plugin documentations (if necessary).

## Changelog entry

Fix WPForms server-side normalization for array and scalar input values.

## Test Plan

1. Install WPForms and Meta Pixel for WordPress
2. Create a form with an Email field and enable “Email Confirmation”
3. Submit the form
