### PR TITLE
Add copyright header to local-config-sample.php

### DIFF
--- a/local-config-sample.php
+++ b/local-config-sample.php
@@ -1,4 +1,16 @@
 <?php
+/*
+* Copyright (C) 2017-present, Meta, Inc.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; version 2 of the License.
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*/
+
 /**
  * Local development overrides (copy to local-config.php).
  *

--- a/local-config-sample.php
+++ b/local-config-sample.php
@@ -1,17 +1,15 @@
 <?php
-/*
-* Copyright (C) 2017-present, Meta, Inc.
-*
-* This program is free software; you can redistribute it and/or modify
-* it under the terms of the GNU General Public License as published by
-* the Free Software Foundation; version 2 of the License.
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-* GNU General Public License for more details.
-*/
-
 /**
+ * Copyright (C) 2017-present, Meta, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
  * Local development overrides (copy to local-config.php).
  *
  * This file is loaded by facebook-for-wordpress.php before anything else.


### PR DESCRIPTION
## Summary
- Add the GPL copyright header block to `local-config-sample.php`, matching the format used in `class-facebookcapievent.php` and other core files.
- Placed at the top of the file so the `Copyright` line falls within the first 16 lines, satisfying the license header check.

## Test plan
- Header follows the same wording (`Copyright (C) 2017-present, Meta, Inc.`) as existing core files.
- PHPCS passes.