### PR TITLE
Release workflow fixes: changelog gen, auto-build, set-stable-tag lookup, build/ packaging

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - 'release/**'
+  pull_request:
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
   workflow_call:
     inputs:
@@ -14,6 +16,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write # to post the build download link on PRs
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -53,3 +56,35 @@ jobs:
         with:
           name: official-facebook-pixel
           path: artifact-contents
+          # Dependencies ship dotfiles (e.g. .babelrc / .eslintrc.json).
+          # upload-artifact excludes hidden files by default, which makes the
+          # artifact diverge from the deployed plugin and trips the Set Stable
+          # Tag comparison. Keep them so the artifact is faithful.
+          include-hidden-files: true
+
+      - name: Post build download link on PR
+        if: github.event_name == 'pull_request'
+        continue-on-error: true # fork PRs get a read-only token; skip quietly
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          MARKER="<!-- plugin-build-artifact -->"
+          BODY="$MARKER
+          ## 📦 Latest plugin build
+
+          **Commit:** ${COMMIT_SHA:0:7}
+          **Download:** [\`official-facebook-pixel\` artifact](${RUN_URL}) — open the run and scroll to the bottom.
+
+          _To install: download → unzip → upload via Plugins › Add New Plugin › Upload Plugin._"
+
+          # Update the existing build comment in place (idempotent via the marker).
+          EXISTING_ID=$(gh api "repos/${{ github.repository }}/issues/${PR_NUMBER}/comments" \
+            --paginate --jq ".[] | select(.body | contains(\"$MARKER\")) | .id" | head -1)
+          if [ -n "$EXISTING_ID" ]; then
+            gh api "repos/${{ github.repository }}/issues/comments/${EXISTING_ID}" -X PATCH -f body="$BODY"
+          else
+            gh pr comment "$PR_NUMBER" --body "$BODY"
+          fi

--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -5,6 +5,12 @@ on:
     branches:
       - 'release/**'
   workflow_dispatch:
+  workflow_call:
+    inputs:
+      ref:
+        description: "Git ref (branch/tag/sha) to build. Defaults to the triggering ref."
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -19,6 +25,8 @@ jobs:
     steps:
       - name: Checkout release branch
         uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -66,6 +66,47 @@ jobs:
               }
             }
 
+      - name: Ensure previous release PR is merged
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
+        run: |
+          set -euo pipefail
+
+          # Each release opens a PR ("Release X.Y.Z", head release/X.Y.Z -> main)
+          # that is merged once the release is published. Don't start a new
+          # release while a previous release PR is still open, otherwise releases
+          # overlap and the changelog/version bookkeeping drifts. Fail fast if any
+          # unmerged release PR (other than this version's) is still open.
+          if ! OPEN_RELEASE_PRS=$(gh pr list \
+            --repo "${{ github.repository }}" \
+            --base main \
+            --state open \
+            --json number,headRefName,title,url); then
+            echo "::error::Failed to query open PRs via the GitHub API; cannot verify previous release PRs are merged."
+            exit 1
+          fi
+
+          # An empty/non-JSON response would make the filter below silently pass
+          # and bypass the guard, so validate we got a JSON array back first.
+          if ! echo "$OPEN_RELEASE_PRS" | jq -e 'type == "array"' >/dev/null 2>&1; then
+            echo "::error::Unexpected response when listing open PRs; cannot verify previous release PRs are merged."
+            exit 1
+          fi
+
+          UNMERGED=$(echo "$OPEN_RELEASE_PRS" | jq -r --arg cur "release/$NEW_VERSION" '
+            [ .[]
+              | select(.headRefName | test("^release/[0-9]+[.][0-9]+[.][0-9]+$"))
+              | select(.headRefName != $cur) ]
+            | .[] | "  - #\(.number) \(.title) (\(.headRefName)) — \(.url)"')
+
+          if [ -n "$UNMERGED" ]; then
+            echo "::error::Cannot prepare release $NEW_VERSION — a previous release PR is still open and must be merged first:"
+            echo "$UNMERGED"
+            exit 1
+          fi
+          echo "✅ No unmerged previous release PRs found."
+
       - name: Get latest release tag
         id: get_release
         env:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  actions: write # required to dispatch build-and-upload.yml for the new release branch
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.inputs.version }}
@@ -19,6 +20,8 @@ jobs:
   prepare-release:
     name: Prepare Release
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set_version.outputs.new_version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
@@ -65,84 +68,72 @@ jobs:
 
       - name: Get latest release tag
         id: get_release
-        uses: actions/github-script@v8
-        with:
-          script: |
-            try {
-              const latestRelease = await github.rest.repos.getLatestRelease({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-              });
-              core.setOutput("latest_tag", latestRelease.data.tag_name);
-              core.setOutput("has_release", "true");
-              console.log("Latest release tag:", latestRelease.data.tag_name);
-            } catch (error) {
-              if (error.status === 404) {
-                console.log("No previous release found. Will include all commits.");
-                core.setOutput("has_release", "false");
-              } else {
-                throw error;
-              }
-            }
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Cutoff for the changelog is the COMMIT timestamp of the latest
+          # release tag (not the release publish time), so PRs are compared
+          # against when the release was actually cut.
+          if TAG=$(gh release view --json tagName --jq '.tagName' 2>/dev/null); then
+            git fetch origin tag "$TAG" --quiet || true
+            CUTOFF=$(git log -1 --format=%ct "$TAG")
+            echo "Latest release tag: $TAG (commit timestamp $CUTOFF)"
+            echo "has_release=true" >> "$GITHUB_OUTPUT"
+            echo "cutoff_timestamp=$CUTOFF" >> "$GITHUB_OUTPUT"
+          else
+            echo "No previous release found. Including all PRs."
+            echo "has_release=false" >> "$GITHUB_OUTPUT"
+            echo "cutoff_timestamp=0" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build changelog from PRs
         id: changelog
-        uses: actions/github-script@v8
         env:
-          HAS_RELEASE: ${{ steps.get_release.outputs.has_release }}
-          LATEST_TAG: ${{ steps.get_release.outputs.latest_tag }}
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_CUTOFF_TIMESTAMP: ${{ steps.get_release.outputs.cutoff_timestamp }}
           NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
-        with:
-          script: |
-            const newVersion = process.env.NEW_VERSION.trim();
-            const hasRelease = process.env.HAS_RELEASE === 'true';
-            const latestTag = process.env.LATEST_TAG;
+        run: |
+          # This repo receives commits via fbshipit, which CLOSES PRs instead of
+          # merging them: mergedAt is null and a "Merged" label is applied by
+          # tooling. Treat a PR as landed if it was merged OR carries the "Merged"
+          # label, and use closedAt as the date fallback. Include every changelog:*
+          # label except changelog:none; skip "Release X.Y.Z" bookkeeping PRs.
+          CHANGELOG=""
+          while IFS=$'\t' read -r DATE LABEL PR_TITLE PR_AUTHOR PR_NUM; do
+            [ -z "$PR_NUM" ] && continue
+            # Capitalize the changelog label for display.
+            LABEL="$(echo "${LABEL:0:1}" | tr '[:lower:]' '[:upper:]')${LABEL:1}"
+            CHANGELOG="${CHANGELOG}* ${LABEL} - ${PR_TITLE} by @${PR_AUTHOR} in #${PR_NUM}\n"
+          done < <(
+            gh pr list --state closed --base main --limit 1000 \
+              --json number,title,author,labels,mergedAt,closedAt --jq '
+              .[]
+              | . as $pr
+              | ($pr.mergedAt // $pr.closedAt) as $date
+              | ([.labels[].name | ascii_downcase] | index("merged")) as $hasMergedLabel
+              | (any(.labels[].name; ascii_downcase | test("^changelog:[[:space:]]*none$"))) as $hasChangelogNone
+              | select(($pr.mergedAt != null) or $hasMergedLabel)
+              | select($hasChangelogNone | not)
+              | select($date != null)
+              | select(($date | fromdateiso8601) > (env.RELEASE_CUTOFF_TIMESTAMP | tonumber))
+              | ([.labels[].name | ascii_downcase | select(startswith("changelog:")) | sub("^changelog:[[:space:]]*"; "")][0] // "") as $label
+              | select($label != "")
+              | select((.title | test("^release\\s+[0-9]+\\.[0-9]+\\.[0-9]+"; "i")) | not)
+              | [$date, $label, .title, .author.login, (.number | tostring)]
+              | @tsv
+            ' | sort
+          )
 
-            // Determine the cutoff date for merged PRs
-            let since = null;
-            if (hasRelease) {
-              const release = await github.rest.repos.getReleaseByTag({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                tag: latestTag,
-              });
-              since = new Date(release.data.published_at);
-              console.log(`Including PRs merged after ${since.toISOString()}`);
-            } else {
-              console.log("No previous release. Including all merged PRs.");
-            }
+          TODAY=$(date -u +%Y-%m-%d)
+          OUTPUT="= ${NEW_VERSION} - ${TODAY} =\n${CHANGELOG}"
+          echo -e "$OUTPUT"
 
-            // Query merged PRs directly — only returns PRs on this repo
-            const prs = await github.paginate(github.rest.pulls.list, {
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              state: 'closed',
-              sort: 'updated',
-              direction: 'desc',
-              base: 'main',
-              per_page: 100,
-            });
-
-            const changelog = [];
-            for (const pr of prs) {
-              if (!pr.merged_at) continue;
-              if (since && new Date(pr.merged_at) < since) continue;
-
-              const labelPrefix = "changelog:";
-              const labels = pr.labels
-                .map(l => l.name)
-                .filter(l => l.startsWith(labelPrefix))
-                .map(l => l.replace(labelPrefix, "").trim());
-              if (labels.length === 0 || labels[0].toLowerCase() === 'none') continue;
-
-              const category = labels[0];
-              changelog.push(`* ${category.charAt(0).toUpperCase()}${category.slice(1)} - ${pr.title} by @${pr.user.login} in #${pr.number}`);
-            }
-
-            const date = new Date().toISOString().slice(0, 10);
-            const output = `= ${newVersion} - ${date} =\n${changelog.join('\n')}\n`;
-            core.setOutput('changelog', output);
-            console.log(output);
+          # Write multiline output for downstream steps.
+          {
+            echo "changelog<<EOF"
+            echo -e "$OUTPUT"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Configure Git
         run: |
@@ -254,3 +245,24 @@ jobs:
           git add .
           git commit -m "Prepare release $NEW_VERSION"
           git push origin HEAD
+
+      - name: Trigger build for the new release branch
+        env:
+          GH_TOKEN: ${{ github.token }}
+          NEW_VERSION: ${{ steps.set_version.outputs.new_version }}
+        run: |
+          # The branch-creation push above uses GITHUB_TOKEN, which by design does
+          # NOT trigger build-and-upload.yml's push event. Dispatch it explicitly
+          # (workflow_dispatch is the exception to that rule) so a standalone
+          # build-and-upload run attributed to release/$NEW_VERSION exists for
+          # Set Stable Tag to compare the marketplace against later.
+          gh workflow run build-and-upload.yml \
+            --repo "${{ github.repository }}" \
+            --ref "release/$NEW_VERSION"
+
+  # Also build inline as part of this run for immediate artifact availability.
+  build-and-upload:
+    needs: prepare-release
+    uses: ./.github/workflows/build-and-upload.yml
+    with:
+      ref: refs/heads/release/${{ needs.prepare-release.outputs.version }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -239,6 +239,11 @@ jobs:
             const fs = require('fs');
             let content = fs.readFileSync('changelog.txt').toString().split('\n');
             const newLines = process.env.CHANGELOG_TEXT.split(/\r?\n/);
+            // Normalize to exactly one blank line between this block and the next.
+            while (newLines.length && newLines[newLines.length - 1].trim() === '') {
+              newLines.pop();
+            }
+            newLines.push('');
             // Insert new entry after the header line
             content.splice(1, 0, ...newLines);
             fs.writeFileSync('changelog.txt', content.join('\n'));
@@ -281,9 +286,13 @@ jobs:
               }
             }
 
-            // Insert new changelog
+            // Insert new changelog with exactly one blank line on each side.
             const newLines = process.env.CHANGELOG_TEXT.split(/\r?\n/);
-            newLines.unshift("");
+            while (newLines.length && newLines[newLines.length - 1].trim() === '') {
+              newLines.pop();
+            }
+            newLines.unshift(""); // blank line after the "== Changelog ==" marker
+            newLines.push("");    // single blank line before the following content
             content.splice(i, 0, ...newLines);
             fs.writeFileSync('readme.txt', content.join('\n'));
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: read # required for `gh pr list` in the changelog step
   actions: write # required to dispatch build-and-upload.yml for the new release branch
 
 concurrency:
@@ -164,6 +165,13 @@ jobs:
               | @tsv
             ' | sort
           )
+
+          # Fail loudly rather than cutting a release with an empty changelog
+          # (e.g. if PR labels are missing or the landed-PR detection regresses).
+          if [ -z "$CHANGELOG" ]; then
+            echo "::error::No changelog entries were generated for $NEW_VERSION. Ensure landed PRs since the last release carry a changelog:* label (other than none)."
+            exit 1
+          fi
 
           TODAY=$(date -u +%Y-%m-%d)
           OUTPUT="= ${NEW_VERSION} - ${TODAY} =\n${CHANGELOG}"

--- a/.github/workflows/release-plugin.yml
+++ b/.github/workflows/release-plugin.yml
@@ -70,6 +70,7 @@ jobs:
         run: |
           readme_file="readme.txt"
           found_changelog=0
+          in_version=0
           echo "RELEASE_NOTES<<EOF" >> $GITHUB_ENV
           while IFS= read -r line || [[ -n $line ]]; do
               clean_line=$(echo "$line" | tr -d '\r' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
@@ -77,13 +78,24 @@ jobs:
                   if [[ "$clean_line" == "== Changelog ==" ]]; then
                       found_changelog=1
                   fi
-              else
-                  if [[ "$clean_line" =~ ^=\ [0-9]+\.[0-9] ]]; then
+                  continue
+              fi
+              # Stop at the next top-level section, e.g. "== Upgrade Notice ==".
+              if [[ "$clean_line" =~ ^==\  ]]; then
+                  break
+              fi
+              if [[ "$clean_line" =~ ^=\ [0-9]+\.[0-9] ]]; then
+                  # The first version header after the marker is the release we
+                  # are cutting; collect its bullets. A second version header
+                  # means we've reached the previous release, so stop.
+                  if [[ $in_version -eq 1 ]]; then
                       break
                   fi
-                  if [[ "$clean_line" == \** ]]; then
-                      echo "$clean_line" >> $GITHUB_ENV
-                  fi
+                  in_version=1
+                  continue
+              fi
+              if [[ $in_version -eq 1 && "$clean_line" == \** ]]; then
+                  echo "$clean_line" >> $GITHUB_ENV
               fi
           done < "$readme_file"
           echo "EOF" >> $GITHUB_ENV

--- a/.github/workflows/set-stable-tag.yml
+++ b/.github/workflows/set-stable-tag.yml
@@ -43,24 +43,58 @@ jobs:
           TEMP_DIR=$(mktemp -d)
           trap "rm -rf $TEMP_DIR" EXIT
 
-          echo "Comparing Meta Pixel for WordPress v$VERSION"
+          echo "🔍 Verifying that the WordPress.org marketplace build matches the latest changes on release/$VERSION (Meta Pixel for WordPress v$VERSION)"
 
-          # Download from WordPress.org
+          # Download the currently published plugin from WordPress.org
+          echo "⬇️  Downloading the published plugin from the WordPress.org marketplace..."
           curl -sL "https://downloads.wordpress.org/plugin/official-facebook-pixel.zip" \
             -o "$TEMP_DIR/marketplace.zip"
 
-          # Download GitHub artifact from prepare-release workflow
-          RUN_ID=$(gh run list \
-            --repo ${{ github.repository }} \
-            --workflow build-and-upload.yml \
-            --status success \
-            --limit 100 \
-            --json databaseId,displayTitle \
-            --jq '[.[] | select(.displayTitle | contains("release/'"$VERSION"'"))] | sort_by(.databaseId) | reverse | .[0].databaseId')
-          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
-              echo "❌ No successful prepare-release build found for release/$VERSION"
+          # Resolve the exact commit currently at the tip of release/$VERSION. We must
+          # compare the marketplace against a build of THIS commit so we never validate
+          # against a stale or still-running build of an older commit.
+          BRANCH_SHA=$(gh api "repos/${{ github.repository }}/branches/release/$VERSION" --jq '.commit.sha')
+          echo "📌 Latest commit on release/$VERSION is $BRANCH_SHA"
+
+          # Locate the build artifact for that exact commit.
+          # build-and-upload.yml builds on every push to the release branch, so a build
+          # for the current HEAD is always produced. It may still be in progress when this
+          # workflow runs, so poll for up to 5 minutes for a SUCCESSFUL build whose commit
+          # SHA matches release/$VERSION's HEAD before giving up.
+          echo "🔎 Looking for a successful build of release/$VERSION at commit $BRANCH_SHA..."
+          MAX_ATTEMPTS=30
+          SLEEP_SECONDS=10
+          RUN_ID=""
+          for ATTEMPT in $(seq 1 "$MAX_ATTEMPTS"); do
+              RUN_ID=$(gh run list \
+                --repo ${{ github.repository }} \
+                --workflow build-and-upload.yml \
+                --branch "release/$VERSION" \
+                --status success \
+                --limit 50 \
+                --json databaseId,headSha \
+                --jq "[.[] | select(.headSha == \"$BRANCH_SHA\")][0].databaseId")
+              if [ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ]; then
+                  echo "✅ Found successful build (run id $RUN_ID) for commit $BRANCH_SHA"
+                  break
+              fi
+              RUN_ID=""
+              echo "⏳ No successful build for commit $BRANCH_SHA yet — it may still be running. Waiting ${SLEEP_SECONDS}s (attempt ${ATTEMPT}/${MAX_ATTEMPTS})..."
+              sleep "$SLEEP_SECONDS"
+          done
+
+          if [ -z "$RUN_ID" ]; then
+              echo "❌ Could not find a successful build of release/$VERSION at commit $BRANCH_SHA after $((MAX_ATTEMPTS * SLEEP_SECONDS / 60)) minutes."
+              echo "   This usually means one of the following:"
+              echo "     • The build for this commit is still running or queued — wait for it to finish, then re-run this workflow."
+              echo "     • The build for this commit failed — check the 'Build and Upload Artifact' workflow runs for release/$VERSION and fix the build."
+              echo "     • No build was ever triggered for this commit — trigger one with:"
+              echo "         gh workflow run build-and-upload.yml --ref release/$VERSION"
+              echo "       then wait for it to succeed and re-run this workflow."
               exit 1
           fi
+
+          echo "⬇️  Downloading the build artifact from run $RUN_ID..."
           gh run download "$RUN_ID" --repo ${{ github.repository }} --dir "$TEMP_DIR/artifact"
 
           # Find and prepare GitHub zip

--- a/build.xml
+++ b/build.xml
@@ -27,6 +27,11 @@
         <exclude name=".githooks/**" />
         <exclude name=".github/**" />
         <exclude name="report/**" />
+        <!-- The build output dir is created before this copy runs; exclude it
+             (and its contents) so it isn't packaged into itself, which would
+             ship a stray nested build/official-facebook-pixel/ directory. -->
+        <exclude name="build" />
+        <exclude name="build/**" />
     </fileset>
 
     <!-- ============================================  -->


### PR DESCRIPTION
Release-workflow fixes, aligning this repo with `facebook-for-woocommerce` and fixing bugs surfaced while cutting 5.2.2.

1. **Changelog generation** (`prepare-release.yml`) — fbshipit closes PRs (`mergedAt=null` + `Merged` label), which the old builder skipped → empty changelogs. Now detects landed PRs via `Merged` label / `merged_at`, `closed_at` date fallback, tag-commit-timestamp cutoff; keeps every `changelog:*` except `none`; skips `Release X.Y.Z` PRs.
2. **Auto-build on prepare** — `build-and-upload.yml` gains `workflow_call` (with `ref`); `prepare-release.yml` calls it inline **and** dispatches a standalone run (for `set-stable-tag` to find). Adds `actions: write` + `version` output.
3. **Woo safeguards** — previous-release-PR guard, `include-hidden-files: true`, per-PR builds.
4. **`set-stable-tag.yml` artifact lookup** — matched runs by `displayTitle` (never contains the branch ref) → "No build found". Now matches by `--branch` + `headSha` with polling. (Previously fixed only on `release/p5.2.1/publish`, never reached `main`.)
5. **Stray `build/` dir in the package** (`build.xml`) — the sourcedir fileset copied `.` into `./build/official-facebook-pixel/` without excluding `build/`, shipping a nested empty `build/`. Invisible because empty dirs are dropped by `upload-artifact` but committed by `svn add`. Excluded `build` + `build/**`.
6. **`pull-requests: read`** on the changelog step (else `gh pr list` 403s under the explicit permissions block) + **fail on empty changelog** (both incorporated from #170, which this supersedes).
7. **Release-notes extraction + spacing** — the `release-plugin.yml` "Extract release notes" loop broke at the current version's own header before collecting bullets, so the GitHub Release body (and the release PR body, copied from it) was always empty; fixed to collect the first block's bullets. Also normalized generated changelog/readme to a single blank line between release blocks.

Supersedes #170.
