### PR TITLE
Harden admin notice dismiss control and resolve Plugin Check findings

### DIFF
--- a/FacebookAds/ApiRequest.php
+++ b/FacebookAds/ApiRequest.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
  /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.

--- a/FacebookAds/CrashReporter.php
+++ b/FacebookAds/CrashReporter.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
  /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.

--- a/FacebookAds/Cursor.php
+++ b/FacebookAds/Cursor.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
  /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.

--- a/FacebookAds/Enum/AbstractEnum.php
+++ b/FacebookAds/Enum/AbstractEnum.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
 /**
  * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
  *

--- a/FacebookAds/Http/Adapter/Curl/AbstractCurl.php
+++ b/FacebookAds/Http/Adapter/Curl/AbstractCurl.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
 /**
  * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
  *

--- a/FacebookAds/Http/Adapter/Curl/Curl.php
+++ b/FacebookAds/Http/Adapter/Curl/Curl.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
 /**
  * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
  *

--- a/FacebookAds/Http/Adapter/Curl/Curl55.php
+++ b/FacebookAds/Http/Adapter/Curl/Curl55.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
 /**
  * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
  *

--- a/FacebookAds/Http/Adapter/CurlAdapter.php
+++ b/FacebookAds/Http/Adapter/CurlAdapter.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
 /**
  * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
  *

--- a/FacebookAds/Http/Client.php
+++ b/FacebookAds/Http/Client.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
 /**
  * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
  *

--- a/FacebookAds/Logger/CurlLogger.php
+++ b/FacebookAds/Logger/CurlLogger.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
 /**
  * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
  *

--- a/FacebookAds/Logger/CurlLogger/JsonNode.php
+++ b/FacebookAds/Logger/CurlLogger/JsonNode.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
 /**
  * Copyright (c) 2014-present, Facebook, Inc. All rights reserved.
  *

--- a/FacebookAds/Object/AbstractCrudObject.php
+++ b/FacebookAds/Object/AbstractCrudObject.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
  /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.

--- a/FacebookAds/Object/AbstractObject.php
+++ b/FacebookAds/Object/AbstractObject.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
  /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.

--- a/FacebookAds/Object/AdImage.php
+++ b/FacebookAds/Object/AdImage.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
  /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.

--- a/FacebookAds/Object/CustomAudience.php
+++ b/FacebookAds/Object/CustomAudience.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
  /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.

--- a/FacebookAds/Object/CustomAudienceMultiKey.php
+++ b/FacebookAds/Object/CustomAudienceMultiKey.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
  /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.

--- a/FacebookAds/Object/ServerSide/CAPIGatewayEndpoint.php
+++ b/FacebookAds/Object/ServerSide/CAPIGatewayEndpoint.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
 /**
  * Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
  *

--- a/FacebookAds/Object/ServerSide/CustomData.php
+++ b/FacebookAds/Object/ServerSide/CustomData.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
 /**
  * Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
  *

--- a/FacebookAds/Object/ServerSide/Normalizer.php
+++ b/FacebookAds/Object/ServerSide/Normalizer.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
 /**
  * Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
  *

--- a/FacebookAds/Object/ServerSide/UserData.php
+++ b/FacebookAds/Object/ServerSide/UserData.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
 /**
  * Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
  *

--- a/FacebookAds/Object/ServerSide/Util.php
+++ b/FacebookAds/Object/ServerSide/Util.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
 /**
  * Copyright (c) 2015-present, Facebook, Inc. All rights reserved.
  *

--- a/FacebookAds/Object/Traits/FieldValidation.php
+++ b/FacebookAds/Object/Traits/FieldValidation.php
@@ -1,4 +1,5 @@
 <?php
+// phpcs:ignoreFile — third-party Meta Business SDK (vendored); excluded from linting.
  /*
  * Copyright (c) Meta Platforms, Inc. and affiliates.
  * All rights reserved.

--- a/__tests__/core/FacebookWordPressSettingsPageTest.php
+++ b/__tests__/core/FacebookWordPressSettingsPageTest.php
@@ -431,6 +431,128 @@ final class FacebookWordPressSettingsPageTest extends FacebookWordpressTestBase 
   }
 
   /**
+   * Tests that the admin notice dismiss control renders as a standard
+   * anchor element rather than an inline event handler.
+   *
+   * @return void
+   */
+  public function testSetNoticeRendersDismissAsAnchorWithoutInlineHandler() {
+    $this->mockNoticeRenderingFunctions();
+    $settings_page = new FacebookWordpressSettingsPage(
+      'facebook_for_wordpress'
+    );
+
+    ob_start();
+    $settings_page->set_notice(
+      'Configure it <a href="%s">here</a>.',
+      FacebookPluginConfig::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE,
+      'warning'
+    );
+    $html = ob_get_clean();
+
+    // Dismiss control is a plain anchor.
+    $this->assertStringContainsString( 'class="notice-dismiss"', $html );
+    $this->assertStringContainsString( '<a', $html );
+    $this->assertStringContainsString( 'href=', $html );
+
+    // No inline event handler / JS-string context to break out of.
+    $this->assertStringNotContainsStringIgnoringCase( 'onclick', $html );
+    $this->assertStringNotContainsString( 'location.href', $html );
+    $this->assertStringNotContainsString( '<button', $html );
+
+    // Notice type and body are still rendered.
+    $this->assertStringContainsString( 'notice-warning', $html );
+    $this->assertStringContainsString( 'Configure it', $html );
+  }
+
+  /**
+   * Tests that when the request URI carries a hostile value, the dismiss
+   * control has no inline handler, its href is built from the trusted
+   * admin_url() base, and the request URI is not reflected into the markup.
+   *
+   * @return void
+   */
+  public function testSetNoticeDoesNotReflectHostileRequestUri() {
+    // A hostile request URI that must never appear in the rendered notice.
+    $payload                = '/wp-admin/options.php/"><script>hostile_marker</script>';
+    $_SERVER['REQUEST_URI'] = $payload;
+
+    $this->mockNoticeRenderingFunctions();
+    $settings_page = new FacebookWordpressSettingsPage(
+      'facebook_for_wordpress'
+    );
+
+    ob_start();
+    $settings_page->set_notice(
+      'Configure it <a href="%s">here</a>.',
+      FacebookPluginConfig::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE,
+      'warning'
+    );
+    $html = ob_get_clean();
+
+    // No inline event handler in the output.
+    $this->assertStringNotContainsStringIgnoringCase( 'onclick', $html );
+
+    // The dismiss href is built from the trusted admin_url() base.
+    $this->assertStringContainsString(
+      'href="https://trusted.example/wp-admin/?' .
+        FacebookPluginConfig::ADMIN_DISMISS_WPCOM_UPDATE_NOTICE . '=1"',
+      $html
+    );
+
+    // The hostile request URI is not reflected anywhere in the output.
+    $this->assertStringNotContainsString( 'hostile_marker', $html );
+    $this->assertStringNotContainsString( $payload, $html );
+  }
+
+  /**
+   * Mocks the WordPress functions used by set_notice() output rendering.
+   *
+   * Escaping/kses functions are identity mappings so assertions can inspect
+   * the raw values passed through; admin_url() returns a fixed trusted base,
+   * and add_query_arg() appends the key/value to the supplied base URL.
+   *
+   * @return void
+   */
+  private function mockNoticeRenderingFunctions() {
+    $this->mockTranslationFunctions();
+    \WP_Mock::userFunction(
+      'admin_url',
+      array(
+        'return' => function ( $path = '' ) {
+          return 'https://trusted.example/wp-admin/' . $path;
+        },
+      )
+    );
+    \WP_Mock::userFunction(
+      'esc_url',
+      array( 'return_arg' => 0 )
+    );
+    \WP_Mock::userFunction(
+      'esc_html',
+      array( 'return_arg' => 0 )
+    );
+    \WP_Mock::userFunction(
+      'wp_kses_post',
+      array( 'return_arg' => 0 )
+    );
+    // Faithfully mirror WordPress: without an explicit base URL,
+    // add_query_arg() falls back to $_SERVER['REQUEST_URI']. This is the
+    // fallback the fix must avoid for the dismiss URL.
+    \WP_Mock::userFunction(
+      'add_query_arg',
+      array(
+        'return' => function ( $key, $value, $url = null ) {
+          if ( null === $url ) {
+            $url = $_SERVER['REQUEST_URI'];
+          }
+          return $url . '?' . $key . '=' . $value;
+        },
+      )
+    );
+  }
+
+  /**
    * Mocks translation functions used by notice generation.
    *
    * @return void

--- a/build.xml
+++ b/build.xml
@@ -17,6 +17,8 @@
         <exclude name="build.properties" />
         <exclude name="build.xml" />
         <exclude name="README.md" />
+        <exclude name="CODE_OF_CONDUCT.md" />
+        <exclude name="CONTRIBUTING.md" />
         <exclude name="vendor/**" />
         <exclude name="task/**" />
         <exclude name="__tests__/**" />

--- a/core/class-facebookwordpresssettingspage.php
+++ b/core/class-facebookwordpresssettingspage.php
@@ -1081,17 +1081,17 @@ class FacebookWordpressSettingsPage {
             '
 <div class="notice notice-%s is-dismissible">
   <p>%s</p>
-  <button
-    type="button"
+  <a
+    href="%s"
     class="notice-dismiss"
-    onClick="location.href=\'%s\'">
+    style="text-decoration: none;">
     <span class="screen-reader-text">%s</span>
-  </button>
+  </a>
 </div>
       ',
             esc_html( $notice_type ),
             wp_kses_post( $link ),
-            esc_url( add_query_arg( $dismiss_config, '' ) ),
+            esc_url( add_query_arg( $dismiss_config, '1', admin_url() ) ),
             esc_html__(
                 'Dismiss this notice.',
                 'official-facebook-pixel'

--- a/facebook-for-wordpress.php
+++ b/facebook-for-wordpress.php
@@ -7,6 +7,8 @@
  * Author: Facebook
  * Author URI: https://www.facebook.com/
  * Version: {*VERSION_NUMBER*}
+ * License: GPLv2
+ * License URI: http://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: official-facebook-pixel
  *
  * @package FacebookPixelPlugin


### PR DESCRIPTION
## Summary

Two small, release-ready changes bundled for the same release.

### 1. Harden admin notice dismiss control rendering
Renders the admin notice dismiss control as a standard anchor element whose URL is escaped with `esc_url()` in an `href` attribute and built from a trusted base (`admin_url()`), replacing the previous inline event-handler markup. This aligns `set_notice()` with the existing `connection_invalid_notice()` implementation and improves the robustness of the admin notice output. Dismiss behavior is unchanged (`dismiss_notices()` keys off `isset($_GET[...])`).

Adds regression tests for `set_notice()` covering: the anchor markup (no inline event handler), the dismiss URL being built from the trusted `admin_url()` base, and a hostile request URI not being reflected into the notice output.

### 2. Resolve WordPress Plugin Check findings
- Add the missing `License` / `License URI` fields to the plugin header, matching `readme.txt` (GPLv2).
- Add `// phpcs:ignoreFile` to the vendored Meta Business SDK files under `FacebookAds/` that Plugin Check flags. This directory is third-party code already excluded from the project's own linting (`phpcs.xml` excludes `FacebookAds/*`, and the main plugin file already uses `phpcs:ignoreFile`).
- Exclude `CODE_OF_CONDUCT.md` and `CONTRIBUTING.md` from the distributed build (`build.xml`), matching the existing `README.md` exclusion.

Version, changelog, and readme Stable tag are intentionally left to release CI.

## Testing
- `php -l` clean on all changed files
- `phpcs --standard=phpcs.xml` clean (matches the `main.yml` CI check)
- Full plugin test suite: 251 tests pass (2 pre-existing skips), including 2 new `set_notice()` regression tests
