### PR TITLE
Add missing GPLv2 copyright headers to project source files

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,4 +1,14 @@
 #!/bin/bash
+#
+# Copyright (C) 2017-present, Meta, Inc.
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; version 2 of the License.
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
 
 # Get staged PHP files for PHP CodeSniffer
 php_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.php$')

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -2,13 +2,8 @@
 #
 # Copyright (C) 2017-present, Meta, Inc.
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; version 2 of the License.
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# This source code is licensed under the license found in the
+# LICENSE file in the root directory of this source tree.
 
 # Get staged PHP files for PHP CodeSniffer
 php_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.php$')

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 /__test_sdk__/report
 .DS_Store
 .vscode
+.claude/
 composer.phar
 .phpunit.result.cache
 local-config.php

--- a/__tests__/core/FacebookCapiCircuitBreakerTest.php
+++ b/__tests__/core/FacebookCapiCircuitBreakerTest.php
@@ -5,6 +5,18 @@
  * @package FacebookPixelPlugin
  */
 
+/*
+* Copyright (C) 2017-present, Meta, Inc.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; version 2 of the License.
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*/
+
 namespace FacebookPixelPlugin\Tests\Core;
 
 use FacebookPixelPlugin\Core\FacebookCapiCircuitBreaker;

--- a/__tests__/core/ReleaseSignalsAjaxTest.php
+++ b/__tests__/core/ReleaseSignalsAjaxTest.php
@@ -3,6 +3,18 @@
  * @package FacebookPixelPlugin
  */
 
+/*
+* Copyright (C) 2017-present, Meta, Inc.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; version 2 of the License.
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*/
+
 namespace FacebookPixelPlugin\Tests\Core;
 
 use FacebookPixelPlugin\Core\ReleaseSignalsAjax;

--- a/__tests__/core/SignalsTest.php
+++ b/__tests__/core/SignalsTest.php
@@ -3,6 +3,18 @@
  * @package FacebookPixelPlugin
  */
 
+/*
+* Copyright (C) 2017-present, Meta, Inc.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; version 2 of the License.
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*/
+
 namespace FacebookPixelPlugin\Tests\Core;
 
 use FacebookPixelPlugin\Core\Signals;

--- a/js/facebook_pixel_add_to_cart.js
+++ b/js/facebook_pixel_add_to_cart.js
@@ -1,3 +1,15 @@
+/**
+ * Copyright (C) 2017-present, Meta, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
 jQuery(document).ready(function ($) {
   $('.edd-add-to-cart').click(function (e) {
     e.preventDefault();

--- a/js/facebook_pixel_add_to_cart.js
+++ b/js/facebook_pixel_add_to_cart.js
@@ -1,13 +1,8 @@
 /**
  * Copyright (C) 2017-present, Meta, Inc.
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; version 2 of the License.
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 jQuery(document).ready(function ($) {

--- a/js/facebook_signal.js
+++ b/js/facebook_signal.js
@@ -1,13 +1,8 @@
 /**
  * Copyright (C) 2017-present, Meta, Inc.
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; version 2 of the License.
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 window.FacebookSignal = window.FacebookSignal || {

--- a/js/facebook_signal.js
+++ b/js/facebook_signal.js
@@ -1,3 +1,15 @@
+/**
+ * Copyright (C) 2017-present, Meta, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
 window.FacebookSignal = window.FacebookSignal || {
   _held: false,
   _releasing: false,

--- a/js/settings_page.js
+++ b/js/settings_page.js
@@ -1,13 +1,8 @@
 /**
  * Copyright (C) 2017-present, Meta, Inc.
  *
- * This program is free software; you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation; version 2 of the License.
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
+ * This source code is licensed under the license found in the
+ * LICENSE file in the root directory of this source tree.
  */
 
 function escapeHtml(str) {

--- a/js/settings_page.js
+++ b/js/settings_page.js
@@ -1,3 +1,15 @@
+/**
+ * Copyright (C) 2017-present, Meta, Inc.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
 function escapeHtml(str) {
     var div = document.createElement("div");
     div.appendChild(document.createTextNode(String(str)));

--- a/task/class-facebookwordpressaddversionnumbertask.php
+++ b/task/class-facebookwordpressaddversionnumbertask.php
@@ -13,6 +13,18 @@
  * @return void
  */
 
+/*
+* Copyright (C) 2017-present, Meta, Inc.
+*
+* This program is free software; you can redistribute it and/or modify
+* it under the terms of the GNU General Public License as published by
+* the Free Software Foundation; version 2 of the License.
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+* GNU General Public License for more details.
+*/
+
 require_once __DIR__ . '/class-basetask.php';
 
 use FacebookPixelPlugin\Core\FacebookPluginConfig;


### PR DESCRIPTION
## Description

Eight project-authored source files were missing a copyright header. This adds one to each, following the convention already established in the repository for that file type.

| File | Header form |
|---|---|
| `__tests__/core/FacebookCapiCircuitBreakerTest.php` | Full GPLv2 block |
| `__tests__/core/ReleaseSignalsAjaxTest.php` | Full GPLv2 block |
| `__tests__/core/SignalsTest.php` | Full GPLv2 block |
| `task/class-facebookwordpressaddversionnumbertask.php` | Full GPLv2 block |
| `js/facebook_pixel_add_to_cart.js` | LICENSE reference |
| `js/facebook_signal.js` | LICENSE reference |
| `js/settings_page.js` | LICENSE reference |
| `.githooks/pre-commit` | LICENSE reference (shell comments) |

Two header forms are used, each matching the existing precedent for its file type:

- **PHP files** get the full GPLv2 block, copied verbatim from `core/class-facebookpixel.php`. This is what essentially every PHP file in the repository already carries.
- **JavaScript and shell files** get a short reference to the `LICENSE` file, modelled on the existing header in `css/admin.css`. No first-party JavaScript file previously carried a copyright header, so `css/admin.css` — the only other first-party non-PHP source file — is the closest precedent.

The vendored JavaScript under `js/lib/` and `js/fbe_allinone.js` carries an upstream BSD header with a patent-rights grant. Those files are third-party and were deliberately left untouched.

Attribution uses `Meta, Inc.`, following the current convention in `core/` and `task/`.

This PR also adds `.claude/` to `.gitignore` so local tooling directories are not reported as untracked. No tracked files are affected by that rule.

This is a comment-only change — no behavior is affected.

Related task: T287000698

### Type of change

- Syntax change (non-breaking change which fixes code modularity, linting or phpcs issues)

## Checklist

- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have confirmed that my changes do not introduce any new PHPCS warnings or errors.
- [x] I have checked plugin debug logs that my changes do not introduce any new PHP warnings or FATAL errors.
- [x] I followed general Pull Request best practices.
- [x] I have added tests (if necessary) and all the new and existing unit tests pass locally with my changes.
- [x] I have completed dogfooding and QA testing, or I have conducted thorough due diligence to ensure that it does not break existing functionality.
- [x] I have updated or requested update to plugin documentations (if necessary).

No tests were added: the change introduces only comments and has no behavior to cover.

## Changelog entry

Add missing copyright headers to project source files.

## Test Plan

All three CI commands from `.github/workflows/main.yml` were run locally on PHP 8.1 and pass:

1. **Unit tests**
   ```bash
   composer install
   vendor/bin/phpunit --bootstrap __tests__/bootstrap.php __tests__
   ```
   Result: `247 tests` — OK, with 1 pre-existing incomplete test.

2. **SDK unit tests**
   ```bash
   vendor/bin/phpunit -c ./phpunit-sdk-unit.xml
   ```
   Result: `110 tests, 337 assertions` — OK.

3. **PHPCS**
   ```bash
   vendor/bin/phpcs --standard=phpcs.xml --extensions=php --ignore=vendor/ .
   ```
   Result: clean, exit code 0.

Additional verification:

- **JavaScript bodies are untouched.** Each modified `.js` file was diffed against its `origin/main` version with the new header stripped; all three are byte-identical below the header.
- **Prettier.** `js/facebook_signal.js` and `js/settings_page.js` report formatting warnings, but they report the identical warnings at `main`. Confirmed by running `npx prettier --check` against pristine copies extracted from `origin/main`. The added headers introduce no new formatting issues.
- **Shell syntax.** `bash -n .githooks/pre-commit` passes.
- **Header coverage.** Re-scanned every tracked `.php`, `.js`, and `.css` file for a copyright header; zero files remain without one.
- **`.gitignore` rule.** Verified with `git check-ignore -v` that `.claude/` matches, and with `git ls-files` that no currently tracked file is affected.

Note on the unit test suite: the reported assertion count varies between runs (observed 850–884 across runs) while the test count, pass status, and single incomplete test remain constant. This non-determinism also reproduces on a pristine `origin/main` checkout and is unrelated to this change.

## Screenshots

Not applicable — comment-only change with no user-facing or visual impact.
